### PR TITLE
fix: misusage of Readable stream

### DIFF
--- a/backend/src/useCases/objects/files.ts
+++ b/backend/src/useCases/objects/files.ts
@@ -149,25 +149,33 @@ const retrieveAndReassembleFile = async (
     return Readable.from(chunkData)
   }
 
-  const CHUNK_SIZE = 100
+  const SIMULTANEOUS_CHUNKS = 100
+  let currentIndex = 0
   return new Readable({
-    read: async function () {
-      for (let i = 0; i < metadata.chunks.length; i += CHUNK_SIZE) {
-        const chunks = metadata.chunks.slice(i, i + CHUNK_SIZE)
+    async read() {
+      if (currentIndex >= metadata.chunks.length) {
+        this.push(null)
+        return
+      }
+
+      const endIndex = currentIndex + SIMULTANEOUS_CHUNKS
+      const chunks = metadata.chunks.slice(currentIndex, endIndex)
+      currentIndex = endIndex
+
+      try {
         const chunkedData = await Promise.all(
           chunks.map((chunk) => NodesUseCases.getChunkData(chunk.cid)),
         )
 
         if (chunkedData.some((e) => e === undefined)) {
-          throw new Error('Chunk not found')
+          this.destroy(new Error('Chunk not found'))
+          return
         }
 
-        const canContinue = this.push(Buffer.concat(chunkedData.map((e) => e!)))
-        if (!canContinue) {
-          await new Promise((resolve) => this.once('drain', resolve))
-        }
+        this.push(Buffer.concat(chunkedData.map((e) => e!)))
+      } catch (err) {
+        this.destroy(err instanceof Error ? err : new Error(String(err)))
       }
-      this.push(null)
     },
   })
 }


### PR DESCRIPTION
Problem: 

`Stream.read()` is meant for ask for more chunks not for retrieving the whole file

Solution:

Implement a reading mechanism using a "closure" variable in the "retrieveAndReassembleFile" method.