### PR TITLE
Improve files fetching

### DIFF
--- a/frontend/src/app/drive/shared/page.tsx
+++ b/frontend/src/app/drive/shared/page.tsx
@@ -1,23 +1,39 @@
 "use client";
 
 import { ApiService } from "@/services/api";
-import { useEffect, useState } from "react";
-import { useLocalStorage } from "usehooks-ts";
-import { UploadedObjectMetadata } from "../../../models/UploadedObjectMetadata";
+import { useCallback, useEffect, useState } from "react";
+import { ObjectSummary } from "../../../models/UploadedObjectMetadata";
 import { SharedFiles } from "../../../components/SharedFiles";
+import { PaginatedResult } from "../../../models/common";
 
 export default function Page() {
+  const [pageSize, setPageSize] = useState(5);
+  const [currentPage, setCurrentPage] = useState(0);
+  const [totalItems, setTotalItems] = useState(0);
+
   const [rootObjectMetadata, setRootObjectMetadata] = useState<
-    UploadedObjectMetadata[] | null
+    ObjectSummary[] | null
   >(null);
+
+  const updateResult = useCallback((result: PaginatedResult<ObjectSummary>) => {
+    setRootObjectMetadata(result.rows);
+    setTotalItems(result.totalCount);
+  }, []);
 
   useEffect(() => {
     setRootObjectMetadata(null);
-    ApiService.getSharedRoots().then((e) => {
-      const promises = e.map((e) => ApiService.fetchUploadedObjectMetadata(e));
-      Promise.all(promises).then(setRootObjectMetadata);
-    });
-  }, []);
+    const offset = currentPage * pageSize;
+    ApiService.getSharedRoots(offset, pageSize).then(updateResult);
+  }, [currentPage, pageSize, updateResult]);
 
-  return <SharedFiles objects={rootObjectMetadata} />;
+  return (
+    <SharedFiles
+      objects={rootObjectMetadata}
+      pageSize={pageSize}
+      setPageSize={setPageSize}
+      currentPage={currentPage}
+      setCurrentPage={setCurrentPage}
+      totalItems={totalItems}
+    />
+  );
 }

--- a/frontend/src/components/Files/Metadata.tsx
+++ b/frontend/src/components/Files/Metadata.tsx
@@ -1,28 +1,24 @@
-import { UploadedObjectMetadata } from "../../models/UploadedObjectMetadata";
+import { ObjectSummary } from "../../models/UploadedObjectMetadata";
 import bytes from "bytes";
 import { getTypeFromMetadata } from "../../utils/file";
 import { InternalLink } from "../common/InternalLink";
 
