### PR TITLE
Download for some files halted w/o finishing ever

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ database.sqlite
 .cursorrules
 hosts.ini
 environment.yaml
+*.debug.ts

--- a/backend/src/core/objects/files/nodeComposer.ts
+++ b/backend/src/core/objects/files/nodeComposer.ts
@@ -44,7 +44,7 @@ export const composeNodesDataAsFileReadable = async ({
         )
 
         if (chunkedData.some((e) => e === undefined)) {
-          const notFoundChunkIndex = chunksToDownload.findIndex(
+          const notFoundChunkIndex = chunkedData.findIndex(
             (e) => e === undefined,
           )
           this.destroy(

--- a/backend/src/infrastructure/services/download/index.ts
+++ b/backend/src/infrastructure/services/download/index.ts
@@ -94,8 +94,8 @@ export const downloadService = {
 
     // Fork the stream again for caching w/o blocking the main thread
     forkStream(cacheStream).then(async ([fsCacheStream, memoryCacheStream]) => {
-      await memoryDownloadCache.set(cid, memoryCacheStream)
-      await fsCache.set(cid, { data: fsCacheStream, size })
+      memoryDownloadCache.set(cid, memoryCacheStream)
+      fsCache.set(cid, { data: fsCacheStream, size })
     })
 
     return returnStream

--- a/backend/src/shared/httpHandlers/download.ts
+++ b/backend/src/shared/httpHandlers/download.ts
@@ -69,6 +69,8 @@ const setFileResponseHeaders = (
     )
     const upperBound = byteRange[1] ?? Number(metadata.totalSize)
     res.set('Content-Length', (upperBound - byteRange[0] + 1).toString())
+  } else {
+    res.set('Content-Length', metadata.totalSize.toString())
   }
 }
 


### PR DESCRIPTION
Downloads from source were performed correctly but the duplication on streams for caching was provoking streams not being consumed therefore pausing the HTTP download.

More precisely, when a stream is forked in two branches the first needs the second (and viceversa) to be consumed too in order to be consumed. The problem was in that we were caching sequentially both `fsCache` and `memoryDownloadCache`  so the first would block the caching of the first won't happen until the second is consumed, effectively halting the download.

**Problem:**

```ts
// Awaiting in first set call was making 'fsCacheStream' to not be consumed blocking the download
forkStream(cacheStream).then(async ([fsCacheStream, memoryCacheStream]) => {
      await memoryDownloadCache.set(cid, memoryCacheStream) // awaiting
      await fsCache.set(cid, { data: fsCacheStream, size })
})
```

**Solution:**

```ts
// Fork the stream again for caching w/o blocking the main thread
forkStream(cacheStream).then(async ([fsCacheStream, memoryCacheStream]) => {
   memoryDownloadCache.set(cid, memoryCacheStream)
   fsCache.set(cid, { data: fsCacheStream, size })
})
```