### PR TITLE
Fix file cache population on object archived

### DIFF
--- a/backend/src/useCases/objects/object.ts
+++ b/backend/src/useCases/objects/object.ts
@@ -315,20 +315,19 @@ const getNonArchivedObjects = async () => {
 }
 
 const populateCaches = async (cid: string) => {
-  downloadService
-    .download(cid)
-    .then((stream) => {
-      logger.debug(
-        `Downloaded object (cid=${cid}) from DB after archival check`,
-      )
-      consumeStream(stream)
-    })
-    .catch((e) => {
-      logger.warn(
-        `Failed to download object (cid=${cid}) from DB after archival check: ${e}`,
-      )
-      throw e
-    })
+  try {
+    const stream = await downloadService.download(cid)
+
+    logger.debug(`Downloaded object (cid=${cid}) from DB after archival check`)
+
+    // Wait until the entire stream has been consumed (and therefore cached)
+    await consumeStream(stream)
+  } catch (e) {
+    logger.warn(
+      `Failed to download object (cid=${cid}) from DB after archival check: ${e}`,
+    )
+    throw e
+  }
 }
 
 const onObjectArchived = async (cid: string) => {


### PR DESCRIPTION
This would solve #417. 

**Problem:**

Populating the cache asynchronously leads to a race condition where the removal of nodes (performed just after the file is populated in cache) starts before the end of the cache population leading to the error shown. 

**Solution:**

Awaiting for the file to be populated for nodes data to be wiped.