### PR TITLE
fix: request tracing with dynamic tags

### DIFF
--- a/backend/src/http/middlewares/requestTrace.ts
+++ b/backend/src/http/middlewares/requestTrace.ts
@@ -11,9 +11,20 @@ export const requestTrace: RequestHandler = (req, res) => {
       ? req.headers['x-auth-provider']
       : 'unknown'
 
+  const tags = {
+    chain: config.monitoring.metricEnvironmentTag,
+    method,
+    path,
+    provider,
+  }
+
+  const tag = Object.entries(tags)
+    .map(([key, value]) => `${key}=${value}`)
+    .join(',')
+
   const metric: Metric = {
     measurement: 'auto_drive_api_request',
-    tag: config.monitoring.metricEnvironmentTag,
+    tag,
     fields: {
       status: res.statusCode,
       method,


### PR DESCRIPTION
Strings cannot be used as values in VMetrics