### PR TITLE
Save events failed events in a separate queue

### DIFF
--- a/backend/src/drivers/rabbit.ts
+++ b/backend/src/drivers/rabbit.ts
@@ -1,8 +1,7 @@
 import { Channel, connect } from 'amqplib'
 import { config } from '../config.js'
 
-export type AutoDriveQueues = (typeof queues)[number]
-const queues = ['task-manager', 'download-manager'] as const
+const queues = ['task-manager', 'download-manager']
 
 let channelPromise: Promise<Channel> | null = null
 
@@ -20,13 +19,14 @@ const getChannel = async () => {
   return channelPromise
 }
 
-const publish = async (queue: (typeof queues)[number], message: object) => {
+const publish = async (queue: string, message: object) => {
   const channel = await getChannel()
+  channel.assertQueue(queue)
   channel.sendToQueue(queue, Buffer.from(JSON.stringify(message)))
 }
 
 const subscribe = async (
-  queue: AutoDriveQueues,
+  queue: string,
   callback: (message: object) => Promise<unknown>,
 ) => {
   const channel = await getChannel()

--- a/backend/src/services/eventRouter/processors/download.ts
+++ b/backend/src/services/eventRouter/processors/download.ts
@@ -17,4 +17,7 @@ export const processDownloadTask = createHandlerWithRetries(
       throw new Error(`Received task ${id} but no handler found.`)
     }
   },
+  {
+    errorPublishQueue: 'download-errors',
+  },
 )

--- a/backend/src/services/eventRouter/processors/frontend.ts
+++ b/backend/src/services/eventRouter/processors/frontend.ts
@@ -18,4 +18,7 @@ export const processFrontendTask = createHandlerWithRetries(
       throw new Error(`Received task ${id} but no handler found.`)
     }
   },
+  {
+    errorPublishQueue: 'frontend-errors',
+  },
 )


### PR DESCRIPTION
Problem:

When there's an bug in auto-drive that makes events to not be processed correctly (e.g low balance in publishing accounts) these events are lost once all retries have been consumed.

Solution:

Create a separate queue for saving failing events so when the an issue is detected and sorted the events could be redirected again to the processing queue so no events are lost. 