### PR TITLE
fix: request tracing

### DIFF
--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -8,7 +8,6 @@ import { handleAuth } from './services/auth/express.js'
 import { uploadController } from './http/controllers/upload.js'
 import { config } from './config.js'
 import { logger } from './drivers/logger.js'
-import { requestTrace } from './http/middlewares/requestTrace.js'
 
 const createServer = async () => {
   const app = express()

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -35,9 +35,6 @@ const createServer = async () => {
   app.use('/objects', objectController)
   app.use('/subscriptions', subscriptionController)
   app.use('/uploads', uploadController)
-  if (config.monitoring.active) {
-    app.use(requestTrace)
-  }
 
   app.get('/health', (_req, res) => {
     res.sendStatus(204)

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -47,13 +47,13 @@ export const config = {
     url: env('RABBITMQ_URL'),
   },
   monitoring: {
-    active: env('MONITORING_ENABLED', 'false') === 'true',
+    active: env('VICTORIA_ACTIVE', 'false') === 'true',
     victoriaEndpoint: process.env.VICTORIA_ENDPOINT,
     auth: {
-      username: process.env.VICTORIA_AUTH_USERNAME,
-      password: process.env.VICTORIA_AUTH_PASSWORD,
+      username: process.env.VICTORIA_USERNAME,
+      password: process.env.VICTORIA_PASSWORD,
     },
-    metricEnvironmentTag: env('ENVIRONMENT_TAG', 'chain=unknown'),
+    metricEnvironmentTag: env('METRIC_ENVIRONMENT_TAG', 'chain=unknown'),
   },
   params: {
     maxConcurrentUploads: Number(env('MAX_CONCURRENT_UPLOADS', '40')),

--- a/backend/src/drivers/vmetrics.ts
+++ b/backend/src/drivers/vmetrics.ts
@@ -18,6 +18,7 @@ export const sendMetricToVictoria = async (metric: Metric): Promise<void> => {
   ).toString('base64')
 
   if (!config.monitoring.victoriaEndpoint) {
+    console.log(JSON.stringify(config.monitoring, null, 2))
     console.error('Victoria endpoint is not set')
     return
   }

--- a/backend/src/http/middlewares/requestTrace.ts
+++ b/backend/src/http/middlewares/requestTrace.ts
@@ -1,14 +1,8 @@
 import { RequestHandler } from 'express'
 import { Metric, sendMetricToVictoria } from '../../drivers/vmetrics.js'
 import { config } from '../../config.js'
-import { logger } from '../../drivers/logger.js'
 
-export const requestTrace: RequestHandler = (req, res, next) => {
-  console.log('Request trace', {
-    path: req.route?.path,
-    method: req.method,
-    provider: req.headers['x-auth-provider'],
-  })
+export const requestTrace: RequestHandler = (req, res) => {
   const path = req.route?.path
 
   const method = req.method

--- a/backend/src/utils/express.ts
+++ b/backend/src/utils/express.ts
@@ -1,4 +1,6 @@
 import { NextFunction, Request, Response } from 'express'
+import { requestTrace } from '../http/middlewares/requestTrace.js'
+import { config } from '../config.js'
 
 export const asyncSafeHandler = (
   fn: (req: Request, res: Response) => unknown,
@@ -6,7 +8,11 @@ export const asyncSafeHandler = (
   return async (req: Request, res: Response, next: NextFunction) => {
     try {
       await fn(req, res)
-      next()
+      if (config.monitoring.active) {
+        requestTrace(req, res, next)
+      } else {
+        console.log('Request trace disabled')
+      }
     } catch (err) {
       next(err)
     }

--- a/docker-compose.devProdAuth.yml
+++ b/docker-compose.devProdAuth.yml
@@ -35,21 +35,11 @@ services:
       - rabbitmq
       - postgres
     restart: unless-stopped
+    env_file:
+      - .env
     environment:
       DATABASE_URL: postgres://postgres:postgres@postgres:5432/postgres
-      RPC_ENDPOINT: ${RPC_ENDPOINT}
-      PRIVATE_KEYS_PATH: ${PRIVATE_KEYS_PATH}
-      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS}
-      OBJECT_MAPPING_ARCHIVER_URL: ${OBJECT_MAPPING_ARCHIVER_URL}
-      MAX_CACHE_SIZE: ${MAX_CACHE_SIZE}
-      JWT_SECRET: ${JWT_SECRET}
-      FILES_GATEWAY_URL: ${FILES_GATEWAY_URL}
-      FILES_GATEWAY_TOKEN: ${FILES_GATEWAY_TOKEN}
-      AUTH_SERVICE_URL: ${AUTH_SERVICE_URL}
-      AUTH_SERVICE_API_KEY: ${AUTH_SERVICE_API_KEY}
       RABBITMQ_URL: amqp://guest:guest@rabbitmq:5672
-      OPTIONAL_AUTH: ${OPTIONAL_AUTH}
-      MAX_CONCURRENT_UPLOADS: ${MAX_CONCURRENT_UPLOADS}
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
       interval: 15s


### PR DESCRIPTION
The usage of middleware was provoking duplicated headers sent. With this setup we avoid that behavior.

Also, I unified the monitoring object with `auto-files-gateway`