### PR TITLE
Make sure the color of the FAQ question are dark

### DIFF
--- a/frontend/src/components/FAQ/index.tsx
+++ b/frontend/src/components/FAQ/index.tsx
@@ -22,7 +22,7 @@ export const FAQ: FC = () => {
                 className='dark:bg-boxDark w-full rounded-lg bg-white p-8 text-left text-gray-900 shadow-md dark:border-none dark:text-white'
                 onClick={() => toggleFAQ(index)}
               >
-                <span className='font-semibold'>
+                <span className='font-semibold text-xl text-gray-900 dark:text-gray-900'>
                   {index + 1}. {question.question}
                 </span>
                 <span className='float-right'>


### PR DESCRIPTION
## Make sure the color of the FAQ question is dark

I actually thought there were no questions/answers, but then I realized that it was just because the question text was white, like the background of the box.

This PR makes sure the color of the text is dark.

Some classes refer to dark: and use specific brand colors not defined in tailwind.config...
(This PR does not address these issues, since the design does not have a dark/light switch anyway)