### PR TITLE
feat: enable no image update deployments

### DIFF
--- a/ansible/auto-drive-deployment.yml
+++ b/ansible/auto-drive-deployment.yml
@@ -2,7 +2,6 @@
 - name: Pull new image, update ssecret, and reboot
   hosts: "{{ target_machines }}"
   vars:
-    image_tag: "{{ image_tag }}"
     env_file_path: ~/deploy/auto-drive/.env
   tasks:
     - name: Show current host information
@@ -29,6 +28,7 @@
     - name: Update image to backend container key BACKEND_IMAGE in folder '/{{ target_machines }}' image to {{ image_tag }}
       ansible.builtin.shell: |
         infisical secrets --projectId {{ infisical_project_id }} --path /{{ target_machines }} --env prod --token {{ login_cmd.stdout }} set BACKEND_IMAGE={{ image_tag }}
+      when: image_tag is defined and image_tag != ''
       register: hello_output
 
     - name: Update .env


### PR DESCRIPTION
Sometimes we will just want to re-deploy after making some changes in `.env` at infisical for this we wouldn't need to update any image, so this step is now skipped if no `image_tag` is defined. 