### PR TITLE
Fix dockerfile after update

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,14 @@
 FROM node:20.18.3-bookworm-slim
 
 COPY . .
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    python3 \
+    python3-pip \
+    python3-setuptools \
+    git \
+    libsqlite3-dev
+RUN apt update && apt install -y curl
 RUN yarn install
 RUN yarn build
 


### PR DESCRIPTION
After #198 update the Dockerfile was not working correctly since the `curl` was not default in base image and it was used in healthcheck. 