### PR TITLE
update: use gateway raw mode

### DIFF
--- a/backend/__tests__/e2e/users/credits.spec.ts
+++ b/backend/__tests__/e2e/users/credits.spec.ts
@@ -7,11 +7,11 @@ import { dbMigration } from '../../utils/dbMigrate'
 import { SubscriptionsUseCases } from '../../../src/useCases'
 
 describe('CreditsUseCases', () => {
-  const mockUser: UserWithOrganization = createMockUser()
-
+  let mockUser: UserWithOrganization
   beforeAll(async () => {
     await getDatabase()
     await dbMigration.up()
+    mockUser = createMockUser()
     const result = await SubscriptionsUseCases.getOrCreateSubscription(mockUser)
     if (!result) throw new PreconditionError('Failed to setup test user')
   })

--- a/backend/migrations/20250127141651-delete-download-cache-schema.js
+++ b/backend/migrations/20250127141651-delete-download-cache-schema.js
@@ -1,53 +1,57 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+var dbm
+var type
+var seed
+var fs = require('fs')
+var path = require('path')
+var Promise
 
 /**
-  * We receive the dbmigrate dependency from dbmigrate initially.
-  * This enables us to not have to rely on NODE_PATH.
-  */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20250127141651-delete-download-cache-schema-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  var filePath = path.join(
+    __dirname,
+    'sqls',
+    '20250127141651-delete-download-cache-schema-up.sql',
+  )
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
+  }).then(function (data) {
+    return db.runSql(data)
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20250127141651-delete-download-cache-schema-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  var filePath = path.join(
+    __dirname,
+    'sqls',
+    '20250127141651-delete-download-cache-schema-down.sql',
+  )
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
+  }).then(function (data) {
+    return db.runSql(data)
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1,
+}

--- a/backend/src/services/dsn/fileGateway/index.ts
+++ b/backend/src/services/dsn/fileGateway/index.ts
@@ -3,7 +3,7 @@ import { request } from 'https'
 
 const downloadFile = async (cid: string): Promise<AsyncIterable<Buffer>> => {
   const req = request(
-    `${config.filesGateway}/files/${cid}?api_key=${config.filesGatewayToken}`,
+    `${config.filesGateway}/files/${cid}?api_key=${config.filesGatewayToken}&raw=true`,
   )
 
   req.end()


### PR DESCRIPTION
When http receives a `Content-Encoding: deflate` it automatically decompresses. Since the SDK manages decompression some issues were raised due to intended double decompression. 

Enabling a raw download makes the SDK the unique responsible for decompression. 