### PR TITLE
fix: import missing .js extension

### DIFF
--- a/backend/src/services/download/fsCache/singleton.ts
+++ b/backend/src/services/download/fsCache/singleton.ts
@@ -1,7 +1,7 @@
 import { createFileCache } from './index.js'
 import { ensureDirectoryExists } from '../../../utils/fs.js'
 import path from 'path'
-import { config } from '../../../config'
+import { config } from '../../../config.js'
 import { Keyv } from 'keyv'
 import KeyvSqlite from '@keyvhq/sqlite'
 import { LRUCache } from 'lru-cache'


### PR DESCRIPTION
Was missing the extension in an import. I'll research into some solution to make it fail on build-time