### PR TITLE
Improve encoding management

### DIFF
--- a/backend/__tests__/e2e/users/credits.spec.ts
+++ b/backend/__tests__/e2e/users/credits.spec.ts
@@ -12,7 +12,7 @@ import { SubscriptionsUseCases } from '../../../src/useCases/index.js'
 describe('CreditsUseCases', () => {
   let mockUser: UserWithOrganization
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     mockRabbitPublish()
     await getDatabase()
     await dbMigration.up()
@@ -21,7 +21,7 @@ describe('CreditsUseCases', () => {
     if (!result) throw new PreconditionError('Failed to setup test user')
   })
 
-  afterAll(async () => {
+  afterEach(async () => {
     unmockMethods()
     await closeDatabase()
     await dbMigration.down()

--- a/backend/src/http/middlewares/requestTrace.ts
+++ b/backend/src/http/middlewares/requestTrace.ts
@@ -11,9 +11,20 @@ export const requestTrace: RequestHandler = (req, res) => {
       ? req.headers['x-auth-provider']
       : 'unknown'
 
+  const tags = {
+    chain: config.monitoring.metricEnvironmentTag,
+    method,
+    path,
+    provider,
+  }
+
+  const tag = Object.entries(tags)
+    .map(([key, value]) => `${key}=${value}`)
+    .join(',')
+
   const metric: Metric = {
     measurement: 'auto_drive_api_request',
-    tag: config.monitoring.metricEnvironmentTag,
+    tag,
     fields: {
       status: res.statusCode,
       method,

--- a/backend/src/repositories/objects/interactions.ts
+++ b/backend/src/repositories/objects/interactions.ts
@@ -51,6 +51,8 @@ const getInteractionsBySubscriptionIdAndTypeInTimeRange = async (
     [subscriptionId, type, start.toISOString(), end.toISOString()],
   )
 
+  console.log(interactions.rows)
+
   return mapRows(interactions.rows)
 }
 

--- a/backend/src/services/download/express.ts
+++ b/backend/src/services/download/express.ts
@@ -9,6 +9,10 @@ export const handleDownloadResponseHeaders = (
   const safeName = encodeURIComponent(metadata.name || 'download')
   const isExpectedDocument = req.headers['sec-fetch-site'] === 'none'
 
+  const shouldHandleEncoding = req.query.ignoreEncoding
+    ? req.query.ignoreEncoding !== 'true'
+    : isExpectedDocument
+
   if (metadata.type === 'file') {
     res.set('Content-Type', metadata.mimeType || 'application/octet-stream')
     res.set(
@@ -17,7 +21,7 @@ export const handleDownloadResponseHeaders = (
     )
     const compressedButNoEncrypted =
       metadata.uploadOptions?.compression && !metadata.uploadOptions?.encryption
-    if (compressedButNoEncrypted && isExpectedDocument) {
+    if (compressedButNoEncrypted && shouldHandleEncoding) {
       res.set('Content-Encoding', 'deflate')
     }
     res.set('Content-Length', metadata.totalSize.toString())


### PR DESCRIPTION
Encoding management of downloaded files has been a bit of an issue since we were conditionally encoding depending on user request headers.

I'm implementing a set of PRs within Auto-Drive repo's for improve the way we handle this complexity. For prior versions of our SDK we don't have a better approach than relying on headers though for newer versions this won't be an issue anymore. 