### PR TITLE
feat: add indexes to db tables

### DIFF
--- a/auth/migrations/20250620112629-indexes.js
+++ b/auth/migrations/20250620112629-indexes.js
@@ -1,0 +1,49 @@
+'use strict'
+
+var dbm
+var type
+var seed
+var fs = require('fs')
+var path = require('path')
+var Promise
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  var filePath = path.join(__dirname, 'sqls', '20250620112629-indexes-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  }).then(function (data) {
+    return db.runSql(data)
+  })
+}
+
+exports.down = function (db) {
+  var filePath = path.join(__dirname, 'sqls', '20250620112629-indexes-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  }).then(function (data) {
+    return db.runSql(data)
+  })
+}
+
+exports._meta = {
+  version: 1,
+}

--- a/auth/migrations/sqls/20250620112629-indexes-down.sql
+++ b/auth/migrations/sqls/20250620112629-indexes-down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS users.idx_users_public_id;

--- a/auth/migrations/sqls/20250620112629-indexes-up.sql
+++ b/auth/migrations/sqls/20250620112629-indexes-up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_users_public_id ON users.users (public_id);

--- a/backend/migrations/20250620113124-indexes.js
+++ b/backend/migrations/20250620113124-indexes.js
@@ -1,0 +1,48 @@
+'use strict'
+
+var dbm
+var type
+var seed
+var fs = require('fs')
+var path = require('path')
+var Promise
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  var filePath = path.join(__dirname, 'sqls', '20250620113124-indexes-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      resolve(data)
+    })
+  }).then(function (data) {
+    return db.runSql(data)
+  })
+}
+
+exports.down = function (db) {
+  var filePath = path.join(__dirname, 'sqls', '20250620113124-indexes-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+
+      resolve(data)
+    })
+  }).then(function (data) {
+    return db.runSql(data)
+  })
+}
+
+exports._meta = {
+  version: 1,
+}

--- a/backend/migrations/sqls/20241002111606-init-schema-up.sql
+++ b/backend/migrations/sqls/20241002111606-init-schema-up.sql
@@ -6,19 +6,6 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
--- public.jwt_token_registry definition
-
--- Drop table
-
--- DROP TABLE public.jwt_token_registry;
-
-CREATE TABLE public.jwt_token_registry (
-	id text NOT NULL,
-	createdat timestamp NULL DEFAULT CURRENT_TIMESTAMP,
-	CONSTRAINT jwt_token_registry_pkey PRIMARY KEY (id)
-);
-
-
 -- public.metadata definition
 
 -- Drop table
@@ -101,28 +88,6 @@ update
     public.object_ownership for each row execute function trigger_set_timestamp();
 
 
--- public.organizations definition
-
--- Drop table
-
--- DROP TABLE public.organizations;
-
-CREATE TABLE public.organizations (
-	id text NOT NULL,
-	"name" text NOT NULL,
-	created_at timestamp NULL DEFAULT CURRENT_TIMESTAMP,
-	updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-	CONSTRAINT organizations_pkey PRIMARY KEY (id)
-);
-
--- Table Triggers
-
-create trigger set_timestamp before
-update
-    on
-    public.organizations for each row execute function trigger_set_timestamp();
-
-
 -- public.published_objects definition
 
 -- Drop table
@@ -188,57 +153,6 @@ update
     public.transaction_results for each row execute function trigger_set_timestamp();
 
 
