### PR TITLE
fix: session not being persistent

### DIFF
--- a/frontend/src/app/api/auth/[...nextauth]/config.ts
+++ b/frontend/src/app/api/auth/[...nextauth]/config.ts
@@ -14,7 +14,7 @@ const refreshingTokenThresholdInSeconds = process.env.REFRESHING_TOKEN_THRESHOLD
   : 60;
 
 const ONE_WEEK_IN_SECONDS = 60 * 60 * 24 * 7;
-const ONE_DAY_IN_SECONDS = 60 * 60 * 24;
+
 export const authOptions: AuthOptions = {
   providers: [
     GoogleProvider({
@@ -82,7 +82,7 @@ export const authOptions: AuthOptions = {
     updateAge: 0,
   },
   jwt: {
-    maxAge: ONE_DAY_IN_SECONDS,
+    maxAge: ONE_WEEK_IN_SECONDS,
   },
   events: {
     async signOut({ token }) {

--- a/frontend/src/app/api/auth/[...nextauth]/config.ts
+++ b/frontend/src/app/api/auth/[...nextauth]/config.ts
@@ -13,8 +13,8 @@ const refreshingTokenThresholdInSeconds = process.env.REFRESHING_TOKEN_THRESHOLD
   ? parseInt(process.env.REFRESHING_TOKEN_THRESHOLD)
   : 60;
 
+const ONE_WEEK_IN_SECONDS = 60 * 60 * 24 * 7;
 const ONE_DAY_IN_SECONDS = 60 * 60 * 24;
-
 export const authOptions: AuthOptions = {
   providers: [
     GoogleProvider({
@@ -78,7 +78,8 @@ export const authOptions: AuthOptions = {
   },
   session: {
     strategy: 'jwt',
-    maxAge: ONE_DAY_IN_SECONDS,
+    maxAge: ONE_WEEK_IN_SECONDS,
+    updateAge: 0,
   },
   jwt: {
     maxAge: ONE_DAY_IN_SECONDS,

--- a/frontend/src/app/api/auth/[...nextauth]/config.ts
+++ b/frontend/src/app/api/auth/[...nextauth]/config.ts
@@ -79,7 +79,6 @@ export const authOptions: AuthOptions = {
   session: {
     strategy: 'jwt',
     maxAge: ONE_WEEK_IN_SECONDS,
-    updateAge: 0,
   },
   jwt: {
     maxAge: ONE_WEEK_IN_SECONDS,

--- a/frontend/src/app/api/auth/[...nextauth]/config.ts
+++ b/frontend/src/app/api/auth/[...nextauth]/config.ts
@@ -80,9 +80,6 @@ export const authOptions: AuthOptions = {
     strategy: 'jwt',
     maxAge: ONE_WEEK_IN_SECONDS,
   },
-  jwt: {
-    maxAge: ONE_WEEK_IN_SECONDS,
-  },
   events: {
     async signOut({ token }) {
       if (token.refreshToken) {

--- a/frontend/src/app/api/auth/[...nextauth]/config.ts
+++ b/frontend/src/app/api/auth/[...nextauth]/config.ts
@@ -13,6 +13,8 @@ const refreshingTokenThresholdInSeconds = process.env.REFRESHING_TOKEN_THRESHOLD
   ? parseInt(process.env.REFRESHING_TOKEN_THRESHOLD)
   : 60;
 
+const ONE_DAY_IN_SECONDS = 60 * 60 * 24;
+
 export const authOptions: AuthOptions = {
   providers: [
     GoogleProvider({
@@ -76,22 +78,10 @@ export const authOptions: AuthOptions = {
   },
   session: {
     strategy: 'jwt',
+    maxAge: ONE_DAY_IN_SECONDS,
   },
-  cookies: {
-    sessionToken: {
-      name:
-        process.env.NODE_ENV === 'production'
-          ? '__Secure-next-auth.session-token'
-          : 'next-auth.session-token',
-      options: {
-        httpOnly: true,
-        sameSite: 'lax',
-        path: '/',
-        secure: true,
-        // 7 days
-        maxAge: 60 * 60 * 24 * 7,
-      },
-    },
+  jwt: {
+    maxAge: ONE_DAY_IN_SECONDS,
   },
   events: {
     async signOut({ token }) {


### PR DESCRIPTION
If you enter into auto-drive after having logged in after less than 7 days shouldn't require a re-login