### PR TITLE
Add vmetrics for request tracing 

### DIFF
--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -2,10 +2,10 @@ import cors from 'cors'
 import express from 'express'
 
 import 'dotenv/config.js'
-import { objectController } from './controllers/object.js'
-import { subscriptionController } from './controllers/subscriptions.js'
+import { objectController } from './http/controllers/object.js'
+import { subscriptionController } from './http/controllers/subscriptions.js'
 import { handleAuth } from './services/auth/express.js'
-import { uploadController } from './controllers/upload.js'
+import { uploadController } from './http/controllers/upload.js'
 import { config } from './config.js'
 import { logger } from './drivers/logger.js'
 
@@ -54,6 +54,8 @@ const createServer = async () => {
       })
     }
   })
+
+  app.use(vMetricsMiddleware)
 
   app.listen(config.express.port, () => {
     logger.info(`Server running at http://localhost:${config.express.port}`)

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -8,6 +8,7 @@ import { handleAuth } from './services/auth/express.js'
 import { uploadController } from './http/controllers/upload.js'
 import { config } from './config.js'
 import { logger } from './drivers/logger.js'
+import { requestTrace } from './http/middlewares/requestTrace.js'
 
 const createServer = async () => {
   const app = express()
@@ -29,6 +30,9 @@ const createServer = async () => {
         origin: config.express.corsAllowedOrigins,
       }),
     )
+  }
+  if (config.monitoring.active) {
+    app.use(requestTrace)
   }
 
   app.use('/objects', objectController)
@@ -54,8 +58,6 @@ const createServer = async () => {
       })
     }
   })
