### PR TITLE
update: how caches are populated

### DIFF
--- a/backend/src/useCases/objects/object.ts
+++ b/backend/src/useCases/objects/object.ts
@@ -24,7 +24,6 @@ import { v4 } from 'uuid'
 import { FilesUseCases } from './files.js'
 import { downloadService } from '../../services/download/index.js'
 import { logger } from '../../drivers/logger.js'
-import { FileGateway } from '../../services/dsn/fileGateway/index.js'
 import { EventRouter } from '../../services/eventRouter/index.js'
 import { createTask } from '../../services/eventRouter/tasks.js'
 
@@ -316,10 +315,9 @@ const getNonArchivedObjects = async () => {
 
 const populateCaches = async (cid: string) => {
   downloadService.download(cid).catch(() => {
-    logger.warn(`Failed to download object ${cid} after archival check`)
-  })
-  FileGateway.getFile(cid).catch(() => {
-    logger.warn(`Failed to download object ${cid} after archival check`)
+    logger.warn(
+      `Failed to download object (cid=${cid}) from DB after archival check`,
+    )
   })
 }
 

--- a/backend/src/useCases/objects/object.ts
+++ b/backend/src/useCases/objects/object.ts
@@ -26,6 +26,7 @@ import { downloadService } from '../../services/download/index.js'
 import { logger } from '../../drivers/logger.js'
 import { EventRouter } from '../../services/eventRouter/index.js'
 import { createTask } from '../../services/eventRouter/tasks.js'
+import { consumeStream } from '../../utils/misc.js'
 
 const getMetadata = async (cid: string) => {
   const entry = await metadataRepository.getMetadata(cid)
@@ -314,11 +315,19 @@ const getNonArchivedObjects = async () => {
 }
 
 const populateCaches = async (cid: string) => {
-  downloadService.download(cid).catch(() => {
-    logger.warn(
-      `Failed to download object (cid=${cid}) from DB after archival check`,
-    )
-  })
+  downloadService
+    .download(cid)
+    .then((stream) => {
+      logger.debug(
+        `Downloaded object (cid=${cid}) from DB after archival check`,
+      )
+      consumeStream(stream)
+    })
+    .catch(() => {
+      logger.warn(
+        `Failed to download object (cid=${cid}) from DB after archival check`,
+      )
+    })
 }
 
 const onObjectArchived = async (cid: string) => {

--- a/backend/src/utils/misc.ts
+++ b/backend/src/utils/misc.ts
@@ -1,3 +1,5 @@
+import { Readable } from 'stream'
+
 export const stringify = (value: unknown) => {
   return JSON.stringify(value, (key, value) =>
     typeof value === 'bigint' ? value.toString() : value,
@@ -29,3 +31,10 @@ export const chunkArray = <T>(array: T[], size: number): T[][] => {
 
 export const optionalBoolEnvironmentVariable = (key: string) =>
   process.env[key] === 'true'
+
+export const consumeStream = async (stream: Readable) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  for await (const _ of stream) {
+    // do nothing
+  }
+}


### PR DESCRIPTION
- **Files gateway cache is not populated when a file is archived:** With the separation of **Frontend** and **Download** services there's no need to populate the **Files Gateway** since it was meant to be cached in there for being able to be retrieved by the public and the private instance regardless from which of these processed the archival. 

- **Consume readable stream:** Readable streams implement a `read` method that is called by nodejs when the stream is consumed, if it's not consumed read operations are not performed and therefore no caching happens.