--- public.users definition
-
--- Drop table
-
--- DROP TABLE public.users;
-
-CREATE TABLE public.users (
-	oauth_provider text NOT NULL,
-	oauth_user_id text NOT NULL,
-	public_id text NULL,
-	"role" text NOT NULL DEFAULT 'User'::text,
-	created_at timestamp NULL DEFAULT CURRENT_TIMESTAMP,
-	updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-	CONSTRAINT users_handle_key UNIQUE (public_id),
-	CONSTRAINT users_pkey PRIMARY KEY (oauth_provider, oauth_user_id)
-);
-
--- Table Triggers
-
-create trigger set_timestamp before
-update
-    on
-    public.users for each row execute function trigger_set_timestamp();
-
-
--- public.api_keys definition
-
--- Drop table
-
--- DROP TABLE public.api_keys;
-
-CREATE TABLE public.api_keys (
-	id text NOT NULL,
-	secret text NOT NULL,
-	oauth_provider text NOT NULL,
-	oauth_user_id text NOT NULL,
-	deleted_at timestamp NULL,
-	created_at timestamp NULL DEFAULT CURRENT_TIMESTAMP,
-	updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-	CONSTRAINT api_keys_pkey PRIMARY KEY (id),
-	CONSTRAINT fk_user_id FOREIGN KEY (oauth_provider,oauth_user_id) REFERENCES public.users(oauth_provider,oauth_user_id)
-);
-
--- Table Triggers
-
-create trigger set_timestamp before
-update
-    on
-    public.api_keys for each row execute function trigger_set_timestamp();
-
-
 -- public.interactions definition
 
 -- Drop table
@@ -262,22 +176,6 @@ update
     on
     public.interactions for each row execute function trigger_set_timestamp();
 
-
--- public.users_organizations definition
-
--- Drop table
-
--- DROP TABLE public.users_organizations;
-
-CREATE TABLE public.users_organizations (
-	oauth_provider text NOT NULL,
-	oauth_user_id text NOT NULL,
-	organization_id text NOT NULL,
-	created_at timestamp NULL DEFAULT CURRENT_TIMESTAMP,
-	updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-	CONSTRAINT fk_organization_id FOREIGN KEY (organization_id) REFERENCES public.organizations(id),
-	CONSTRAINT fk_user_id FOREIGN KEY (oauth_provider,oauth_user_id) REFERENCES public.users(oauth_provider,oauth_user_id)
-);
 
 -- DROP SCHEMA uploads;
 

--- a/backend/migrations/sqls/20250620113124-indexes-down.sql
+++ b/backend/migrations/sqls/20250620113124-indexes-down.sql
@@ -1,0 +1,10 @@
+-- interactions
+DROP INDEX IF EXISTS idx_interactions_subscription_id;
+
+-- nodes
+DROP INDEX IF EXISTS idx_nodes_root_cid;
+DROP INDEX IF EXISTS idx_nodes_head_cid;
+
+
+-- metadata
+DROP INDEX IF EXISTS idx_metadata_head_cid;

--- a/backend/migrations/sqls/20250620113124-indexes-up.sql
+++ b/backend/migrations/sqls/20250620113124-indexes-up.sql
@@ -1,0 +1,9 @@
+-- metadata
+CREATE INDEX idx_metadata_head_cid ON public.metadata (head_cid);
+
+-- nodes
+CREATE INDEX idx_nodes_head_cid ON public.nodes (head_cid);
+CREATE INDEX idx_nodes_root_cid ON public.nodes (root_cid);
+
+-- interactions
+CREATE INDEX idx_interactions_subscription_id ON public.interactions (subscription_id);


### PR DESCRIPTION
**Description:**

Add some indexes for improving the following read operations: 

- **User by Public ID:** Every operation in the backend that is performed checks the user's by public id
- **Metadata by Head CID:** Metadata has a PK (root cid, head_cid) though most times metadata is fetched by `head_cid` since there's no need to know if the object is inside a folder.
- **Nodes by Head CID & Root CID:** Some operations for example `encoded_node` field removal are performed not by `cid` but for `root_cid` (this happens with `head_cid` as well) so having an index would increase the speed of these operations. 
- **Interactions by Subscription ID:**: There's basically one main operation in this table and it's to filter by `subscription_id` and `type` so having this index would improve the speed of this operation. 


**Drawback considerations:**

All the tables except `nodes` table  doesn't have a really significant need for write processing speed and since they're much read heavier than write, these indexes makes sense. 

Big files files might get slowed down due to `nodes` table index but since the upload of big files have other bottlenecks (i.e. IPLD encoding), I think that won't be too much of a pain but might be needed to remove it if we notice that is huge bottleneck. 