### PR TITLE
fix: refresh session on landing page

### DIFF
--- a/frontend/src/components/Home/index.tsx
+++ b/frontend/src/components/Home/index.tsx
@@ -6,8 +6,12 @@ import { LandingHeader } from 'components/common/LandingHeader';
 import { SigningInButtons } from './SignInButtons';
 import Image from 'next/image';
 import { EXTERNAL_ROUTES } from '../../constants/routes';
+import { getSession } from 'next-auth/react';
 
 export const Home = () => {
+  // Ensure session is refreshed
+  getSession();
+
   return (
     <div className='flex min-h-screen flex-col items-center justify-between gap-2 bg-gradient-to-b from-backgroundLight to-backgroundDark dark:bg-darkWhite dark:from-backgroundDark dark:to-backgroundDarkest dark:text-darkBlack'>
       <LandingHeader />


### PR DESCRIPTION
The middleware uses `getToken` next-auth method for retrieving the session information of the request user. The root cause of the issue is that `getToken` method doesn't refresh the session if needed making the call to `checkAuth` to fail.

For ensuring no authentication is asked before refresh token expiration a session refresh is forced on the landing page. 