-export const Metadata = ({ object }: { object: UploadedObjectMetadata }) => {
+export const Metadata = ({ object }: { object: ObjectSummary }) => {
   return (
     <div className="bg-white p-4 rounded-lg border-[#202124] border border-opacity-20 text-xs">
       <div className="flex flex-col mb-4">
         <h4 className="font-medium text-sm text-black text-wrap">
-          {object.metadata.name}
+          {object.name}
         </h4>
-        <p className="text-gray-500">
-          Size: {bytes(object.metadata.totalSize)}
-        </p>
+        <p className="text-gray-500">Size: {bytes(object.size)}</p>
         <p>
-          CID: <span className="text-blue-500">{object.metadata.dataCid}</span>
+          CID: <span className="text-blue-500">{object.headCid}</span>
         </p>
       </div>
       <div className="grid grid-cols-2 gap-y-2 gap-x-4 text-black font-light">
         <div className="flex">
           <span>Type:</span>
-          <span className="ml-[4px]">
-            {getTypeFromMetadata(object.metadata)}
-          </span>
+          <span className="ml-[4px]">{getTypeFromMetadata(object)}</span>
         </div>
         <div className="flex">
           <span>{"Owner: "}</span>
@@ -54,7 +50,7 @@ export const Metadata = ({ object }: { object: UploadedObjectMetadata }) => {
         </div>
       </div>
       <div className="flex justify-end">
-        <InternalLink href={`/drive/metadata/${object.metadata.dataCid}`}>
+        <InternalLink href={`/drive/metadata/${object.headCid}`}>
           <span className="text-primary font-semibold hover:cursor-pointer mt-4">
             See more
           </span>

--- a/frontend/src/components/SharedFiles/index.tsx
+++ b/frontend/src/components/SharedFiles/index.tsx
@@ -1,5 +1,8 @@
 import { LoaderCircle } from "lucide-react";
-import { UploadedObjectMetadata } from "../../models/UploadedObjectMetadata";
+import {
+  ObjectSummary,
+  UploadedObjectMetadata,
+} from "../../models/UploadedObjectMetadata";
 import { FileDropZone } from "../Files/FileDropZone";
 import { FileTable } from "../common/FileTable";
 import { UploadingObjects } from "../Files/UploadingObjects";
@@ -7,8 +10,18 @@ import { NoSharedFilesPlaceholder } from "./NoSharedFilesPlaceholder";
 
 export const SharedFiles = ({
   objects,
+  pageSize,
+  setPageSize,
+  currentPage,
+  setCurrentPage,
+  totalItems,
 }: {
-  objects: UploadedObjectMetadata[] | null;
+  objects: ObjectSummary[] | null;
+  pageSize: number;
+  setPageSize: (pageSize: number) => void;
+  currentPage: number;
+  setCurrentPage: (currentPage: number) => void;
+  totalItems: number;
 }) => {
   return (
     <div className="flex w-full">
@@ -21,7 +34,16 @@ export const SharedFiles = ({
               <LoaderCircle className="w-10 h-10 animate-spin" />
             </div>
           )}
-          {objects && objects.length > 0 && <FileTable files={objects} />}
+          {objects && objects.length > 0 && (
+            <FileTable
+              files={objects}
+              pageSize={pageSize}
+              setPageSize={setPageSize}
+              currentPage={currentPage}
+              setCurrentPage={setCurrentPage}
+              totalItems={totalItems}
+            />
+          )}
           {objects && objects.length === 0 && <NoSharedFilesPlaceholder />}
         </div>
       </div>

--- a/frontend/src/components/TrashFiles/index.tsx
+++ b/frontend/src/components/TrashFiles/index.tsx
@@ -1,5 +1,8 @@
 import { LoaderCircle } from "lucide-react";
-import { UploadedObjectMetadata } from "../../models/UploadedObjectMetadata";
+import {
+  ObjectSummary,
+  UploadedObjectMetadata,
+} from "../../models/UploadedObjectMetadata";
 import { FileDropZone } from "../Files/FileDropZone";
 import { UploadingObjects } from "../Files/UploadingObjects";
 import { NoFilesInTrashPlaceholder } from "./NoFilesInTrashPlaceholder";
@@ -7,8 +10,18 @@ import { DeletedFilesTable } from "../common/DeleteFilesTable";
 
 export const TrashFiles = ({
   objects,
+  pageSize,
+  setPageSize,
+  currentPage,
+  setCurrentPage,
+  totalItems,
 }: {
-  objects: UploadedObjectMetadata[] | null;
+  objects: ObjectSummary[] | null;
+  pageSize: number;
+  setPageSize: (pageSize: number) => void;
+  currentPage: number;
+  setCurrentPage: (currentPage: number) => void;
+  totalItems: number;
 }) => {
   return (
     <div className="flex w-full">
@@ -22,7 +35,14 @@ export const TrashFiles = ({
             </div>
           )}
           {objects && objects.length > 0 && (
-            <DeletedFilesTable files={objects} />
+            <DeletedFilesTable
+              files={objects}
+              pageSize={pageSize}
+              setPageSize={setPageSize}
+              currentPage={currentPage}
+              setCurrentPage={setCurrentPage}
+              totalItems={totalItems}
+            />
           )}
           {objects && objects.length === 0 && <NoFilesInTrashPlaceholder />}
         </div>

--- a/frontend/src/components/common/Table/TableFooter.tsx
+++ b/frontend/src/components/common/Table/TableFooter.tsx
@@ -1,0 +1,11 @@
+import { ReactNode } from "react";
+
+export const TableFooter = ({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) => {
+  return <tfoot className={className}>{children}</tfoot>;
+};

--- a/frontend/src/components/common/TablePaginator/index.tsx
+++ b/frontend/src/components/common/TablePaginator/index.tsx
@@ -1,0 +1,55 @@
+import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
+
+export const TablePaginator = ({
+  pageSize,
+  setPageSize,
+  currentPage,
+  setCurrentPage,
+  totalItems,
+}: {
+  pageSize: number;
+  setPageSize: (pageSize: number) => void;
+  currentPage: number;
+  setCurrentPage: (currentPage: number) => void;
+  totalItems: number;
+}) => {
+  return (
+    <div className="flex w-full items-center justify-between p-4 text-light-gray text-sm">
+      <div className="flex items-center">
+        <span className="mr-2">Items per page:</span>
+        <select
+          className="border border-gray-300 rounded p-1 bg-gray-100 pr-1"
+          value={pageSize}
+          onChange={(e) => setPageSize(parseInt(e.target.value))}
+        >
+          <option value="5">5</option>
+          <option value="10">10</option>
+          <option value="20">20</option>
+        </select>
+      </div>
+      <div>
+        <span>
+          {currentPage * pageSize + 1}-
+          {Math.min(currentPage * pageSize + pageSize, totalItems)} of{" "}
+          {totalItems} items
+        </span>
+      </div>
+      <div className="flex items-center gap-2">
+        <button
+          disabled={currentPage === 0}
+          className="p-2 text-gray-800 cursor-pointer rounded-md border border-light-gray hover:scale-[102%] transition-all disabled:opacity-0"
+          onClick={() => setCurrentPage(currentPage - 1)}
+        >
+          <ChevronLeftIcon className="w-4 h-4" />
+        </button>
+        <button
+          disabled={currentPage * pageSize + pageSize >= totalItems}
+          className="p-2 text-gray-800 cursor-pointer rounded-md border border-light-gray hover:scale-[102%] transition-all disabled:opacity-0"
+          onClick={() => setCurrentPage(currentPage + 1)}
+        >
+          <ChevronRightIcon className="w-4 h-4" />
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/models/UploadedObjectMetadata.ts
+++ b/frontend/src/models/UploadedObjectMetadata.ts
@@ -22,3 +22,20 @@ export enum OwnerRole {
   ADMIN = "admin",
   VIEWER = "viewer",
 }
+
+export type ObjectSummary = {
+  headCid: string;
+  name?: string;
+  size: number;
+  owners: Owner[];
+  uploadStatus: UploadStatus;
+} & (
+  | {
+      type: "file";
+      mimeType?: string;
+    }
+  | {
+      type: "folder";
+      children: (OffchainMetadata & { type: "folder" })["children"];
+    }
+);

--- a/frontend/src/models/common.tsx
+++ b/frontend/src/models/common.tsx
@@ -1,0 +1,4 @@
+export type PaginatedResult<T> = {
+  rows: T[];
+  totalCount: number;
+};

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,11 +1,15 @@
 import { ApiKey, ApiKeyWithoutSecret } from "../models/ApiKey";
+import { PaginatedResult } from "../models/common";
 import { FolderTree } from "../models/FileTree";
 import { ObjectSearchResult } from "../models/ObjectSearchResult";
 import {
   SubscriptionGranularity,
   SubscriptionWithUser,
 } from "../models/Subscriptions";
-import { UploadedObjectMetadata } from "../models/UploadedObjectMetadata";
+import {
+  ObjectSummary,
+  UploadedObjectMetadata,
+} from "../models/UploadedObjectMetadata";
 import { User, UserInfo } from "../models/User";
 import { getAuthSession } from "../utils/auth";
 import { uploadFileContent } from "../utils/file";
@@ -194,14 +198,18 @@ export const ApiService = {
 
     return response.json();
   },
-  getRootObjects: async (scope: "user" | "global"): Promise<string[]> => {
+  getRootObjects: async (
+    scope: "user" | "global",
+    offset: number,
+    limit: number
+  ): Promise<PaginatedResult<ObjectSummary>> => {
     const session = await getAuthSession();
     if (!session) {
       throw new Error("No session");
     }
 
     const response = await fetch(
-      `${API_BASE_URL}/objects/roots?scope=${scope}`,
+      `${API_BASE_URL}/objects/roots?scope=${scope}&offset=${offset}&limit=${limit}`,
       {
         headers: {
           Authorization: `Bearer ${session?.accessToken}`,
@@ -212,18 +220,24 @@ export const ApiService = {
 
     return response.json();
   },
-  getSharedRoots: async (): Promise<string[]> => {
+  getSharedRoots: async (
+    offset: number,
+    limit: number
+  ): Promise<PaginatedResult<ObjectSummary>> => {
     const session = await getAuthSession();
     if (!session) {
       throw new Error("No session");
     }
 
-    const response = await fetch(`${API_BASE_URL}/objects/roots/shared`, {
-      headers: {
-        Authorization: `Bearer ${session?.accessToken}`,
-        "X-Auth-Provider": "google",
-      },
-    });
+    const response = await fetch(
+      `${API_BASE_URL}/objects/roots/shared?offset=${offset}&limit=${limit}`,
+      {
+        headers: {
+          Authorization: `Bearer ${session?.accessToken}`,
+          "X-Auth-Provider": "google",
+        },
+      }
+    );
 
     if (!response.ok) {
       throw new Error(`Network response was not ok: ${response.statusText}`);
@@ -231,18 +245,24 @@ export const ApiService = {
 
     return response.json();
   },
-  getTrashObjects: async (): Promise<string[]> => {
+  getTrashObjects: async (
+    offset: number,
+    limit: number
+  ): Promise<PaginatedResult<ObjectSummary>> => {
     const session = await getAuthSession();
     if (!session) {
       throw new Error("No session");
     }
 
-    const response = await fetch(`${API_BASE_URL}/objects/roots/deleted`, {
-      headers: {
-        Authorization: `Bearer ${session?.accessToken}`,
-        "X-Auth-Provider": "google",
-      },
-    });
+    const response = await fetch(
+      `${API_BASE_URL}/objects/roots/deleted?offset=${offset}&limit=${limit}`,
+      {
+        headers: {
+          Authorization: `Bearer ${session?.accessToken}`,
+          "X-Auth-Provider": "google",
+        },
+      }
+    );
 
     if (!response.ok) {
       throw new Error(`Network response was not ok: ${response.statusText}`);

--- a/frontend/src/utils/file.ts
+++ b/frontend/src/utils/file.ts
@@ -2,6 +2,7 @@ import { OffchainMetadata } from "@autonomys/auto-drive";
 import { decryptFile } from "./encryption";
 import { streamToAsyncIterable } from "./stream";
 import { decompressFileByChunks } from "./compression";
+import { ObjectSummary } from "../models/UploadedObjectMetadata";
 
 export class InvalidDecryptKey extends Error {
   constructor() {
@@ -70,7 +71,10 @@ export const handleFileDownload = async (
   }
 };
 
-export const getTypeFromMetadata = (metadata: OffchainMetadata) => {
+export const getTypeFromMetadata = (metadata: {
+  type: OffchainMetadata["type"];
+  mimeType?: string;
+}) => {
   if (metadata.type === "file") {
     return metadata.mimeType;
   }

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -16,6 +16,7 @@ const config: Config = {
         "lighter-accent": "#90C2E7",
         "light-danger": "#ffcdd2",
         "gray-button": "#9EA49F",
+        "light-gray": "#4E4F54",
       },
     },
   },


### PR DESCRIPTION
Solves issue #69 

- Creates table paginator
- Paginates getRoots, getShareRoots, getDeletedRoots requests. 
- The type of these methods has been updated from CIDs (that posteriorly were one by one fetch its metadata) to ObjectSummary that basically composes only the needed data for table representation