### PR TITLE
update: cache populating policy

### DIFF
--- a/backend/__tests__/e2e/objects/nodes.spec.ts
+++ b/backend/__tests__/e2e/objects/nodes.spec.ts
@@ -19,9 +19,7 @@ import {
 } from '../../../src/repositories/index.js'
 import { ObjectMappingListEntry } from '@auto-drive/models'
 import { mockRabbitPublish, unmockMethods } from '../../utils/mocks.js'
-import { downloadService } from '../../../src/services/download/index.js'
 import { jest } from '@jest/globals'
-import { Readable } from 'stream'
 
 describe('Nodes', () => {
   const id = v4()
@@ -183,15 +181,10 @@ describe('Nodes', () => {
     const processArchivalSpy = jest
       .spyOn(ObjectUseCases, 'processArchival')
       .mockResolvedValue()
-    const downloadServiceSpy = jest
-      .spyOn(downloadService, 'download')
-      .mockResolvedValue(Readable.from(Buffer.from(encodeNode(node))))
     const hash = Buffer.from(blake3HashFromCid(cid)).toString('hex')
     await NodesUseCases.processNodeArchived([[hash, 1, 1]])
 
     expect(processArchivalSpy).toHaveBeenCalledWith(cidToString(cid))
-    expect(downloadServiceSpy).toHaveBeenCalledWith(cidToString(cid))
     expect(processArchivalSpy).toHaveBeenCalledTimes(1)
-    expect(downloadServiceSpy).toHaveBeenCalledTimes(1)
   })
 })

--- a/backend/__tests__/e2e/objects/nodes.spec.ts
+++ b/backend/__tests__/e2e/objects/nodes.spec.ts
@@ -179,7 +179,7 @@ describe('Nodes', () => {
     )
 
     const processArchivalSpy = jest
-      .spyOn(ObjectUseCases, 'processArchival')
+      .spyOn(ObjectUseCases, 'onObjectArchived')
       .mockResolvedValue()
     const hash = Buffer.from(blake3HashFromCid(cid)).toString('hex')
     await NodesUseCases.processNodeArchived([[hash, 1, 1]])

--- a/backend/src/useCases/objects/object.ts
+++ b/backend/src/useCases/objects/object.ts
@@ -321,7 +321,7 @@ const populateCaches = async (cid: string) => {
   })
 }
 
-const processArchival = async (cid: string) => {
+const onObjectArchived = async (cid: string) => {
   await populateCaches(cid)
   await metadataRepository.markAsArchived(cid)
   await nodesRepository.removeNodesByRootCid(cid)
@@ -395,7 +395,7 @@ const checkObjectsArchivalStatus = async () => {
 
   await Promise.all(
     cidsToArchive.map(async (cid) => {
-      await ObjectUseCases.processArchival(cid)
+      await ObjectUseCases.onObjectArchived(cid)
     }),
   )
 }
@@ -421,7 +421,7 @@ export const ObjectUseCases = {
   isArchived,
   hasAllNodesArchived,
   getNonArchivedObjects,
-  processArchival,
+  onObjectArchived,
   publishObject,
   downloadPublishedObject,
   unpublishObject,


### PR DESCRIPTION
Now on object archival the auto-drive cache is populated from DB file re-construction and the is forced a download in files gateway for populating their cache. 

This is because we'd want the public instance (the one used by `gateway.autonomys.xyz`) to have the object cached but the upload is done via the private one. 