### PR TITLE
fix: missing header in allowed cors headers

### DIFF
--- a/nginx/backend.mainnet.private.conf
+++ b/nginx/backend.mainnet.private.conf
@@ -41,7 +41,7 @@ server {
         # Add CORS
         add_header 'Access-Control-Allow-Origin' '*' always;
         add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
-        add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,X-Auth-Provider' always;
+        add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,X-Auth-Provider,X-Auto-Sdk-Version' always;
         add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range' always;
         add_header 'Access-Control-Max-Age' '3600' always;
         add_header 'Access-Control-Allow-Credentials' 'true' always;
@@ -49,7 +49,7 @@ server {
         if ($request_method = 'OPTIONS') {
             add_header 'Access-Control-Allow-Origin' '*' always;
             add_header 'Access-Control-Allow-Methods' 'GET, POST, DELETE, OPTIONS' always;
-            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,X-Auth-Provider' always;
+            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,X-Auth-Provider,X-Auto-Sdk-Version' always;
             add_header 'Access-Control-Max-Age' 1728000 always;
             add_header 'Content-Type' 'text/plain charset=UTF-8' always;
             add_header 'Content-Length' 0 always;

--- a/nginx/backend.mainnet.public.conf
+++ b/nginx/backend.mainnet.public.conf
@@ -41,7 +41,7 @@ server {
         # Add CORS
         add_header 'Access-Control-Allow-Origin' '*' always;
         add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
-        add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,X-Auth-Provider' always;
+        add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,X-Auth-Provider,X-Auto-Sdk-Version' always;
         add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range' always;
         add_header 'Access-Control-Max-Age' '3600' always;
         add_header 'Access-Control-Allow-Credentials' 'true' always;
@@ -49,7 +49,7 @@ server {
         if ($request_method = 'OPTIONS') {
             add_header 'Access-Control-Allow-Origin' '*' always;
             add_header 'Access-Control-Allow-Methods' 'GET, POST, DELETE, OPTIONS' always;
-            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,X-Auth-Provider' always;
+            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,X-Auth-Provider,X-Auto-Sdk-Version' always;
             add_header 'Access-Control-Max-Age' 1728000 always;
             add_header 'Content-Type' 'text/plain charset=UTF-8' always;
             add_header 'Content-Length' 0 always;

--- a/nginx/backend.taurus.private.conf
+++ b/nginx/backend.taurus.private.conf
@@ -41,7 +41,7 @@ server {
         # Add CORS
         add_header 'Access-Control-Allow-Origin' '*' always;
         add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
-        add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,X-Auth-Provider' always;
+        add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,X-Auth-Provider,X-Auto-Sdk-Version' always;
         add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range' always;
         add_header 'Access-Control-Max-Age' '3600' always;
         add_header 'Access-Control-Allow-Credentials' 'true' always;
@@ -49,7 +49,7 @@ server {
         if ($request_method = 'OPTIONS') {
             add_header 'Access-Control-Allow-Origin' '*' always;
             add_header 'Access-Control-Allow-Methods' 'GET, POST, DELETE, OPTIONS' always;
-            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,X-Auth-Provider' always;
+            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,X-Auth-Provider,X-Auto-Sdk-Version' always;
             add_header 'Access-Control-Max-Age' 1728000 always;
             add_header 'Content-Type' 'text/plain charset=UTF-8' always;
             add_header 'Content-Length' 0 always;

--- a/nginx/backend.taurus.public.conf
+++ b/nginx/backend.taurus.public.conf
@@ -41,7 +41,7 @@ server {
         # Add CORS
         add_header 'Access-Control-Allow-Origin' '*' always;
         add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
-        add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,X-Auth-Provider' always;
+        add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,X-Auth-Provider,X-Auto-Sdk-Version' always;
         add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range' always;
         add_header 'Access-Control-Max-Age' '3600' always;
         add_header 'Access-Control-Allow-Credentials' 'true' always;
@@ -49,7 +49,7 @@ server {
         if ($request_method = 'OPTIONS') {
             add_header 'Access-Control-Allow-Origin' '*' always;
             add_header 'Access-Control-Allow-Methods' 'GET, POST, DELETE, OPTIONS' always;
-            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,X-Auth-Provider' always;
+            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,X-Auth-Provider,X-Auto-Sdk-Version' always;
             add_header 'Access-Control-Max-Age' 1728000 always;
             add_header 'Content-Type' 'text/plain charset=UTF-8' always;
             add_header 'Content-Length' 0 always;


### PR DESCRIPTION
Configuration has been already applied. Missing header used in `@autonomys/auto-drive` package for debugging purposes