### PR TITLE
Fix uploading nodes

### DIFF
--- a/backend/src/services/upload/onchainPublisher/index.ts
+++ b/backend/src/services/upload/onchainPublisher/index.ts
@@ -41,7 +41,7 @@ const publishNodes = safeCallback(
     const someNodeFailed = results.some((result) => !result.success)
     if (someNodeFailed) {
       republishNodes(
-        nodes
+        filteredNodes
           .filter((_, index) => !results[index].success)
           .map((node) => node.cid),
         retriesLeft,
@@ -49,7 +49,7 @@ const publishNodes = safeCallback(
     }
 
     await Promise.all(
-      nodes.map((node, index) => {
+      filteredNodes.map((node, index) => {
         const isSuccess = results[index].success
         if (!isSuccess) return null
         return NodesUseCases.setPublishedOn(node.cid, results[index])


### PR DESCRIPTION
Discarding duplicated nodes led to misreading the results. Just updating to `filteredNodes` fix it