### PR TITLE
fix: search bar display

### DIFF
--- a/frontend/src/app/drive/page.tsx
+++ b/frontend/src/app/drive/page.tsx
@@ -42,11 +42,11 @@ export default function Page() {
   return (
     <div className='flex w-full'>
       <div className='flex w-full flex-col gap-4'>
-        <div className='flex items-center justify-between gap-4'>
-          <SearchBar scope='user' />
-          <div className='flex-1'>
-            <FileDropZone />
-          </div>
+        <div className='flex-1'>
+          <FileDropZone />
+        </div>
+        <div className='w-full max-w-md'>
+          <SearchBar scope='global' />
         </div>
         <div className=''>
           <UploadingObjects />


### PR DESCRIPTION
In a previous PR I updated the height of FileDropZone this led to a not too nice UI display. I updated to this interface:

<img width="1363" alt="image" src="https://github.com/user-attachments/assets/7b6a3e5f-4aec-445f-9961-bb75e5ba6cb4">
