### PR TITLE
Fix share details generation

### DIFF
--- a/frontend/src/components/FileTables/common/ObjectShareModal.tsx
+++ b/frontend/src/components/FileTables/common/ObjectShareModal.tsx
@@ -77,7 +77,7 @@ export const ObjectShareModal = ({
     }
 
     navigator.clipboard.writeText(
-      `${window.location.origin}/${ROUTES.objectDetails(
+      `${window.location.origin}${ROUTES.objectDetails(
         network.network.id,
         metadata?.metadata.dataCid,
       )}`,


### PR DESCRIPTION
Double slash (`//`) was introduced in this copy button