### PR TITLE
Update transaction manager

### DIFF
--- a/backend/src/services/upload/onchainPublisher/transactionManager.ts
+++ b/backend/src/services/upload/onchainPublisher/transactionManager.ts
@@ -140,10 +140,12 @@ export const createTransactionManager = () => {
   ): Promise<TransactionResult[]> => {
     await ensureInitialized()
 
-    const transactionWithAccount = transactions.map((transaction) => {
-      const { account, nonce } = accountManager.registerTransaction()
+    const trxPromises = transactions.map(async (transaction) => {
+      const { account, nonce } = await accountManager.registerTransaction()
       return { transaction, account, nonce }
     })
+
+    const transactionWithAccount = await Promise.all(trxPromises)
 
     const promises = transactionWithAccount.map(
       ({ transaction, account, nonce }) => {
@@ -161,9 +163,9 @@ export const createTransactionManager = () => {
                 status: 'Failed',
               }
             })
-            .then((result) => {
+            .then(async (result) => {
               if (!result.success) {
-                accountManager.removeAccount(account.address)
+                await accountManager.removeAccount(account.address)
               }
 
               return result

--- a/frontend/src/components/Files/UploadingFileModal.tsx
+++ b/frontend/src/components/Files/UploadingFileModal.tsx
@@ -69,7 +69,7 @@ export const UploadingFileModal = ({
                     style={{ width: `${progress}%` }}
                   />
                 </div>
-                <div className='mt-4 flex justify-center text-sm font-semibold'>
+                <div className='dark:text-darkBlack mt-4 flex justify-center text-sm font-semibold text-black'>
                   <div>Uploading... {progressPercentage}%</div>
                 </div>
               </div>


### PR DESCRIPTION
Make nonce read on-chain when accounts are re-init. This would make the transaction manager more robust to errors within submitted transactions.  

I introduced the `uniqueExecution` framework here for improving the readability of this service since managing correctly lock-ish mechanism with Promises tend to have poor readability.