### PR TITLE
Fix "rendered fewer hooks than expected" error

### DIFF
--- a/frontend/src/app/drive/page.tsx
+++ b/frontend/src/app/drive/page.tsx
@@ -28,6 +28,7 @@ export default function Page() {
 
   useEffect(() => {
     const offset = currentPage * pageSize;
+    setRootObjectMetadata(null);
     ApiService.getRootObjects(scope, offset, pageSize).then(updateResult);
   }, [scope, currentPage, pageSize, updateResult]);
 


### PR DESCRIPTION
After implementing pagination and batching for files fetching in #76, there was an error when `TablePaginator` provoked a refetch of file list (by updating either `pageSize` or `currentPage`). What happened is that a change of state in the child provoked an update in the parent's state for breaking this loop, it's needed an intermediary state `setRootObjectMetadata(null)` 