### PR TITLE
Fix metadata creation for zip download

### DIFF
--- a/backend/src/useCases/files.ts
+++ b/backend/src/useCases/files.ts
@@ -94,11 +94,15 @@ const processTree = async (
     throw new Error("Folder node not found");
   }
 
+  const directChildrenMetadata = childrenMetadata.filter((e) =>
+    folderNode.Links.some((link) => cidToString(link.Hash) === e.dataCid)
+  );
+
   const chunkNodes = Array.from(nodes.values());
 
   const metadata: OffchainFolderMetadata = folderMetadata(
     cidToString(cidOfNode(folderNode)),
-    childrenMetadata.map((e) => ({
+    directChildrenMetadata.map((e) => ({
       cid: e.dataCid,
       name: e.name,
       type: e.type,
@@ -172,7 +176,9 @@ const retrieveAndReassembleFolderAsZip = async (
       }),
     ...metadata.children
       .filter((e) => e.type === "folder")
-      .map((e) => retrieveAndReassembleFolderAsZip(parent, e.cid)),
+      .map(async (e) => {
+        return retrieveAndReassembleFolderAsZip(folder, e.cid);
+      }),
   ]);
 
   return folder;


### PR DESCRIPTION
Metadata was saved as it was processed in `processTree` but I changed this because I wanted to group by UploadCID and make the operation atomic too. For this I forwarded all the children metadata of an folder (including the children of children nodes) so the operation is atomic and could be grouped. The issue is that the field `metadata` includes children of children, that are not meant to be at the `childrenMetadata` of a folder's off-chain metadata.

Additionally, there was some bug generating the `zip` file 