### PR TITLE
Fix submodules sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ gateway: install
 
 init-submodules:
 	# Ignore errors if submodules are already initialized
+	git submodule init
 	git submodule sync
 	git submodule update --remote
 


### PR DESCRIPTION
@jfrank-summit You reported some issue on the past syncing, for already initialised workspaces the `init-submodules` would correctly keep up to date the latest pointer to submodules though would fail for not initialised workspaces.