### PR TITLE
fix: folder upload

### DIFF
--- a/backend/src/useCases/uploads/blockstore.ts
+++ b/backend/src/useCases/uploads/blockstore.ts
@@ -25,7 +25,9 @@ const getFileUploadIdCID = async (uploadId: string): Promise<CID> => {
     MetadataType.File,
   )
   if (blockstoreEntry.length !== 1) {
-    throw new Error('Invalid number of blockstore entries')
+    throw new Error(
+      `Invalid number of blockstore entries for file upload with id=${uploadId}`,
+    )
   }
   const cid = blockstoreEntry[0].cid
 
@@ -38,7 +40,9 @@ const getFolderUploadIdCID = async (uploadId: string): Promise<CID> => {
     MetadataType.Folder,
   )
   if (blockstoreEntry.length !== 1) {
-    throw new Error('Invalid number of blockstore entries')
+    throw new Error(
+      `Invalid number of blockstore entries for folder upload with id=${uploadId}`,
+    )
   }
   const cid = blockstoreEntry[0].cid
 

--- a/backend/src/useCases/uploads/uploads.ts
+++ b/backend/src/useCases/uploads/uploads.ts
@@ -195,7 +195,10 @@ const completeUpload = async (
 
   await uploadsRepository.updateUploadEntry(updatedUpload)
 
-  await scheduleNodeMigration(uploadId)
+  const isRootUpload = upload.root_upload_id === uploadId
+  if (isRootUpload) {
+    await scheduleNodeMigration(uploadId)
+  }
 
   return cidToString(cid)
 }


### PR DESCRIPTION
Folder uploads consists of several linked uploads where node publishing doesn't occurr until the whole upload is finished. 

After the update of the message-based uploads within a folder were being migrated, this shouldn't occur until the whole upload is uploaded and parsed into IPLD nodes. For solving this, we should just ensure the scheduling of node migration is only emitted once the root upload is finished and processed.