### PR TITLE
update: session cookies maxAge

### DIFF
--- a/frontend/src/app/api/auth/[...nextauth]/config.ts
+++ b/frontend/src/app/api/auth/[...nextauth]/config.ts
@@ -77,6 +77,22 @@ export const authOptions: AuthOptions = {
   session: {
     strategy: 'jwt',
   },
+  cookies: {
+    sessionToken: {
+      name:
+        process.env.NODE_ENV === 'production'
+          ? `__Secure-next-auth.session-token`
+          : `next-auth.session-token`,
+      options: {
+        httpOnly: true,
+        sameSite: 'lax',
+        path: '/',
+        secure: true,
+        // 7 days
+        maxAge: 60 * 60 * 24 * 7,
+      },
+    },
+  },
   events: {
     async signOut({ token }) {
       if (token.refreshToken) {

--- a/frontend/src/app/api/auth/[...nextauth]/config.ts
+++ b/frontend/src/app/api/auth/[...nextauth]/config.ts
@@ -81,8 +81,8 @@ export const authOptions: AuthOptions = {
     sessionToken: {
       name:
         process.env.NODE_ENV === 'production'
-          ? `__Secure-next-auth.session-token`
-          : `next-auth.session-token`,
+          ? '__Secure-next-auth.session-token'
+          : 'next-auth.session-token',
       options: {
         httpOnly: true,
         sameSite: 'lax',


### PR DESCRIPTION
Default next auth config is for cookies to persist during session, this means that if a user closes the tab the user should re-login. 

I like the experience of not having to re-login when a session token still valid. I updated the liveliness of the session token to make it equal to the liveliness of the refresh token. 