### PR TITLE
fix: update backend volume paths

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -72,7 +72,7 @@ services:
     ports:
       - "${BACKEND_WORKER_PORT}:3000"
     volumes:
-      - files_cache:/usr/src/app/.cache
+      - files_cache:/usr/src/app/backend/.cache
     restart: unless-stopped
     env_file:
       - .env
@@ -93,7 +93,7 @@ services:
   backend-api:
     image: ${BACKEND_IMAGE}
     volumes:
-      - files_cache:/usr/src/app/.cache
+      - files_cache:/usr/src/app/backend/.cache
     ports:
       - "${BACKEND_API_PORT}:3000"
     restart: unless-stopped
@@ -121,7 +121,7 @@ services:
   backend-download-worker:
     image: ${BACKEND_IMAGE}
     volumes:
-      - files_cache:/usr/src/app/.cache
+      - files_cache:/usr/src/app/backend/.cache
     restart: unless-stopped
     ports:
       - "${BACKEND_DOWNLOAD_WORKER_PORT}:3000"
@@ -144,7 +144,7 @@ services:
   backend-download-api:
     image: ${BACKEND_IMAGE}
     volumes:
-      - files_cache:/usr/src/app/.cache
+      - files_cache:/usr/src/app/backend/.cache
     ports:
       - "${BACKEND_DOWNLOAD_API_PORT}:3000"
     restart: unless-stopped


### PR DESCRIPTION
**Problem:**

Cache was not populated with new files since volume path was misconfigured leading to file system cache to be wiped after the update of the docker image.

**Solution:**

Setup correctly the cache path.