### PR TITLE
update: node publishing life cycle

### DIFF
--- a/backend/__tests__/e2e/uploads/files.spec.ts
+++ b/backend/__tests__/e2e/uploads/files.spec.ts
@@ -214,13 +214,6 @@ files.map((file, index) => {
         ).resolves.not.toThrow()
 
         expect(rabbitMock).toHaveBeenCalledWith({
-          id: 'publish-nodes',
-          params: {
-            nodes: expect.arrayContaining([cidToString(cid)]),
-          },
-        })
-
-        expect(rabbitMock).toHaveBeenCalledWith({
           id: 'tag-upload',
           params: {
             cid: cidToString(cid),
@@ -234,6 +227,15 @@ files.map((file, index) => {
           upload.id,
         )
         expect(uploadEntry).toBeNull()
+
+        // Tag the upload
+        await UploadsUseCases.tagUpload(cidToString(cid))
+        expect(rabbitMock).toHaveBeenCalledWith({
+          id: 'publish-nodes',
+          params: {
+            nodes: expect.arrayContaining([cidToString(cid)]),
+          },
+        })
       })
     })
 

--- a/backend/__tests__/e2e/uploads/folder.spec.ts
+++ b/backend/__tests__/e2e/uploads/folder.spec.ts
@@ -273,13 +273,6 @@ describe('Folder Upload', () => {
 
       const uploads = await uploadsRepository.getUploadsByRoot(folderUpload.id)
       expect(uploads).toHaveLength(0)
-
-      expect(rabbitMock).toHaveBeenCalledWith({
-        id: 'publish-nodes',
-        params: {
-          nodes: expect.arrayContaining([cidToString(cid)]),
-        },
-      })
     })
 
     it('tagging folder should mark subfile as insecure', async () => {
@@ -287,6 +280,13 @@ describe('Folder Upload', () => {
       const metadata = await metadataRepository.getMetadata(subfileCID)
       expect(metadata).toMatchObject({
         tags: ['insecure'],
+      })
+
+      expect(rabbitMock).toHaveBeenCalledWith({
+        id: 'publish-nodes',
+        params: {
+          nodes: expect.arrayContaining([folderCID, subfileCID, subfolderCid]),
+        },
       })
     })
 

--- a/backend/src/useCases/uploads/uploads.ts
+++ b/backend/src/useCases/uploads/uploads.ts
@@ -273,9 +273,8 @@ const removeUploadArtifacts = async (uploadId: string): Promise<void> => {
   await fileProcessingInfoRepository.deleteFileProcessingInfo(uploadId)
 }
 
-const scheduleNodesPublish = async (uploadId: string): Promise<void> => {
-  const cid = await BlockstoreUseCases.getUploadCID(uploadId)
-  const nodes = await NodesUseCases.getCidsByRootCid(cidToString(cid))
+const scheduleNodesPublish = async (cid: string): Promise<void> => {
+  const nodes = await NodesUseCases.getCidsByRootCid(cid)
 
   const tasks: Task[] = chunkArray(
     nodes,
@@ -316,6 +315,8 @@ const tagUpload = async (cid: string): Promise<void> => {
       await ObjectUseCases.addTag(cid, 'insecure')
     }
   }
+
+  await scheduleNodesPublish(cid)
 }
 
 const processMigration = async (uploadId: string): Promise<void> => {
@@ -327,7 +328,6 @@ const processMigration = async (uploadId: string): Promise<void> => {
   const cid = await BlockstoreUseCases.getUploadCID(uploadId)
   await NodesUseCases.migrateFromBlockstoreToNodesTable(uploadId)
 
-  await scheduleNodesPublish(uploadId)
   await removeUploadArtifacts(uploadId)
   await scheduleUploadTagging(cidToString(cid))
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build:frontend": "yarn workspace frontend build",
     "build:auth": "yarn workspace auth build",
     "build": "make all",
-    "test": "make test  ",
+    "test": "make test",
     "frontend": "yarn workspace frontend",
     "lint": "yarn workspaces foreach --all --exclude hasura --exclude @auto-drive/models run lint",
     "backend": "yarn workspace backend",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build:frontend": "yarn workspace frontend build",
     "build:auth": "yarn workspace auth build",
     "build": "make all",
-    "test": "make test",
+    "test": "make test  ",
     "frontend": "yarn workspace frontend",
     "lint": "yarn workspaces foreach --all --exclude hasura --exclude @auto-drive/models run lint",
     "backend": "yarn workspace backend",


### PR DESCRIPTION
Nodes were published just after being migrated from the temporary table to the persistent table. 

For avoiding that illegitimate uploads get to into the DSN the node publishing tasks are scheduled once the processing of the tags has been completed.