### PR TITLE
fix: checking downloading headers

### DIFF
--- a/backend/src/services/download/express.ts
+++ b/backend/src/services/download/express.ts
@@ -7,7 +7,10 @@ export const handleDownloadResponseHeaders = (
   metadata: OffchainMetadata,
 ) => {
   const safeName = encodeURIComponent(metadata.name || 'download')
-  const isExpectedDocument = req.headers['sec-fetch-site'] === 'none'
+  const isExpectedDocument =
+    req.headers['sec-fetch-site'] === 'none' ||
+    (req.headers['sec-fetch-site'] === 'same-site' &&
+      req.headers['sec-fetch-mode'] === 'navigate')
 
   const shouldHandleEncoding = req.query.ignoreEncoding
     ? req.query.ignoreEncoding !== 'true'


### PR DESCRIPTION
I've discovered that exists this case in which the document should be rendered as a document