### PR TITLE
Ignore download error on archiving

### DIFF
--- a/backend/src/repositories/objects/metadata.ts
+++ b/backend/src/repositories/objects/metadata.ts
@@ -270,15 +270,12 @@ const markAsArchived = async (cid: string) => {
   })
 }
 
-const getMetadataByIsArchived = async (
-  isArchived: boolean,
-  limit: number = 100,
-) => {
+const getMetadataByIsArchived = async (isArchived: boolean) => {
   const db = await getDatabase()
 
   const result = await db.query<MetadataEntry>({
-    text: 'SELECT * FROM metadata WHERE is_archived = $1 LIMIT $2',
-    values: [isArchived, limit],
+    text: 'SELECT * FROM metadata WHERE is_archived = $1',
+    values: [isArchived],
   })
 
   return result.rows

--- a/backend/src/useCases/objects/object.ts
+++ b/backend/src/useCases/objects/object.ts
@@ -383,7 +383,7 @@ const checkObjectsArchivalStatus = async () => {
 
   await Promise.all(
     cidsToArchive.map(async (cid) => {
-      await downloadService.download(cid)
+      await downloadService.download(cid).catch(() => {})
       await ObjectUseCases.processArchival(cid)
     }),
   )

--- a/backend/src/useCases/objects/object.ts
+++ b/backend/src/useCases/objects/object.ts
@@ -23,6 +23,7 @@ import { publishedObjectsRepository } from '../../repositories/objects/published
 import { v4 } from 'uuid'
 import { FilesUseCases } from './files.js'
 import { downloadService } from '../../services/download/index.js'
+import { logger } from '../../drivers/logger.js'
 
 const getMetadata = async (cid: string) => {
   const entry = await metadataRepository.getMetadata(cid)
@@ -383,7 +384,9 @@ const checkObjectsArchivalStatus = async () => {
 
   await Promise.all(
     cidsToArchive.map(async (cid) => {
-      await downloadService.download(cid).catch(() => {})
+      await downloadService.download(cid).catch(() => {
+        logger.warn(`Failed to download object ${cid} after archival check`)
+      })
       await ObjectUseCases.processArchival(cid)
     }),
   )


### PR DESCRIPTION
Sometimes nodes are already removed but the download is tried causing the file download to fail and re-executing the full batch again