### PR TITLE
fix: session lasting hour

### DIFF
--- a/auth/src/services/authManager/providers/custom.ts
+++ b/auth/src/services/authManager/providers/custom.ts
@@ -68,7 +68,7 @@ const createAccessToken = async (
   };
 
   return jwt.sign(payload, JWT_SECRET, {
-    expiresIn: "2d",
+    expiresIn: "1h",
     algorithm: JWT_SECRET_ALGORITHM,
   });
 };

--- a/frontend/src/app/api/auth/[...nextauth]/config.ts
+++ b/frontend/src/app/api/auth/[...nextauth]/config.ts
@@ -50,6 +50,15 @@ export const authOptions: AuthOptions = {
       throw new Error('No account or token found');
     },
     async session({ session, token }) {
+      const isTokenExpired = token.exp < Date.now() / 1000;
+      if (isTokenExpired) {
+        const accessToken = await refreshAccessToken({
+          underlyingUserId: token.underlyingUserId!,
+          underlyingProvider: token.underlyingProvider!,
+          refreshToken: token.refreshToken!,
+        });
+        session.accessToken = accessToken.accessToken;
+      }
       session.accessToken = token.accessToken;
       session.authProvider = token.authProvider;
       session.authUserId = token.authUserId;

--- a/frontend/src/app/api/auth/[...nextauth]/config.ts
+++ b/frontend/src/app/api/auth/[...nextauth]/config.ts
@@ -8,6 +8,11 @@ import {
   refreshAccessToken,
 } from './jwt';
 
+// 1 minute before the token expires
+const refreshingTokenThresholdInSeconds = process.env.REFRESHING_TOKEN_THRESHOLD
+  ? parseInt(process.env.REFRESHING_TOKEN_THRESHOLD)
+  : 60;
+
 export const authOptions: AuthOptions = {
   providers: [
     GoogleProvider({
@@ -50,7 +55,9 @@ export const authOptions: AuthOptions = {
       throw new Error('No account or token found');
     },
     async session({ session, token }) {
-      const isTokenExpired = token.exp < Date.now() / 1000;
+      const nowInSeconds = Math.floor(Date.now() / 1000);
+      const isTokenExpired =
+        token.exp < nowInSeconds + refreshingTokenThresholdInSeconds;
       if (isTokenExpired) {
         const accessToken = await refreshAccessToken({
           underlyingUserId: token.underlyingUserId!,


### PR DESCRIPTION
@jfrank-summit reported that sessions in auto-drive were lasting an hour only though the refreshing token was setup  to 7-day-long. 

Refreshing access token was not managed correctly now every time a session called is made by the user a refreshing in intended (in the case access token is to expired)