-
-  app.use(vMetricsMiddleware)
 
   app.listen(config.express.port, () => {
     logger.info(`Server running at http://localhost:${config.express.port}`)

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -46,6 +46,14 @@ export const config = {
   rabbitmq: {
     url: env('RABBITMQ_URL'),
   },
+  monitoring: {
+    victoriaEndpoint: env('VICTORIA_ENDPOINT'),
+    auth: {
+      username: env('VICTORIA_AUTH_USERNAME'),
+      password: env('VICTORIA_AUTH_PASSWORD'),
+    },
+    metricEnvironmentTag: env('ENVIRONMENT_TAG', 'chain=unknown'),
+  },
   params: {
     maxConcurrentUploads: Number(env('MAX_CONCURRENT_UPLOADS', '40')),
     maxUploadNodesPerBatch: Number(env('MAX_UPLOAD_NODES_PER_BATCH', '20')),

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -48,10 +48,10 @@ export const config = {
   },
   monitoring: {
     active: env('MONITORING_ENABLED', 'false') === 'true',
-    victoriaEndpoint: env('VICTORIA_ENDPOINT'),
+    victoriaEndpoint: process.env.VICTORIA_ENDPOINT,
     auth: {
-      username: env('VICTORIA_AUTH_USERNAME'),
-      password: env('VICTORIA_AUTH_PASSWORD'),
+      username: process.env.VICTORIA_AUTH_USERNAME,
+      password: process.env.VICTORIA_AUTH_PASSWORD,
     },
     metricEnvironmentTag: env('ENVIRONMENT_TAG', 'chain=unknown'),
   },

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -47,6 +47,7 @@ export const config = {
     url: env('RABBITMQ_URL'),
   },
   monitoring: {
+    active: env('MONITORING_ENABLED', 'false') === 'true',
     victoriaEndpoint: env('VICTORIA_ENDPOINT'),
     auth: {
       username: env('VICTORIA_AUTH_USERNAME'),

--- a/backend/src/drivers/vmetrics.ts
+++ b/backend/src/drivers/vmetrics.ts
@@ -17,6 +17,11 @@ export const sendMetricToVictoria = async (metric: Metric): Promise<void> => {
     `${config.monitoring.auth.username}:${config.monitoring.auth.password}`,
   ).toString('base64')
 
+  if (!config.monitoring.victoriaEndpoint) {
+    console.error('Victoria endpoint is not set')
+    return
+  }
+
   const response = await fetch(config.monitoring.victoriaEndpoint, {
     method: 'POST',
     body: data,

--- a/backend/src/drivers/vmetrics.ts
+++ b/backend/src/drivers/vmetrics.ts
@@ -1,0 +1,30 @@
+import { config } from '../config.js'
+
+export interface Metric {
+  measurement: string
+  tag: string
+  fields: Record<string, string | number | bigint>
+  timestamp?: number
+}
+
+export const sendMetricToVictoria = async (metric: Metric): Promise<void> => {
+  const values = Object.entries(metric.fields).map(
+    ([key, value]) => `${key}=${value}`,
+  )
+  const data = `${metric.measurement},${metric.tag} ${values.join(',')}`
+
+  const basicAuthToken = Buffer.from(
+    `${config.monitoring.auth.username}:${config.monitoring.auth.password}`,
+  ).toString('base64')
+
+  const response = await fetch(config.monitoring.victoriaEndpoint, {
+    method: 'POST',
+    body: data,
+    headers: {
+      Authorization: `Basic ${basicAuthToken}`,
+    },
+  })
+  if (!response.ok) {
+    throw new Error(`Failed to send metric to Victoria: ${response.statusText}`)
+  }
+}

--- a/backend/src/http/controllers/object.ts
+++ b/backend/src/http/controllers/object.ts
@@ -1,14 +1,14 @@
 import { Router } from 'express'
 import { pipeline } from 'stream'
-import { handleAuth, handleOptionalAuth } from '../services/auth/express.js'
+import { handleAuth, handleOptionalAuth } from '../../services/auth/express.js'
 import {
   FilesUseCases,
   ObjectUseCases,
   UploadStatusUseCases,
-} from '../useCases/index.js'
-import { logger } from '../drivers/logger.js'
-import { asyncSafeHandler } from '../utils/express.js'
-import { handleDownloadResponseHeaders } from '../services/download/express.js'
+} from '../../useCases/index.js'
+import { logger } from '../../drivers/logger.js'
+import { asyncSafeHandler } from '../../utils/express.js'
+import { handleDownloadResponseHeaders } from '../../services/download/express.js'
 
 const objectController = Router()
 

--- a/backend/src/http/controllers/subscriptions.ts
+++ b/backend/src/http/controllers/subscriptions.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express'
-import { handleAuth } from '../services/auth/express.js'
-import { SubscriptionsUseCases } from '../useCases/users/subscriptions.js'
-import { asyncSafeHandler } from '../utils/express.js'
+import { handleAuth } from '../../services/auth/express.js'
+import { SubscriptionsUseCases } from '../../useCases/users/subscriptions.js'
+import { asyncSafeHandler } from '../../utils/express.js'
 
 const subscriptionController = Router()
 

--- a/backend/src/http/controllers/upload.ts
+++ b/backend/src/http/controllers/upload.ts
@@ -1,11 +1,11 @@
 import { Router } from 'express'
-import { handleAuth } from '../services/auth/express.js'
-import { UploadsUseCases } from '../useCases/uploads/uploads.js'
+import { handleAuth } from '../../services/auth/express.js'
+import { UploadsUseCases } from '../../useCases/uploads/uploads.js'
 import multer from 'multer'
 import { FolderTreeFolderSchema, uploadOptionsSchema } from '@auto-drive/models'
 import { z } from 'zod'
-import { logger } from '../drivers/logger.js'
-import { asyncSafeHandler } from '../utils/express.js'  
+import { logger } from '../../drivers/logger.js'
+import { asyncSafeHandler } from '../../utils/express.js'
 
 const uploadController = Router()
 

--- a/backend/src/http/middlewares/requestTrace.ts
+++ b/backend/src/http/middlewares/requestTrace.ts
@@ -1,0 +1,34 @@
+import { RequestHandler } from 'express'
+import { Metric, sendMetricToVictoria } from '../../drivers/vmetrics'
+import { config } from '../../config'
+
+export const requestTrace: RequestHandler = (req, res, next) => {
+  const path = req.route?.path
+
+  if (!path) {
+    return next()
+  }
+
+  res.once('finish', () => {
+    const method = req.method
+    const provider =
+      typeof req.headers['x-auth-provider'] === 'string'
+        ? req.headers['x-auth-provider']
+        : 'unknown'
+
+    const metric: Metric = {
+      measurement: 'auto_drive_api_request',
+      tag: config.monitoring.metricEnvironmentTag,
+      fields: {
+        status: res.statusCode,
+        method,
+        path,
+        provider,
+      },
+    }
+
+    sendMetricToVictoria(metric).catch(console.error)
+  })
+
+  next()
+}

--- a/frontend/.yarnrc.yml
+++ b/frontend/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules


### PR DESCRIPTION
This will allow us to obtain metrics about the performance of auto-drive's request so we could make better decisions.

To Reviewers:

- This [file](https://github.com/autonomys/auto-drive/pull/215/files#diff-34d0b2d40c6eb707c9b07269305407202117e4a6f19e1772551cf8ef881c0cd4) is the major change
- I added http at root level including `middlewares` and `controllers`
- Copied VMetrics driver from [auto-files-gateway](https://github.com/autonomys/auto-files-gateway/blob/004e1bf1470e8bc0e4c30e5a117f2a46684e967a/services/file-retriever/src/drivers/metrics.ts)
