### PR TITLE
Fix missing chunk during migration

### DIFF
--- a/backend/src/repositories/uploads/blockstore.ts
+++ b/backend/src/repositories/uploads/blockstore.ts
@@ -130,6 +130,17 @@ const deleteBlockstoreEntry = async (uploadId: string, cid: string) => {
   )
 }
 
+const getNodesByCid = async (cid: string) => {
+  const db = await getDatabase()
+
+  const result = await db.query<BlockstoreEntry>(
+    'SELECT * FROM uploads.blockstore WHERE cid = $1 ORDER BY sort_id ASC',
+    [cid],
+  )
+
+  return result.rows.map(parseEntry)
+}
+
 export const blockstoreRepository = {
   addBlockstoreEntry,
   addBatchBlockstoreEntries,
@@ -141,4 +152,5 @@ export const blockstoreRepository = {
   deleteBlockstoreEntry,
   getByCIDWithoutData,
   getByCIDAndRootUploadId,
+  getNodesByCid,
 }

--- a/backend/src/useCases/uploads/blockstore.ts
+++ b/backend/src/useCases/uploads/blockstore.ts
@@ -151,10 +151,22 @@ const processFolderUpload = async (upload: FolderUpload): Promise<CID> => {
   return processFileTree(upload.id, upload, fileTree)
 }
 
+const getNode = async (cid: string): Promise<Buffer | undefined> => {
+  const nodes = await blockstoreRepository.getNodesByCid(cid)
+  if (nodes.length === 0) {
+    return undefined
+  }
+
+  const node = nodes[0]
+
+  return Buffer.from(node.data)
+}
+
 export const BlockstoreUseCases = {
   getFileUploadIdCID,
   getFolderUploadIdCID,
   getUploadCID,
   getChunksByNodeType,
   processFolderUpload,
+  getNode,
 }


### PR DESCRIPTION
When a file is uploaded the IPLD nodes are generated and saved in a temporary table (`uploads.blockstore`) when the upload is completed by the user these nodes are migrated to the persistent table (`public.nodes`). 

If a user tries to fetch the file when this migration is not completed the fetch failed. This should fix that by searching in the temp table if the persistent table fails.  