### PR TITLE
Separate services for Worker & API

### DIFF
--- a/backend/__tests__/e2e/objects/nodes.spec.ts
+++ b/backend/__tests__/e2e/objects/nodes.spec.ts
@@ -17,9 +17,11 @@ import {
   Node,
   nodesRepository,
 } from '../../../src/repositories/index.js'
-import { ObjectMappingListEntry } from '@auto-drive/models'
+import { ObjectMapping, ObjectMappingListEntry, TransactionResult } from '@auto-drive/models'
 import { mockRabbitPublish, unmockMethods } from '../../utils/mocks.js'
 import { jest } from '@jest/globals'
+import { TaskManager } from '../../../src/services/taskManager/index.js'
+import { BlockstoreUseCases } from '../../../src/useCases/uploads/blockstore.js'
 
 describe('Nodes', () => {
   const id = v4()
@@ -186,5 +188,196 @@ describe('Nodes', () => {
 
     expect(processArchivalSpy).toHaveBeenCalledWith(cidToString(cid))
     expect(processArchivalSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('should get chunk data from node repository', async () => {
+    const text = 'chunk_data_test'
+    const node = createSingleFileIpldNode(Buffer.from(text), text)
+    const cid = cidOfNode(node)
+    const cidString = cidToString(cid)
+    const encodedNode = Buffer.from(encodeNode(node)).toString('base64')
+
+    await nodesRepository.saveNode({
+      cid: cidString,
+      head_cid: cidString,
+      root_cid: cidString,
+      type: MetadataType.File,
+      encoded_node: encodedNode,
+      block_published_on: null,
+      tx_published_on: null,
+      piece_index: null,
+      piece_offset: null,
+    })
+
+    const chunkData = await NodesUseCases.getChunkData(cid)
+    expect(chunkData).toBeDefined()
+    expect(chunkData?.toString()).toBe(text)
+  })
+
+  it('should get chunk data from blockstore if not in node repository', async () => {
+    const text = 'blockstore_chunk_data'
+    const node = createSingleFileIpldNode(Buffer.from(text), text)
+    const cid = cidOfNode(node)
+    const cidString = cidToString(cid)
+
+    // Mock BlockstoreUseCases.getNode to return the node
+    const getNodeSpy = jest
+      .spyOn(BlockstoreUseCases, 'getNode')
+      .mockResolvedValue(Buffer.from(encodeNode(node)))
+
+    const chunkData = await NodesUseCases.getChunkData(cidString)
+    expect(getNodeSpy).toHaveBeenCalledWith(cidString)
+    expect(chunkData).toBeDefined()
+    expect(chunkData?.toString()).toBe(text)
+
+    getNodeSpy.mockRestore()
+  })
+
+  it('should return undefined when chunk data is not found', async () => {
+    const nonExistentCid =
+      'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi'
+
+    // Mock BlockstoreUseCases.getNode to return undefined
+    const getNodeSpy = jest
+      .spyOn(BlockstoreUseCases, 'getNode')
+      .mockResolvedValue(undefined)
+
+    const chunkData = await NodesUseCases.getChunkData(nonExistentCid)
+    expect(chunkData).toBeUndefined()
+
+    getNodeSpy.mockRestore()
+  })
+
+  it('should save multiple nodes', async () => {
+    const text1 = 'save_nodes_test_1'
+    const text2 = 'save_nodes_test_2'
+    const node1 = createSingleFileIpldNode(Buffer.from(text1), text1)
+    const node2 = createSingleFileIpldNode(Buffer.from(text2), text2)
+    const rootCid = cidOfNode(node1)
+    const headCid = cidOfNode(node2)
+
+    await NodesUseCases.saveNodes(rootCid, headCid, [node1, node2])
+
+    const savedNode1 = await nodesRepository.getNode(
+      cidToString(cidOfNode(node1)),
+    )
+    const savedNode2 = await nodesRepository.getNode(
+      cidToString(cidOfNode(node2)),
+    )
+
+    expect(savedNode1).toBeDefined()
+    expect(savedNode2).toBeDefined()
+    expect(savedNode1?.root_cid).toBe(cidToString(rootCid))
+    expect(savedNode2?.root_cid).toBe(cidToString(rootCid))
+    expect(savedNode1?.head_cid).toBe(cidToString(headCid))
+    expect(savedNode2?.head_cid).toBe(cidToString(headCid))
+  })
+
+  it('should get CIDs by root CID', async () => {
+    const text = 'get_cids_by_root_test'
+    const node = createSingleFileIpldNode(Buffer.from(text), text)
+    const cid = cidOfNode(node)
+    const cidString = cidToString(cid)
+
+    await nodesRepository.saveNode({
+      cid: cidString,
+      head_cid: cidString,
+      root_cid: cidString,
+      type: MetadataType.File,
+      encoded_node: Buffer.from(encodeNode(node)).toString('base64'),
+      block_published_on: null,
+      tx_published_on: null,
+      piece_index: null,
+      piece_offset: null,
+    })
+
+    const cids = await NodesUseCases.getCidsByRootCid(cidString)
+    expect(cids).toContain(cidString)
+  })
+
+  it('should get nodes by CIDs', async () => {
+    const text = 'get_nodes_by_cids_test'
+    const node = createSingleFileIpldNode(Buffer.from(text), text)
+    const cid = cidOfNode(node)
+    const cidString = cidToString(cid)
+
+    await nodesRepository.saveNode({
+      cid: cidString,
+      head_cid: cidString,
+      root_cid: cidString,
+      type: MetadataType.File,
+      encoded_node: Buffer.from(encodeNode(node)).toString('base64'),
+      block_published_on: null,
+      tx_published_on: null,
+      piece_index: null,
+      piece_offset: null,
+    })
+
+    const nodes = await NodesUseCases.getNodesByCids([cidString])
+    expect(nodes).toHaveLength(1)
+    expect(nodes[0].cid).toBe(cidString)
+  })
+
+  it('should schedule node archiving', async () => {
+    const publishSpy = jest
+      .spyOn(TaskManager, 'publish')
+      .mockImplementation(() => {})
+
+    const objects: ObjectMapping[] = [['deadbeef', 1, 2]]
+    await NodesUseCases.scheduleNodeArchiving(objects)
+
+    expect(publishSpy).toHaveBeenCalledWith([
+      expect.objectContaining({
+        id: 'archive-objects',
+        params: {
+          objects,
+        },
+      }),
+    ])
+
+    publishSpy.mockRestore()
+  })
+
+  it('should set published on information', async () => {
+    const text = 'set_published_on_test'
+    const node = createSingleFileIpldNode(Buffer.from(text), text)
+    const cid = cidOfNode(node)
+    const cidString = cidToString(cid)
+
+    await nodesRepository.saveNode({
+      cid: cidString,
+      head_cid: cidString,
+      root_cid: cidString,
+      type: MetadataType.File,
+      encoded_node: Buffer.from(encodeNode(node)).toString('base64'),
+      block_published_on: null,
+      tx_published_on: null,
+      piece_index: null,
+      piece_offset: null,
+    })
+
+    const result: TransactionResult = {
+      blockNumber: 12345,
+      txHash: '0xabcdef',
+      status: 'success',
+      success: true,
+    }
+
+    await NodesUseCases.setPublishedOn(cidString, result)
+
+    const updatedNode = await nodesRepository.getNode(cidString)
+    expect(updatedNode?.block_published_on).toBe(12345)
+    expect(updatedNode?.tx_published_on).toBe('0xabcdef')
+  })
+
+  it('should throw error when setting published on with missing data', async () => {
+    const cidString =
+      'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi'
+    // @ts-expect-error: This is a test
+    const incompleteResult: TransactionResult = {}
+
+    await expect(
+      NodesUseCases.setPublishedOn(cidString, incompleteResult),
+    ).rejects.toThrow(`No block number or tx hash for ${cidString}`)
   })
 })

--- a/backend/__tests__/unit/TaskManager.spec.ts
+++ b/backend/__tests__/unit/TaskManager.spec.ts
@@ -1,0 +1,162 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { jest, describe, it, expect, beforeEach } from '@jest/globals'
+import { Task } from '../../src/services/taskManager/tasks.js'
+import { Rabbit as RabbitT } from '../../src/drivers/rabbit.js'
+import { TaskManager as TaskManagerT } from '../../src/services/taskManager/index.js'
+import { UploadsUseCases as UploadsUseCasesT } from '../../src/useCases/uploads/uploads.js'
+import { OnchainPublisher as OnchainPublisherT } from '../../src/services/upload/onchainPublisher/index.js'
+import { logger as LoggerT } from '../../src/drivers/logger.js'
+
+// Mock dependencies before imports
+jest.unstable_mockModule('../../src/drivers/rabbit.js', () => ({
+  Rabbit: {
+    subscribe: jest.fn(),
+    publish: jest.fn(),
+  },
+}))
+
+jest.unstable_mockModule('../../src/useCases/objects/nodes.js', () => ({
+  NodesUseCases: {
+    processNodeArchived: jest.fn(),
+  },
+}))
+
+jest.unstable_mockModule('../../src/useCases/uploads/uploads.js', () => ({
+  UploadsUseCases: {
+    processMigration: jest.fn(),
+    tagUpload: jest.fn(),
+  },
+}))
+
+jest.unstable_mockModule(
+  '../../src/services/upload/onchainPublisher/index.js',
+  () => ({
+    OnchainPublisher: {
+      publishNodes: jest.fn(),
+    },
+  }),
+)
+
+jest.unstable_mockModule('../../src/drivers/logger.js', () => ({
+  logger: {
+    error: jest.fn(),
+  },
+}))
+
+describe('TaskManager', () => {
+  let subscribeCallback: (obj: object) => Promise<unknown>
+  let TaskManager: typeof TaskManagerT
+  let Rabbit: typeof RabbitT
+  let UploadsUseCases: typeof UploadsUseCasesT
+  let OnchainPublisher: typeof OnchainPublisherT
+  let logger: typeof LoggerT
+  beforeAll(async () => {
+    // Import modules after mocks
+    TaskManager = (await import('../../src/services/taskManager/index.js'))
+      .TaskManager
+    Rabbit = (await import('../../src/drivers/rabbit.js')).Rabbit
+    UploadsUseCases = (await import('../../src/useCases/uploads/uploads.js'))
+      .UploadsUseCases
+    OnchainPublisher = (
+      await import('../../src/services/upload/onchainPublisher/index.js')
+    ).OnchainPublisher
+    logger = (await import('../../src/drivers/logger.js')).logger
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    // Capture the callback passed to Rabbit.subscribe
+    jest.mocked(Rabbit.subscribe).mockImplementation(async (callback) => {
+      subscribeCallback = callback
+      return Promise.resolve(() => {})
+    })
+  })
+
+  describe('start', () => {
+    it('should subscribe to the rabbit queue', () => {
+      TaskManager.start()
+      expect(Rabbit.subscribe).toHaveBeenCalled()
+    })
+
+    it('should log an error when receiving an invalid task', async () => {
+      TaskManager.start()
+      await subscribeCallback({})
+      expect(logger.error).toHaveBeenCalledWith(
+        'Invalid task',
+        expect.anything(),
+      )
+    })
+
+    it('should process a valid task', async () => {
+      TaskManager.start()
+      const validTask = {
+        id: 'migrate-upload-nodes',
+        params: { uploadId: '123' },
+        retriesLeft: 3,
+      }
+
+      await subscribeCallback(validTask)
+
+      expect(UploadsUseCases.processMigration).toHaveBeenCalledWith('123')
+    })
+
+    it('should log an error when a task fails and has no retries left', async () => {
+      TaskManager.start()
+      const validTask = {
+        id: 'publish-nodes',
+        params: { nodes: ['node1', 'node2'] },
+        retriesLeft: 0,
+      }
+
+      jest
+        .mocked(OnchainPublisher.publishNodes)
+        .mockImplementationOnce(async () => {
+          throw new Error('Test error')
+        })
+
+      await subscribeCallback(validTask)
+
+      expect(logger.error).toHaveBeenCalledWith(
+        'Task failed',
+        expect.anything(),
+      )
+      expect(Rabbit.publish).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('publish', () => {
+    it('should publish a single task', () => {
+      const task: Task = {
+        id: 'tag-upload',
+        params: { cid: 'test-cid' },
+        retriesLeft: 3,
+      }
+
+      TaskManager.publish(task)
+
+      expect(Rabbit.publish).toHaveBeenCalledWith(task)
+    })
+
+    it('should publish multiple tasks', () => {
+      const tasks: Task[] = [
+        {
+          id: 'tag-upload',
+          params: { cid: 'test-cid-1' },
+          retriesLeft: 3,
+        },
+        {
+          id: 'publish-nodes',
+          params: { nodes: ['node1'] },
+          retriesLeft: 3,
+        },
+      ]
+
+      TaskManager.publish(tasks)
+
+      expect(Rabbit.publish).toHaveBeenCalledTimes(2)
+      expect(Rabbit.publish).toHaveBeenCalledWith(tasks[0])
+      expect(Rabbit.publish).toHaveBeenCalledWith(tasks[1])
+    })
+  })
+})

--- a/backend/__tests__/unit/repositories/metadata.spec.ts
+++ b/backend/__tests__/unit/repositories/metadata.spec.ts
@@ -1,0 +1,379 @@
+import { describe, it, expect, beforeAll, afterAll } from '@jest/globals'
+import { metadataRepository } from '../../../src/repositories/objects/metadata.js'
+import { OffchainMetadata } from '@autonomys/auto-dag-data'
+import { dbMigration } from '../../utils/dbMigrate.js'
+import { ownershipRepository } from '../../../src/repositories/index.js'
+
+describe('Metadata Repository', () => {
+  beforeAll(async () => {
+    await dbMigration.up()
+  })
+
+  afterAll(async () => {
+    await dbMigration.down()
+  })
+
+  beforeEach(async () => {
+    // Clean up the database before each test
+    const allMetadata = await metadataRepository.getAllMetadata()
+    for (const metadata of allMetadata) {
+      await metadataRepository.markAsArchived(metadata.head_cid)
+    }
+  })
+
+  it('should set and get metadata', async () => {
+    const rootCid = 'test-root-cid'
+    const headCid = 'test-head-cid'
+    const metadata: OffchainMetadata = {
+      totalSize: 100n,
+      type: 'file',
+      dataCid: 'test-data-cid',
+      totalChunks: 1,
+      chunks: [],
+      name: 'test-file',
+    }
+
+    await metadataRepository.setMetadata(rootCid, headCid, metadata)
+    const result = await metadataRepository.getMetadata(headCid)
+
+    expect(result).toBeDefined()
+    expect(result?.root_cid).toBe(rootCid)
+    expect(result?.head_cid).toBe(headCid)
+    expect(result?.metadata.name).toBe(metadata.name)
+    expect(result?.metadata.type).toBe(metadata.type)
+    expect(result?.metadata.dataCid).toBe(metadata.dataCid)
+  })
+
+  it('should search metadata by CID', async () => {
+    const rootCid = 'search-root-cid'
+    const headCid = 'search-head-cid'
+    const metadata: OffchainMetadata = {
+      totalSize: 100n,
+      type: 'file',
+      dataCid: 'search-data-cid',
+      totalChunks: 1,
+      chunks: [],
+      name: 'search-file',
+    }
+
+    await metadataRepository.setMetadata(rootCid, headCid, metadata)
+
+    // Note: This test might fail because searchMetadataByCID requires object_ownership entries
+    // In a real implementation, we would need to add ownership records
+    const results = await metadataRepository.searchMetadataByCID('search', 10)
+
+    // This might be empty if ownership records are required
+    if (results.length > 0) {
+      expect(results[0].head_cid).toBe(headCid)
+    }
+  })
+
+  it('should mark metadata as archived', async () => {
+    const rootCid = 'archive-root-cid'
+    const headCid = 'archive-head-cid'
+    const metadata: OffchainMetadata = {
+      totalSize: 100n,
+      type: 'file',
+      dataCid: 'archive-data-cid',
+      totalChunks: 1,
+      chunks: [],
+      name: 'archive-file',
+    }
+
+    await metadataRepository.setMetadata(rootCid, headCid, metadata)
+    await metadataRepository.markAsArchived(headCid)
+
+    const result = await metadataRepository.getMetadata(headCid)
+    expect(result?.is_archived).toBe(true)
+
+    const archivedResults =
+      await metadataRepository.getMetadataByIsArchived(true)
+    expect(archivedResults.some((m) => m.head_cid === headCid)).toBe(true)
+  })
+
+  it('should add tags to metadata', async () => {
+    const rootCid = 'tag-root-cid'
+    const headCid = 'tag-head-cid'
+    const metadata: OffchainMetadata = {
+      totalSize: 100n,
+      type: 'file',
+      dataCid: 'tag-data-cid',
+      totalChunks: 1,
+      chunks: [],
+      name: 'tag-file',
+    }
+
+    await metadataRepository.setMetadata(rootCid, headCid, metadata)
+    await metadataRepository.addTag(headCid, 'test-tag')
+
+    const result = await metadataRepository.getMetadata(headCid)
+    expect(result?.tags).toContain('test-tag')
+  })
+
+  it('should get metadata by root CID', async () => {
+    const rootCid = 'root-cid-test'
+    const headCid1 = 'head-cid-test-1'
+    const headCid2 = 'head-cid-test-2'
+
+    const metadata1: OffchainMetadata = {
+      totalSize: 100n,
+      type: 'file',
+      dataCid: 'data-cid-1',
+      totalChunks: 1,
+      chunks: [],
+      name: 'file-1',
+    }
+
+    const metadata2: OffchainMetadata = {
+      totalSize: 200n,
+      type: 'file',
+      dataCid: 'data-cid-2',
+      totalChunks: 1,
+      chunks: [],
+      name: 'file-2',
+    }
+
+    await metadataRepository.setMetadata(rootCid, headCid1, metadata1)
+    await metadataRepository.setMetadata(rootCid, headCid2, metadata2)
+
+    const results = await metadataRepository.getMetadataByRootCid(rootCid)
+
+    expect(results.length).toBe(2)
+    expect(results.map((r) => r.head_cid)).toContain(headCid1)
+    expect(results.map((r) => r.head_cid)).toContain(headCid2)
+  })
+
+  it('should get all metadata', async () => {
+    const rootCid = 'all-metadata-root-cid'
+    const headCid = 'all-metadata-head-cid'
+    const metadata: OffchainMetadata = {
+      totalSize: 100n,
+      type: 'file',
+      dataCid: 'all-metadata-data-cid',
+      totalChunks: 1,
+      chunks: [],
+      name: 'all-metadata-file',
+    }
+
+    await metadataRepository.setMetadata(rootCid, headCid, metadata)
+
+    const results = await metadataRepository.getAllMetadata()
+    expect(results.length).toBeGreaterThan(0)
+    expect(results.some((r) => r.head_cid === headCid)).toBe(true)
+  })
+
+  it('should search metadata by CID', async () => {
+    const rootCid = 'search-cid-root'
+    const headCid = 'search-cid-head-unique'
+    const metadata: OffchainMetadata = {
+      totalSize: 100n,
+      type: 'file',
+      dataCid: 'search-cid-data',
+      totalChunks: 1,
+      chunks: [],
+      name: 'search-cid-file',
+    }
+
+    await ownershipRepository.setUserAsAdmin(headCid, 'test-provider', 'test-user-id')
+    await metadataRepository.setMetadata(rootCid, headCid, metadata)
+
+    const results = await metadataRepository.searchMetadataByCID(
+      headCid,
+      10000,
+    )
+    expect(
+      results.find((r) => r.metadata.dataCid === metadata.dataCid),
+    ).toBeTruthy()
+  })
+
+  it('should search metadata by CID and user', async () => {
+    const rootCid = 'search-cid-user-root'
+    const headCid = 'search-cid-user-head-special'
+    const metadata: OffchainMetadata = {
+      totalSize: 100n,
+      type: 'file',
+      dataCid: 'search-cid-user-data',
+      totalChunks: 1,
+      chunks: [],
+      name: 'search-cid-user-file',
+    }
+    const provider = 'test-provider'
+    const userId = 'test-user-id'
+
+    await metadataRepository.setMetadata(rootCid, headCid, metadata)
+    // Note: This test assumes object_ownership is set up correctly
+
+    const results = await metadataRepository.searchMetadataByCIDAndUser(
+      'special',
+      10,
+      provider,
+      userId,
+    )
+    // This might return empty if the ownership isn't set up in the test
+    expect(Array.isArray(results)).toBe(true)
+  })
+
+  it('should search metadata by name and user', async () => {
+    const rootCid = 'search-name-user-root'
+    const headCid = 'search-name-user-head'
+    const metadata: OffchainMetadata = {
+      totalSize: 100n,
+      type: 'file',
+      dataCid: 'search-name-user-data',
+      totalChunks: 1,
+      chunks: [],
+      name: 'unique-search-name-test',
+    }
+    const provider = 'test-provider'
+    const userId = 'test-user-id'
+
+    await metadataRepository.setMetadata(rootCid, headCid, metadata)
+
+    const results = await metadataRepository.searchMetadataByNameAndUser(
+      'unique-search',
+      provider,
+      userId,
+      10,
+    )
+    // This might return empty if the ownership isn't set up in the test
+    expect(Array.isArray(results)).toBe(true)
+  })
+
+  it('should search metadata by name', async () => {
+    const rootCid = 'search-name-root'
+    const headCid = 'search-name-head'
+    const metadata: OffchainMetadata = {
+      totalSize: 100n,
+      type: 'file',
+      dataCid: 'search-name-data',
+      totalChunks: 1,
+      chunks: [],
+      name: 'very-specific-name-for-search',
+    }
+
+    await metadataRepository.setMetadata(rootCid, headCid, metadata)
+
+    const results = await metadataRepository.searchMetadataByName(
+      'specific-name',
+      10,
+    )
+    expect(results.some((r) => r.head_cid === headCid)).toBe(true)
+  })
+
+  it('should get root objects with pagination', async () => {
+    const rootCid = 'root-objects-root'
+    const headCid = rootCid // Same for root objects
+    const metadata: OffchainMetadata = {
+      totalSize: 100n,
+      type: 'file',
+      dataCid: 'root-objects-data',
+      totalChunks: 1,
+      chunks: [],
+      name: 'root-objects-file',
+    }
+
+    await metadataRepository.setMetadata(rootCid, headCid, metadata)
+
+    const result = await metadataRepository.getRootObjects(10, 0)
+    expect(result).toHaveProperty('rows')
+    expect(result).toHaveProperty('totalCount')
+    expect(Array.isArray(result.rows)).toBe(true)
+  })
+
+  it('should get root objects by user with pagination', async () => {
+    const provider = 'test-provider'
+    const userId = 'test-user-id'
+
+    const result = await metadataRepository.getRootObjectsByUser(
+      provider,
+      userId,
+      10,
+      0,
+    )
+    expect(result).toHaveProperty('rows')
+    expect(result).toHaveProperty('totalCount')
+    expect(Array.isArray(result.rows)).toBe(true)
+  })
+
+  it('should get shared root objects by user with pagination', async () => {
+    const provider = 'test-provider'
+    const userId = 'test-user-id'
+
+    const result = await metadataRepository.getSharedRootObjectsByUser(
+      provider,
+      userId,
+      10,
+      0,
+    )
+    expect(result).toHaveProperty('rows')
+    expect(result).toHaveProperty('totalCount')
+    expect(Array.isArray(result.rows)).toBe(true)
+  })
+
+  it('should get marked as deleted root objects by user with pagination', async () => {
+    const provider = 'test-provider'
+    const userId = 'test-user-id'
+
+    const result = await metadataRepository.getMarkedAsDeletedRootObjectsByUser(
+      provider,
+      userId,
+      10,
+      0,
+    )
+    expect(result).toHaveProperty('rows')
+    expect(result).toHaveProperty('totalCount')
+    expect(Array.isArray(result.rows)).toBe(true)
+  })
+
+  it('should get metadata by user', async () => {
+    const provider = 'test-provider'
+    const userId = 'test-user-id'
+
+    const result = await metadataRepository.getMetadataByUser(provider, userId)
+    expect(result).toHaveProperty('rows')
+    expect(Array.isArray(result.rows)).toBe(true)
+  })
+
+  it('should mark metadata as archived', async () => {
+    const rootCid = 'archive-root-cid'
+    const headCid = 'archive-head-cid'
+    const metadata: OffchainMetadata = {
+      totalSize: 100n,
+      type: 'file',
+      dataCid: 'archive-data-cid',
+      totalChunks: 1,
+      chunks: [],
+      name: 'archive-file',
+    }
+
+    await metadataRepository.setMetadata(rootCid, headCid, metadata)
+    await metadataRepository.markAsArchived(headCid)
+
+    const result = await metadataRepository.getMetadata(headCid)
+    expect(result?.is_archived).toBe(true)
+  })
+
+  it('should get metadata by archived status', async () => {
+    const rootCid = 'archived-status-root-cid'
+    const headCid = 'archived-status-head-cid'
+    const metadata: OffchainMetadata = {
+      totalSize: 100n,
+      type: 'file',
+      dataCid: 'archived-status-data-cid',
+      totalChunks: 1,
+      chunks: [],
+      name: 'archived-status-file',
+    }
+
+    await metadataRepository.setMetadata(rootCid, headCid, metadata)
+    await metadataRepository.markAsArchived(headCid)
+
+    const archivedResults =
+      await metadataRepository.getMetadataByIsArchived(true)
+    expect(archivedResults.some((r) => r.head_cid === headCid)).toBe(true)
+
+    const nonArchivedResults =
+      await metadataRepository.getMetadataByIsArchived(false)
+    expect(nonArchivedResults.some((r) => r.head_cid === headCid)).toBe(false)
+  })
+})

--- a/backend/__tests__/unit/repositories/nodes.spec.ts
+++ b/backend/__tests__/unit/repositories/nodes.spec.ts
@@ -1,0 +1,537 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+} from '@jest/globals'
+import {
+  nodesRepository,
+  Node,
+} from '../../../src/repositories/objects/nodes.js'
+import { dbMigration } from '../../utils/dbMigrate.js'
+import { MetadataType } from '@autonomys/auto-dag-data'
+
+describe('Nodes Repository', () => {
+  beforeAll(async () => {
+    await dbMigration.up()
+  })
+
+  afterAll(async () => {
+    await dbMigration.down()
+  })
+
+  beforeEach(async () => {
+    // Clean up the database before each test
+    const nodes = await nodesRepository.getNodesByRootCid('test-root-cid')
+    for (const node of nodes) {
+      await nodesRepository.removeNodesByRootCid(node.root_cid)
+    }
+  })
+
+  it('should save and get a node', async () => {
+    const node: Node = {
+      cid: 'test-cid',
+      root_cid: 'test-root-cid',
+      head_cid: 'test-head-cid',
+      type: 'file',
+      encoded_node: 'test-encoded-node',
+      piece_index: null,
+      piece_offset: null,
+      block_published_on: null,
+      tx_published_on: null,
+    }
+
+    await nodesRepository.saveNode(node)
+    const result = await nodesRepository.getNode(node.cid)
+
+    expect(result).toBeDefined()
+    expect(result?.cid).toBe(node.cid)
+    expect(result?.root_cid).toBe(node.root_cid)
+    expect(result?.head_cid).toBe(node.head_cid)
+    expect(result?.type).toBe(node.type)
+    expect(result?.encoded_node).toBe(node.encoded_node)
+  })
+
+  it('should save multiple nodes at once', async () => {
+    const nodes: Node[] = [
+      {
+        cid: 'test-cid-1',
+        root_cid: 'test-root-cid',
+        head_cid: 'test-head-cid-1',
+        type: 'file',
+        encoded_node: 'test-encoded-node-1',
+        piece_index: null,
+        piece_offset: null,
+        block_published_on: null,
+        tx_published_on: null,
+      },
+      {
+        cid: 'test-cid-2',
+        root_cid: 'test-root-cid',
+        head_cid: 'test-head-cid-2',
+        type: 'file',
+        encoded_node: 'test-encoded-node-2',
+        piece_index: null,
+        piece_offset: null,
+        block_published_on: null,
+        tx_published_on: null,
+      },
+    ]
+
+    await nodesRepository.saveNodes(nodes)
+
+    const result1 = await nodesRepository.getNode(nodes[0].cid)
+    const result2 = await nodesRepository.getNode(nodes[1].cid)
+
+    expect(result1).toBeDefined()
+    expect(result2).toBeDefined()
+    expect(result1?.cid).toBe(nodes[0].cid)
+    expect(result2?.cid).toBe(nodes[1].cid)
+  })
+
+  it('should get nodes by head CID', async () => {
+    const headCid = 'test-head-cid-for-query'
+    const nodes: Node[] = [
+      {
+        cid: 'test-cid-3',
+        root_cid: 'test-root-cid',
+        head_cid: headCid,
+        type: 'file',
+        encoded_node: 'test-encoded-node-3',
+        piece_index: null,
+        piece_offset: null,
+        block_published_on: null,
+        tx_published_on: null,
+      },
+      {
+        cid: 'test-cid-4',
+        root_cid: 'test-root-cid',
+        head_cid: headCid,
+        type: 'file',
+        encoded_node: 'test-encoded-node-4',
+        piece_index: null,
+        piece_offset: null,
+        block_published_on: null,
+        tx_published_on: null,
+      },
+    ]
+
+    await nodesRepository.saveNodes(nodes)
+
+    const results = await nodesRepository.getNodesByHeadCid(headCid)
+
+    expect(results.length).toBe(2)
+    expect(results.map((r) => r.cid)).toContain(nodes[0].cid)
+    expect(results.map((r) => r.cid)).toContain(nodes[1].cid)
+  })
+
+  it('should get nodes by root CID', async () => {
+    const rootCid = 'test-root-cid-for-query'
+    const nodes: Node[] = [
+      {
+        cid: 'test-cid-5',
+        root_cid: rootCid,
+        head_cid: 'test-head-cid-5',
+        type: 'file',
+        encoded_node: 'test-encoded-node-5',
+        piece_index: null,
+        piece_offset: null,
+        block_published_on: null,
+        tx_published_on: null,
+      },
+      {
+        cid: 'test-cid-6',
+        root_cid: rootCid,
+        head_cid: 'test-head-cid-6',
+        type: 'file',
+        encoded_node: 'test-encoded-node-6',
+        piece_index: null,
+        piece_offset: null,
+        block_published_on: null,
+        tx_published_on: null,
+      },
+    ]
+
+    await nodesRepository.saveNodes(nodes)
+
+    const results = await nodesRepository.getNodesByRootCid(rootCid)
+
+    expect(results.length).toBe(2)
+    expect(results.map((r) => r.cid)).toContain(nodes[0].cid)
+    expect(results.map((r) => r.cid)).toContain(nodes[1].cid)
+  })
+
+  it('should get node count', async () => {
+    const rootCid = 'test-root-cid-count'
+    const nodes: Node[] = [
+      {
+        cid: 'test-cid-count-1',
+        root_cid: rootCid,
+        head_cid: 'test-head-cid-count',
+        type: 'file',
+        encoded_node: 'test-encoded-node-count-1',
+        piece_index: null,
+        piece_offset: null,
+        block_published_on: null,
+        tx_published_on: null,
+      },
+      {
+        cid: 'test-cid-count-2',
+        root_cid: rootCid,
+        head_cid: 'test-head-cid-count',
+        type: 'directory',
+        encoded_node: 'test-encoded-node-count-2',
+        piece_index: null,
+        piece_offset: null,
+        block_published_on: null,
+        tx_published_on: null,
+      },
+    ]
+
+    await nodesRepository.saveNodes(nodes)
+
+    const count = await nodesRepository.getNodeCount({ rootCid })
+
+    expect(count.totalCount).toBe(2)
+    expect(count.publishedCount).toBe(0)
+    expect(count.archivedCount).toBe(0)
+  })
+
+  it('should get node count filtered by cid', async () => {
+    const rootCid = 'test-root-cid-filter-cid'
+    const nodes: Node[] = [
+      {
+        cid: 'test-cid-filter-1',
+        root_cid: rootCid,
+        head_cid: 'test-head-cid-filter',
+        type: 'file',
+        encoded_node: 'test-encoded-node-filter-1',
+        piece_index: null,
+        piece_offset: null,
+        block_published_on: null,
+        tx_published_on: null,
+      },
+      {
+        cid: 'test-cid-filter-2',
+        root_cid: rootCid,
+        head_cid: 'test-head-cid-filter',
+        type: 'directory',
+        encoded_node: 'test-encoded-node-filter-2',
+        piece_index: null,
+        piece_offset: null,
+        block_published_on: null,
+        tx_published_on: null,
+      },
+    ]
+
+    await nodesRepository.saveNodes(nodes)
+
+    const count = await nodesRepository.getNodeCount({
+      cid: 'test-cid-filter-1',
+    })
+
+    expect(count.totalCount).toBe(1)
+    expect(count.publishedCount).toBe(0)
+    expect(count.archivedCount).toBe(0)
+  })
+
+  it('should get node count filtered by head_cid', async () => {
+    const rootCid = 'test-root-cid-filter-head'
+    const nodes: Node[] = [
+      {
+        cid: 'test-cid-head-filter-1',
+        root_cid: rootCid,
+        head_cid: 'test-head-cid-filter-1',
+        type: 'file',
+        encoded_node: 'test-encoded-node-head-1',
+        piece_index: null,
+        piece_offset: null,
+        block_published_on: null,
+        tx_published_on: null,
+      },
+      {
+        cid: 'test-cid-head-filter-2',
+        root_cid: rootCid,
+        head_cid: 'test-head-cid-filter-2',
+        type: 'directory',
+        encoded_node: 'test-encoded-node-head-2',
+        piece_index: null,
+        piece_offset: null,
+        block_published_on: null,
+        tx_published_on: null,
+      },
+    ]
+
+    await nodesRepository.saveNodes(nodes)
+
+    const count = await nodesRepository.getNodeCount({
+      headCid: 'test-head-cid-filter-1',
+    })
+
+    expect(count.totalCount).toBe(1)
+    expect(count.publishedCount).toBe(0)
+    expect(count.archivedCount).toBe(0)
+  })
+
+  it('should get node count filtered by type', async () => {
+    const rootCid = 'test-root-cid-filter-type'
+    const nodes: Node[] = [
+      {
+        cid: 'test-cid-type-filter-1',
+        root_cid: rootCid,
+        head_cid: 'test-head-cid-type',
+        type: MetadataType.File,
+        encoded_node: 'test-encoded-node-type-1',
+        piece_index: null,
+        piece_offset: null,
+        block_published_on: null,
+        tx_published_on: null,
+      },
+      {
+        cid: 'test-cid-type-filter-2',
+        root_cid: rootCid,
+        head_cid: 'test-head-cid-type',
+        type: MetadataType.Folder,
+        encoded_node: 'test-encoded-node-type-2',
+        piece_index: null,
+        piece_offset: null,
+        block_published_on: null,
+        tx_published_on: null,
+      },
+      {
+        cid: 'test-cid-type-filter-3',
+        root_cid: rootCid,
+        head_cid: 'test-head-cid-type',
+        type: MetadataType.File,
+        encoded_node: 'test-encoded-node-type-3',
+        piece_index: null,
+        piece_offset: null,
+        block_published_on: null,
+        tx_published_on: null,
+      },
+    ]
+
+    await nodesRepository.saveNodes(nodes)
+
+    const count = await nodesRepository.getNodeCount({
+      type: MetadataType.File,
+    })
+
+    expect(count.totalCount).toBe(2)
+    expect(count.publishedCount).toBe(0)
+    expect(count.archivedCount).toBe(0)
+  })
+
+  it('should get archiving nodes CID', async () => {
+    const node: Node = {
+      cid: 'test-cid-archiving',
+      root_cid: 'test-root-cid-archiving',
+      head_cid: 'test-head-cid-archiving',
+      type: 'file',
+      encoded_node: 'test-encoded-node-archiving',
+      piece_index: null,
+      piece_offset: null,
+      block_published_on: null,
+      tx_published_on: null,
+    }
+
+    await nodesRepository.saveNode(node)
+
+    const archivingCids = await nodesRepository.getArchivingNodesCID()
+
+    expect(archivingCids).toContain(node.cid)
+  })
+
+  it('should set node archiving data', async () => {
+    const node: Node = {
+      cid: 'test-cid-set-archiving',
+      root_cid: 'test-root-cid-set-archiving',
+      head_cid: 'test-head-cid-set-archiving',
+      type: 'file',
+      encoded_node: 'test-encoded-node-set-archiving',
+      piece_index: null,
+      piece_offset: null,
+      block_published_on: null,
+      tx_published_on: null,
+    }
+
+    await nodesRepository.saveNode(node)
+    await nodesRepository.setNodeArchivingData({
+      cid: node.cid,
+      pieceIndex: 1,
+      pieceOffset: 100,
+    })
+
+    const result = await nodesRepository.getNode(node.cid)
+
+    expect(result?.piece_index).toBe(1)
+    expect(result?.piece_offset).toBe(100)
+  })
+
+  it('should remove nodes by root CID', async () => {
+    const rootCid = 'test-root-cid-remove'
+    const nodes: Node[] = [
+      {
+        cid: 'test-cid-remove-1',
+        root_cid: rootCid,
+        head_cid: 'test-head-cid-remove',
+        type: 'file',
+        encoded_node: 'test-encoded-node-remove-1',
+        piece_index: null,
+        piece_offset: null,
+        block_published_on: null,
+        tx_published_on: null,
+      },
+      {
+        cid: 'test-cid-remove-2',
+        root_cid: rootCid,
+        head_cid: 'test-head-cid-remove',
+        type: 'file',
+        encoded_node: 'test-encoded-node-remove-2',
+        piece_index: null,
+        piece_offset: null,
+        block_published_on: null,
+        tx_published_on: null,
+      },
+    ]
+
+    await nodesRepository.saveNodes(nodes)
+    await nodesRepository.removeNodesByRootCid(rootCid)
+
+    const results = await nodesRepository.getNodesByRootCid(rootCid)
+
+    expect(results.length).toBe(0)
+  })
+
+  it('should get nodes by CIDs', async () => {
+    const nodes: Node[] = [
+      {
+        cid: 'test-cid-get-by-cids-1',
+        root_cid: 'test-root-cid-get-by-cids',
+        head_cid: 'test-head-cid-get-by-cids',
+        type: 'file',
+        encoded_node: 'test-encoded-node-get-by-cids-1',
+        piece_index: null,
+        piece_offset: null,
+        block_published_on: null,
+        tx_published_on: null,
+      },
+      {
+        cid: 'test-cid-get-by-cids-2',
+        root_cid: 'test-root-cid-get-by-cids',
+        head_cid: 'test-head-cid-get-by-cids',
+        type: 'file',
+        encoded_node: 'test-encoded-node-get-by-cids-2',
+        piece_index: null,
+        piece_offset: null,
+        block_published_on: null,
+        tx_published_on: null,
+      },
+    ]
+
+    await nodesRepository.saveNodes(nodes)
+
+    const results = await nodesRepository.getNodesByCids([
+      nodes[0].cid,
+      nodes[1].cid,
+    ])
+
+    expect(results.length).toBe(2)
+    expect(results.map((r) => r.cid)).toContain(nodes[0].cid)
+    expect(results.map((r) => r.cid)).toContain(nodes[1].cid)
+  })
+
+  it('should update node published on', async () => {
+    const node: Node = {
+      cid: 'test-cid-published',
+      root_cid: 'test-root-cid-published',
+      head_cid: 'test-head-cid-published',
+      type: 'file',
+      encoded_node: 'test-encoded-node-published',
+      piece_index: null,
+      piece_offset: null,
+      block_published_on: null,
+      tx_published_on: null,
+    }
+
+    await nodesRepository.saveNode(node)
+    await nodesRepository.updateNodePublishedOn(node.cid, 12345, 'tx-hash')
+
+    const result = await nodesRepository.getNode(node.cid)
+
+    expect(result?.block_published_on).toBe(12345)
+    expect(result?.tx_published_on).toBe('tx-hash')
+  })
+
+  it('should get uploaded nodes by root CID', async () => {
+    const rootCid = 'test-root-cid-uploaded'
+    const nodes: Node[] = [
+      {
+        cid: 'test-cid-uploaded-1',
+        root_cid: rootCid,
+        head_cid: 'test-head-cid-uploaded',
+        type: 'file',
+        encoded_node: 'test-encoded-node-uploaded-1',
+        piece_index: null,
+        piece_offset: null,
+        block_published_on: 12345,
+        tx_published_on: 'tx-hash-1',
+      },
+      {
+        cid: 'test-cid-uploaded-2',
+        root_cid: rootCid,
+        head_cid: 'test-head-cid-uploaded',
+        type: 'file',
+        encoded_node: 'test-encoded-node-uploaded-2',
+        piece_index: null,
+        piece_offset: null,
+        block_published_on: null,
+        tx_published_on: null,
+      },
+    ]
+
+    await nodesRepository.saveNodes(nodes)
+
+    const results = await nodesRepository.getUploadedNodesByRootCid(rootCid)
+
+    expect(results.length).toBe(1)
+    expect(results[0].cid).toBe(nodes[0].cid)
+  })
+
+  it('should get last archived piece node', async () => {
+    const nodes: Node[] = [
+      {
+        cid: 'test-cid-last-archived-1',
+        root_cid: 'test-root-cid-last-archived',
+        head_cid: 'test-head-cid-last-archived',
+        type: 'file',
+        encoded_node: 'test-encoded-node-last-archived-1',
+        piece_index: 1,
+        piece_offset: 100,
+        block_published_on: null,
+        tx_published_on: null,
+      },
+      {
+        cid: 'test-cid-last-archived-2',
+        root_cid: 'test-root-cid-last-archived',
+        head_cid: 'test-head-cid-last-archived',
+        type: 'file',
+        encoded_node: 'test-encoded-node-last-archived-2',
+        piece_index: 2,
+        piece_offset: 200,
+        block_published_on: null,
+        tx_published_on: null,
+      },
+    ]
+
+    await nodesRepository.saveNodes(nodes)
+
+    const result = await nodesRepository.getLastArchivedPieceNode()
+
+    expect(result).toBeDefined()
+    expect(result?.piece_index).toBe(2)
+    expect(result?.piece_offset).toBe(200)
+  })
+})

--- a/backend/__tests__/unit/useCases/files.spec.ts
+++ b/backend/__tests__/unit/useCases/files.spec.ts
@@ -1,0 +1,119 @@
+import { jest } from '@jest/globals'
+import { ObjectUseCases } from '../../../src/useCases/objects/object.js'
+import { FilesUseCases } from '../../../src/useCases/objects/files.js'
+import { ObjectStatus } from '@auto-drive/models'
+import { OffchainMetadata } from '@autonomys/auto-dag-data'
+import { config } from '../../../src/config.js'
+
+jest.unstable_mockModule('../../../src/useCases/objects/object.js', () => ({
+  ObjectUseCases: {
+    getObjectInformation: jest.fn(),
+  },
+}))
+
+describe('FilesUseCases', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  beforeAll(() => {})
+
+  it('should handle file upload', async () => {
+    const metadata: OffchainMetadata = {
+      totalSize: 100n,
+      type: 'file',
+      dataCid: 'test-cid',
+      totalChunks: 1,
+      chunks: [],
+    }
+
+    jest.spyOn(ObjectUseCases, 'getObjectInformation').mockResolvedValue({
+      metadata: metadata,
+      tags: [],
+      cid: '',
+      createdAt: '',
+      status: ObjectStatus.Processing,
+      uploadState: {
+        uploadedNodes: 0,
+        totalNodes: 0,
+        archivedNodes: 0,
+        minimumBlockDepth: 0,
+        maximumBlockDepth: 0,
+      },
+      owners: [],
+      publishedObjectId: null,
+    })
+
+    const result = await FilesUseCases.downloadObjectByAnonymous(
+      metadata.dataCid,
+    )
+
+    // Expect not to throw
+    expect(result.metadata).toEqual(metadata)
+  })
+
+  it('should block file upload', async () => {
+    const mockFile = {
+      cid: 'test-cid',
+      type: 'file',
+    }
+
+    jest.spyOn(ObjectUseCases, 'getObjectInformation').mockResolvedValue({
+      metadata: {
+        totalSize: 100n,
+        type: 'file',
+        dataCid: 'test-cid',
+        totalChunks: 1,
+        chunks: [],
+      },
+      tags: ['insecure'],
+      cid: '',
+      createdAt: '',
+      status: ObjectStatus.Processing,
+      uploadState: {
+        uploadedNodes: 0,
+        totalNodes: 0,
+        archivedNodes: 0,
+        minimumBlockDepth: 0,
+        maximumBlockDepth: 0,
+      },
+      owners: [],
+      publishedObjectId: null,
+    })
+
+    expect(
+      FilesUseCases.downloadObjectByAnonymous(mockFile.cid, ['insecure']),
+    ).rejects.toThrow(new Error('File is blocked'))
+  })
+
+  it('should throw if file is too large', async () => {
+    const metadata: OffchainMetadata = {
+      totalSize: BigInt(config.params.maxAnonymousDownloadSize) + 1n,
+      type: 'file',
+      dataCid: 'test-cid',
+      totalChunks: 1,
+      chunks: [],
+    }
+
+    jest.spyOn(ObjectUseCases, 'getObjectInformation').mockResolvedValue({
+      metadata: metadata,
+      tags: [],
+      cid: '',
+      createdAt: '',
+      status: ObjectStatus.Processing,
+      uploadState: {
+        uploadedNodes: 0,
+        totalNodes: 0,
+        archivedNodes: 0,
+        minimumBlockDepth: 0,
+        maximumBlockDepth: 0,
+      },
+      owners: [],
+      publishedObjectId: null,
+    })
+
+    expect(
+      FilesUseCases.downloadObjectByAnonymous(metadata.dataCid),
+    ).rejects.toThrow(new Error('File too large to be downloaded anonymously.'))
+  })
+})

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,6 +11,8 @@
     "start:prod": "node dist/server.prod.js",
     "start:docs": "node --loader ts-node/esm src/http/controllers/docs.ts",
     "test": "node --experimental-vm-modules ../node_modules/jest/bin/jest.js --runInBand --coverage --forceExit",
+    "start:worker": "node dist/worker.js",
+    "start:api": "node dist/api.js",
     "lint": "eslint . "
   },
   "dependencies": {

--- a/backend/src/http/middlewares/requestTrace.ts
+++ b/backend/src/http/middlewares/requestTrace.ts
@@ -5,6 +5,8 @@ import { config } from '../../config.js'
 export const requestTrace: RequestHandler = (req, res) => {
   const path = req.route?.path
 
+  const rawPath = req.path
+
   const method = req.method
   const provider =
     typeof req.headers['x-auth-provider'] === 'string'
@@ -30,6 +32,7 @@ export const requestTrace: RequestHandler = (req, res) => {
       method,
       path,
       provider,
+      rawPath,
     },
   }
 

--- a/backend/src/repositories/objects/metadata.ts
+++ b/backend/src/repositories/objects/metadata.ts
@@ -226,8 +226,8 @@ const getSharedRootObjectsByUser = async (
 const getMarkedAsDeletedRootObjectsByUser = async (
   provider: string,
   userId: string,
-  limit: number = 100,
-  offset: number = 0,
+  limit: number,
+  offset: number,
 ): Promise<PaginatedResult<MetadataEntry['head_cid']>> => {
   const db = await getDatabase()
 

--- a/backend/src/repositories/objects/nodes.ts
+++ b/backend/src/repositories/objects/nodes.ts
@@ -37,13 +37,17 @@ const saveNodes = async (nodes: Node[]) => {
 
   return db.query({
     text: pgFormat(
-      'INSERT INTO nodes (cid, root_cid, head_cid, type, encoded_node) VALUES %L ON CONFLICT (cid) DO NOTHING',
+      'INSERT INTO nodes (cid, root_cid, head_cid, type, encoded_node, piece_index, piece_offset, block_published_on, tx_published_on) VALUES %L ON CONFLICT (cid) DO NOTHING',
       nodes.map((node) => [
         node.cid,
         node.root_cid,
         node.head_cid,
         node.type,
         node.encoded_node,
+        node.piece_index,
+        node.piece_offset,
+        node.block_published_on,
+        node.tx_published_on,
       ]),
     ),
   })

--- a/backend/src/repositories/objects/publishedObjects.ts
+++ b/backend/src/repositories/objects/publishedObjects.ts
@@ -72,15 +72,15 @@ const updatePublishedObject = async (
   return result.rows.map(mapToPublishedObject)[0]
 }
 
-const deletePublishedObject = async (id: string): Promise<void> => {
+const deletePublishedObjectByCid = async (cid: string): Promise<void> => {
   const db = await getDatabase()
-  await db.query('DELETE FROM public.published_objects WHERE id = $1', [id])
+  await db.query('DELETE FROM public.published_objects WHERE cid = $1', [cid])
 }
 
 export const publishedObjectsRepository = {
   createPublishedObject,
   getPublishedObjectById,
   updatePublishedObject,
-  deletePublishedObject,
+  deletePublishedObjectByCid,
   getPublishedObjectByCid,
 }

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,9 +1,8 @@
-const loadServer = async () => {
+const createApi = async () => {
   if (process.env.NODE_ENV === 'production') {
     await import('./awsSetup.js').then(({ setupFinished }) => setupFinished)
   }
-  await import('./worker.js')
   await import('./api.js')
 }
 
-loadServer()
+createApi()

--- a/backend/src/useCases/objects/nodes.ts
+++ b/backend/src/useCases/objects/nodes.ts
@@ -97,7 +97,7 @@ const saveNodes = async (
     nodes.map((node) => {
       const cid = cidToString(cidOfNode(node))
       const { type } = IPLDNodeData.decode(node.Data!)
-      saveNode(
+      return saveNode(
         rootCid,
         headCid,
         cid,

--- a/backend/src/useCases/objects/object.ts
+++ b/backend/src/useCases/objects/object.ts
@@ -367,7 +367,7 @@ const downloadPublishedObject = async (id: string, blockingTags?: string[]) => {
 
 const unpublishObject = async (user: User, cid: string) => {
   const publishedObject =
-    await publishedObjectsRepository.getPublishedObjectById(cid)
+    await publishedObjectsRepository.getPublishedObjectByCid(cid)
   if (!publishedObject) {
     return
   }
@@ -376,7 +376,7 @@ const unpublishObject = async (user: User, cid: string) => {
     throw new Error('User does not have access to this object')
   }
 
-  await publishedObjectsRepository.deletePublishedObject(cid)
+  await publishedObjectsRepository.deletePublishedObjectByCid(cid)
 }
 
 const checkObjectsArchivalStatus = async () => {

--- a/backend/src/worker.ts
+++ b/backend/src/worker.ts
@@ -1,11 +1,20 @@
-import { config } from './config.js'
-import { objectMappingArchiver } from './services/dsn/objectMappingListener/index.js'
-import { TaskManager } from './services/taskManager/index.js'
+const createWorkerService = async () => {
+  if (process.env.NODE_ENV === 'production') {
+    await import('./awsSetup.js').then(({ setupFinished }) => setupFinished)
+  }
 
-if (config.services.objectMappingArchiver.active) {
-  objectMappingArchiver.start()
+  const { config } = await import('./config.js')
+  const { TaskManager } = await import('./services/taskManager/index.js')
+  const { objectMappingArchiver } = await import(
+    './services/dsn/objectMappingListener/index.js'
+  )
+  if (config.services.objectMappingArchiver.active) {
+    objectMappingArchiver.start()
+  }
+
+  if (config.services.taskManager.active) {
+    TaskManager.start()
+  }
 }
 
-if (config.services.taskManager.active) {
-  TaskManager.start()
-}
+createWorkerService()

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -70,7 +70,7 @@ services:
       driver: loki
       options:
         loki-url: "https://logging.subspace.network/loki/api/v1/push"
-  backend:
+  backend-worker:
     image: ${BACKEND_IMAGE}
     volumes:
       - files_cache:/usr/src/app/.cache
@@ -90,6 +90,37 @@ services:
       driver: loki
       options:
         loki-url: "https://logging.subspace.network/loki/api/v1/push"
+    command:
+      - yarn
+      - workspace
+      - backend
+      - start:worker
+
+  backend-api:
+    image: ${BACKEND_IMAGE}
+    volumes:
+      - files_cache:/usr/src/app/.cache
+    ports:
+      - "3000:3000"
+    restart: unless-stopped
+    env_file:
+      - .env
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
+      interval: 15s
+      timeout: 10s
+      retries: 3
+    profiles:
+      - base
+    logging:
+      driver: loki
+      options:
+        loki-url: "https://logging.subspace.network/loki/api/v1/push"
+    command:
+      - yarn
+      - workspace
+      - backend
+      - start:api
   agent:
     container_name: newrelic-infra
     image: newrelic/infrastructure:latest


### PR DESCRIPTION
Most of the issues at the API are caused by problems in the worker (e.g tasks processing wrong due to some bug). Separating them into two processes we decouple the issues