### PR TITLE
update: do not remove nodes but just `encoded_node` field

### DIFF
--- a/backend/__tests__/unit/repositories/nodes.spec.ts
+++ b/backend/__tests__/unit/repositories/nodes.spec.ts
@@ -26,7 +26,7 @@ describe('Nodes Repository', () => {
     // Clean up the database before each test
     const nodes = await nodesRepository.getNodesByRootCid('test-root-cid')
     for (const node of nodes) {
-      await nodesRepository.removeNodesByRootCid(node.root_cid)
+      await nodesRepository.removeNodeByRootCid(node.root_cid)
     }
   })
 
@@ -398,11 +398,14 @@ describe('Nodes Repository', () => {
     ]
 
     await nodesRepository.saveNodes(nodes)
-    await nodesRepository.removeNodesByRootCid(rootCid)
-
+    await nodesRepository.removeNodeDataByRootCid(rootCid)
     const results = await nodesRepository.getNodesByRootCid(rootCid)
-
-    expect(results.length).toBe(0)
+    const fullNodes = await Promise.all(
+      results.map((r) => nodesRepository.getNode(r.cid)),
+    )
+    fullNodes.forEach((n) => {
+      expect(n?.encoded_node).toBeNull()
+    })
   })
 
   it('should get nodes by CIDs', async () => {

--- a/backend/src/repositories/objects/nodes.ts
+++ b/backend/src/repositories/objects/nodes.ts
@@ -171,11 +171,11 @@ const setNodeArchivingData = async ({
   })
 }
 
-const removeNodesByRootCid = async (rootCid: string) => {
+const removeNodeDataByRootCid = async (rootCid: string) => {
   const db = await getDatabase()
 
   return db.query({
-    text: 'DELETE FROM nodes WHERE root_cid = $1',
+    text: 'UPDATE nodes SET encoded_node = NULL WHERE root_cid = $1',
     values: [rootCid],
   })
 }
@@ -234,7 +234,7 @@ export const nodesRepository = {
   setNodeArchivingData,
   getNodesByHeadCid,
   getNodesByRootCid,
-  removeNodesByRootCid,
+  removeNodeDataByRootCid,
   getNodesByCids,
   updateNodePublishedOn,
   getUploadedNodesByRootCid,

--- a/backend/src/repositories/objects/nodes.ts
+++ b/backend/src/repositories/objects/nodes.ts
@@ -180,6 +180,14 @@ const removeNodeDataByRootCid = async (rootCid: string) => {
   })
 }
 
+const removeNodeByRootCid = async (rootCid: string) => {
+  const db = await getDatabase()
+
+  return db.query({
+    text: 'DELETE FROM nodes WHERE root_cid = $1',
+    values: [rootCid],
+  })
+}
 const getNodesByCids = async (cids: string[]): Promise<Node[]> => {
   const db = await getDatabase()
 
@@ -239,4 +247,5 @@ export const nodesRepository = {
   updateNodePublishedOn,
   getUploadedNodesByRootCid,
   getLastArchivedPieceNode,
+  removeNodeByRootCid,
 }

--- a/backend/src/useCases/objects/object.ts
+++ b/backend/src/useCases/objects/object.ts
@@ -326,7 +326,7 @@ const populateCaches = async (cid: string) => {
 const onObjectArchived = async (cid: string) => {
   await ObjectUseCases.populateCaches(cid)
   await metadataRepository.markAsArchived(cid)
-  await nodesRepository.removeNodesByRootCid(cid)
+  await nodesRepository.removeNodeDataByRootCid(cid)
 }
 
 const publishObject = async (user: UserWithOrganization, cid: string) => {


### PR DESCRIPTION
Previously we were removing nodes DB entries instead of just the `encoded_node` data when a file was archived but this had several problems as not having the node count of a file.