### PR TITLE
fix: encoding handling

### DIFF
--- a/backend/src/services/download/express.ts
+++ b/backend/src/services/download/express.ts
@@ -7,9 +7,7 @@ export const handleDownloadResponseHeaders = (
   metadata: OffchainMetadata,
 ) => {
   const safeName = encodeURIComponent(metadata.name || 'download')
-  const isExpectedDocument =
-    req.headers['sec-fetch-dest'] === 'document' ||
-    req.headers['sec-fetch-dest'] === 'iframe'
+  const isExpectedDocument = req.headers['sec-fetch-site'] === 'none'
 
   if (metadata.type === 'file') {
     res.set('Content-Type', metadata.mimeType || 'application/octet-stream')


### PR DESCRIPTION
The issue is that we conditionally manage compression on the server depending on whether is the requester is the SDK or not. This is because the SDK was responsible of managing encryption & compression but chrome for showing the file needs to be decompressed or marked with header Content-Encoding: deflate;

The detection of the requester type was not correctly since `Sec-Fetch-Dest` didn't determine it in all cases.

[Sec-Fetch-Site](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Site#none) explains the relationship between a request initiator's origin and the origin of the requested resource, being `none` when there is not initiator.

Anyways, I'll create an issue for improving the compression handling of auto-drive's both backend & SDK. 