### PR TITLE
Fix scope switch init value

### DIFF
--- a/frontend/src/components/common/ScopeSwitch.tsx
+++ b/frontend/src/components/common/ScopeSwitch.tsx
@@ -15,6 +15,10 @@ export const ScopeSwitch = () => {
     setScope(global ? "global" : "user");
   }, [global]);
 
+  useEffect(() => {
+    setGlobal(scope === "global");
+  }, []);
+
   return (
     <Switch
       checked={global}


### PR DESCRIPTION
The `global` state was not init correctly and led to wrong representation of the scopeSwitch