### PR TITLE
Improve query performance

### DIFF
--- a/backend/migrations/sqls/20250620113124-indexes-down.sql
+++ b/backend/migrations/sqls/20250620113124-indexes-down.sql
@@ -4,7 +4,21 @@ DROP INDEX IF EXISTS idx_interactions_subscription_id;
 -- nodes
 DROP INDEX IF EXISTS idx_nodes_root_cid;
 DROP INDEX IF EXISTS idx_nodes_head_cid;
+DROP INDEX IF EXISTS idx_nodes_head_block_inc_tx;
+DROP INDEX IF EXISTS idx_nodes_published_by_head;
+DROP INDEX IF EXISTS idx_nodes_archived_by_head;
 
 
 -- metadata
 DROP INDEX IF EXISTS idx_metadata_head_cid;
+
+-- object_ownership
+DROP INDEX IF EXISTS idx_object_ownership_admin_partial;
+DROP INDEX IF EXISTS idx_object_admin_cid;
+
+-- metadata
+DROP INDEX IF EXISTS idx_metadata_roots_partial;
+DROP INDEX IF EXISTS idx_metadata_created_at;
+DROP INDEX IF EXISTS idx_root_metadata_created_at;
+DROP INDEX IF EXISTS idx_metadata_root_cid;
+DROP INDEX IF EXISTS idx_metadata_created_desc;

--- a/backend/migrations/sqls/20250620113124-indexes-up.sql
+++ b/backend/migrations/sqls/20250620113124-indexes-up.sql
@@ -21,8 +21,6 @@ WHERE (is_admin IS TRUE);
 CREATE INDEX IF NOT EXISTS idx_object_admin_cid
 ON public.object_ownership USING btree (cid, is_admin);
 
--- Note: Skipped idx_object_cid because idx_object_admin_cid (leading cid) already covers cid-only lookups.
-
 -- =========================
 -- NODES
 -- =========================

--- a/backend/migrations/sqls/20250620113124-indexes-up.sql
+++ b/backend/migrations/sqls/20250620113124-indexes-up.sql
@@ -7,3 +7,65 @@ CREATE INDEX idx_nodes_root_cid ON public.nodes (root_cid);
 
 -- interactions
 CREATE INDEX idx_interactions_subscription_id ON public.interactions (subscription_id);
+
+-- =========================
+-- OBJECT_OWNERSHIP
+-- =========================
+
+-- Partial index for fast admin-exists checks (used in your EXISTS filters)
+CREATE INDEX IF NOT EXISTS idx_object_ownership_admin_partial
+ON public.object_ownership USING btree (cid)
+WHERE (is_admin IS TRUE);
+
+-- Covers lookups by cid and admin flag; also serves pure cid lookups due to leading column
+CREATE INDEX IF NOT EXISTS idx_object_admin_cid
+ON public.object_ownership USING btree (cid, is_admin);
+
+-- Note: Skipped idx_object_cid because idx_object_admin_cid (leading cid) already covers cid-only lookups.
+
+-- =========================
+-- NODES
+-- =========================
+
+-- Counts by head, published/archived filters, and "top row by block_published_on"
+-- This INCLUDE allows fetching tx_published_on without heap lookups.
+CREATE INDEX IF NOT EXISTS idx_nodes_head_block_inc_tx
+ON public.nodes USING btree (head_cid, block_published_on)
+INCLUDE (tx_published_on);
+
+-- Fast counts where published (block_published_on IS NOT NULL)
+CREATE INDEX IF NOT EXISTS idx_nodes_published_by_head
+ON public.nodes USING btree (head_cid)
+WHERE (block_published_on IS NOT NULL);
+
+-- Fast counts where archived (piece_offset IS NOT NULL)
+CREATE INDEX IF NOT EXISTS idx_nodes_archived_by_head
+ON public.nodes USING btree (head_cid)
+WHERE (piece_offset IS NOT NULL);
+
+-- =========================
+-- METADATA
+-- =========================
+
+-- “Roots only” fast path (head_cid = root_cid)
+CREATE INDEX IF NOT EXISTS idx_metadata_roots_partial
+ON public.metadata USING btree (head_cid)
+WHERE (head_cid = root_cid);
+
+-- Plain created_at for generic time filters
+CREATE INDEX IF NOT EXISTS idx_metadata_created_at
+ON public.metadata USING btree (created_at);
+
+-- Created_at restricted to roots (root_cid = head_cid) for Top-N roots
+CREATE INDEX IF NOT EXISTS idx_root_metadata_created_at
+ON public.metadata USING btree (created_at)
+WHERE (root_cid = head_cid);
+
+-- Direct access by root_cid (helps joining metadata_roots -> metadata)
+CREATE INDEX IF NOT EXISTS idx_metadata_root_cid
+ON public.metadata USING btree (root_cid);
+
+-- Ordered index for DESC queries (e.g., Top-N by created_at) with join keys handy
+CREATE INDEX IF NOT EXISTS idx_metadata_created_desc
+ON public.metadata USING btree (created_at DESC, root_cid, head_cid)
+INCLUDE (head_cid);

--- a/frontend/codegen.ts
+++ b/frontend/codegen.ts
@@ -6,7 +6,7 @@ dotenv.config();
 const config: CodegenConfig = {
   generates: {
     './gql/graphql.ts': {
-      schema: 'https://demo.auto-drive.autonomys.xyz/hasura/v1/graphql',
+      schema: process.env.HASURA_URL ?? 'http://localhost:6565/v1/graphql',
       documents: ['./src/**/query.graphql'],
       plugins: [
         'typescript',

--- a/frontend/codegen.ts
+++ b/frontend/codegen.ts
@@ -6,7 +6,7 @@ dotenv.config();
 const config: CodegenConfig = {
   generates: {
     './gql/graphql.ts': {
-      schema: 'http://localhost:6565/v1/graphql',
+      schema: 'https://demo.auto-drive.autonomys.xyz/hasura/v1/graphql',
       documents: ['./src/**/query.graphql'],
       plugins: [
         'typescript',

--- a/frontend/gql/graphql.ts
+++ b/frontend/gql/graphql.ts
@@ -2367,12 +2367,7 @@ export type SearchUserMetadataByCidOrNameQuery = { __typename?: 'query_root', me
 
 export const GetGlobalFilesDocument = gql`
     query GetGlobalFiles($aggregateLimit: Int!, $limit: Int!, $offset: Int!, $orderBy: [metadata_roots_order_by!], $search: String) {
-  metadata_roots(
-    where: {inner_metadata: {object_ownership: {is_admin: {_eq: true}}}}
-    limit: $limit
-    offset: $offset
-    order_by: $orderBy
-  ) {
+  metadata_roots(limit: $limit, offset: $offset, order_by: $orderBy) {
     cid: head_cid
     tags
     type: metadata(path: "type")
@@ -2420,7 +2415,7 @@ export const GetGlobalFilesDocument = gql`
   }
   metadata_roots_aggregate(
     limit: $aggregateLimit
-    where: {inner_metadata: {object_ownership: {is_admin: {_eq: true}}}}
+    where: {inner_metadata: {object_ownership: {is_admin: {_eq: true}}}, _or: [{head_cid: {_ilike: $search}}, {name: {_ilike: $search}}]}
   ) {
     aggregate {
       count

--- a/frontend/gql/graphql.ts
+++ b/frontend/gql/graphql.ts
@@ -2279,10 +2279,11 @@ export type Timestamp_Comparison_Exp = {
 };
 
 export type GetGlobalFilesQueryVariables = Exact<{
+  aggregateLimit: Scalars['Int']['input'];
   limit: Scalars['Int']['input'];
   offset: Scalars['Int']['input'];
   orderBy?: InputMaybe<Array<Metadata_Roots_Order_By> | Metadata_Roots_Order_By>;
-  search: Scalars['String']['input'];
+  search?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
@@ -2294,6 +2295,7 @@ export type GetSharedFilesQueryVariables = Exact<{
   limit: Scalars['Int']['input'];
   offset: Scalars['Int']['input'];
   orderBy?: InputMaybe<Array<Metadata_Roots_Order_By> | Metadata_Roots_Order_By>;
+  aggregateLimit: Scalars['Int']['input'];
 }>;
 
 
@@ -2305,6 +2307,7 @@ export type GetTrashedFilesQueryVariables = Exact<{
   limit: Scalars['Int']['input'];
   offset: Scalars['Int']['input'];
   orderBy?: InputMaybe<Array<Metadata_Roots_Order_By> | Metadata_Roots_Order_By>;
+  aggregateLimit: Scalars['Int']['input'];
 }>;
 
 
@@ -2317,6 +2320,7 @@ export type GetMyFilesQueryVariables = Exact<{
   offset: Scalars['Int']['input'];
   orderBy?: InputMaybe<Array<Metadata_Roots_Order_By> | Metadata_Roots_Order_By>;
   search: Scalars['String']['input'];
+  aggregateLimit: Scalars['Int']['input'];
 }>;
 
 
@@ -2362,9 +2366,9 @@ export type SearchUserMetadataByCidOrNameQuery = { __typename?: 'query_root', me
 
 
 export const GetGlobalFilesDocument = gql`
-    query GetGlobalFiles($limit: Int!, $offset: Int!, $orderBy: [metadata_roots_order_by!], $search: String!) {
+    query GetGlobalFiles($aggregateLimit: Int!, $limit: Int!, $offset: Int!, $orderBy: [metadata_roots_order_by!], $search: String) {
   metadata_roots(
-    where: {inner_metadata: {object_ownership: {is_admin: {_eq: true}}}, _or: [{head_cid: {_ilike: $search}}, {name: {_ilike: $search}}]}
+    where: {inner_metadata: {object_ownership: {is_admin: {_eq: true}}}}
     limit: $limit
     offset: $offset
     order_by: $orderBy
@@ -2415,7 +2419,8 @@ export const GetGlobalFilesDocument = gql`
     }
   }
   metadata_roots_aggregate(
-    where: {inner_metadata: {object_ownership: {is_admin: {_eq: true}}}, _or: [{head_cid: {_ilike: $search}}, {name: {_ilike: $search}}]}
+    limit: $aggregateLimit
+    where: {inner_metadata: {object_ownership: {is_admin: {_eq: true}}}}
   ) {
     aggregate {
       count
@@ -2436,6 +2441,7 @@ export const GetGlobalFilesDocument = gql`
  * @example
  * const { data, loading, error } = useGetGlobalFilesQuery({
  *   variables: {
+ *      aggregateLimit: // value for 'aggregateLimit'
  *      limit: // value for 'limit'
  *      offset: // value for 'offset'
  *      orderBy: // value for 'orderBy'
@@ -2460,7 +2466,7 @@ export type GetGlobalFilesLazyQueryHookResult = ReturnType<typeof useGetGlobalFi
 export type GetGlobalFilesSuspenseQueryHookResult = ReturnType<typeof useGetGlobalFilesSuspenseQuery>;
 export type GetGlobalFilesQueryResult = Apollo.QueryResult<GetGlobalFilesQuery, GetGlobalFilesQueryVariables>;
 export const GetSharedFilesDocument = gql`
-    query GetSharedFiles($oauthUserId: String!, $oauthProvider: String!, $limit: Int!, $offset: Int!, $orderBy: [metadata_roots_order_by!]) {
+    query GetSharedFiles($oauthUserId: String!, $oauthProvider: String!, $limit: Int!, $offset: Int!, $orderBy: [metadata_roots_order_by!], $aggregateLimit: Int!) {
   metadata_roots(
     where: {inner_metadata: {object_ownership: {_and: {oauth_user_id: {_eq: $oauthUserId}, oauth_provider: {_eq: $oauthProvider}, marked_as_deleted: {_is_null: true}, is_admin: {_eq: false}}}}}
     limit: $limit
@@ -2513,6 +2519,7 @@ export const GetSharedFilesDocument = gql`
     }
   }
   metadata_roots_aggregate(
+    limit: $aggregateLimit
     where: {inner_metadata: {object_ownership: {_and: {oauth_user_id: {_eq: $oauthUserId}, oauth_provider: {_eq: $oauthProvider}, marked_as_deleted: {_is_null: true}, is_admin: {_eq: false}}}}}
   ) {
     aggregate {
@@ -2539,6 +2546,7 @@ export const GetSharedFilesDocument = gql`
  *      limit: // value for 'limit'
  *      offset: // value for 'offset'
  *      orderBy: // value for 'orderBy'
+ *      aggregateLimit: // value for 'aggregateLimit'
  *   },
  * });
  */
@@ -2559,7 +2567,7 @@ export type GetSharedFilesLazyQueryHookResult = ReturnType<typeof useGetSharedFi
 export type GetSharedFilesSuspenseQueryHookResult = ReturnType<typeof useGetSharedFilesSuspenseQuery>;
 export type GetSharedFilesQueryResult = Apollo.QueryResult<GetSharedFilesQuery, GetSharedFilesQueryVariables>;
 export const GetTrashedFilesDocument = gql`
-    query GetTrashedFiles($oauthUserId: String!, $oauthProvider: String!, $limit: Int!, $offset: Int!, $orderBy: [metadata_roots_order_by!]) {
+    query GetTrashedFiles($oauthUserId: String!, $oauthProvider: String!, $limit: Int!, $offset: Int!, $orderBy: [metadata_roots_order_by!], $aggregateLimit: Int!) {
   metadata_roots(
     where: {inner_metadata: {object_ownership: {_and: {oauth_user_id: {_eq: $oauthUserId}, oauth_provider: {_eq: $oauthProvider}, marked_as_deleted: {_is_null: false}}}}}
     limit: $limit
@@ -2615,7 +2623,7 @@ export const GetTrashedFilesDocument = gql`
     }
   }
   metadata_roots_aggregate(
-    distinct_on: root_cid
+    limit: $aggregateLimit
     where: {inner_metadata: {object_ownership: {_and: {oauth_user_id: {_eq: $oauthUserId}, oauth_provider: {_eq: $oauthProvider}, marked_as_deleted: {_is_null: false}}}}}
   ) {
     aggregate {
@@ -2642,6 +2650,7 @@ export const GetTrashedFilesDocument = gql`
  *      limit: // value for 'limit'
  *      offset: // value for 'offset'
  *      orderBy: // value for 'orderBy'
+ *      aggregateLimit: // value for 'aggregateLimit'
  *   },
  * });
  */
@@ -2662,7 +2671,7 @@ export type GetTrashedFilesLazyQueryHookResult = ReturnType<typeof useGetTrashed
 export type GetTrashedFilesSuspenseQueryHookResult = ReturnType<typeof useGetTrashedFilesSuspenseQuery>;
 export type GetTrashedFilesQueryResult = Apollo.QueryResult<GetTrashedFilesQuery, GetTrashedFilesQueryVariables>;
 export const GetMyFilesDocument = gql`
-    query GetMyFiles($oauthUserId: String!, $oauthProvider: String!, $limit: Int!, $offset: Int!, $orderBy: [metadata_roots_order_by!], $search: String!) {
+    query GetMyFiles($oauthUserId: String!, $oauthProvider: String!, $limit: Int!, $offset: Int!, $orderBy: [metadata_roots_order_by!], $search: String!, $aggregateLimit: Int!) {
   metadata_roots(
     where: {inner_metadata: {object_ownership: {_and: {oauth_user_id: {_eq: $oauthUserId}, oauth_provider: {_eq: $oauthProvider}, is_admin: {_eq: true}, marked_as_deleted: {_is_null: true}}}}, _or: [{head_cid: {_ilike: $search}}, {name: {_ilike: $search}}]}
     limit: $limit
@@ -2718,6 +2727,7 @@ export const GetMyFilesDocument = gql`
     }
   }
   metadata_roots_aggregate(
+    limit: $aggregateLimit
     where: {inner_metadata: {object_ownership: {_and: {oauth_user_id: {_eq: $oauthUserId}, oauth_provider: {_eq: $oauthProvider}, is_admin: {_eq: true}, marked_as_deleted: {_is_null: true}}}, _or: [{head_cid: {_ilike: $search}}, {name: {_ilike: $search}}]}}
   ) {
     aggregate {
@@ -2745,6 +2755,7 @@ export const GetMyFilesDocument = gql`
  *      offset: // value for 'offset'
  *      orderBy: // value for 'orderBy'
  *      search: // value for 'search'
+ *      aggregateLimit: // value for 'aggregateLimit'
  *   },
  * });
  */

--- a/frontend/src/components/FileTables/GlobalFiles/index.tsx
+++ b/frontend/src/components/FileTables/GlobalFiles/index.tsx
@@ -21,6 +21,7 @@ export const GlobalFiles = () => {
   const setFetcher = useFileTableState((e) => e.setFetcher);
   const sortBy = useFileTableState((e) => e.sortBy);
   const page = useFileTableState((e) => e.page);
+  const aggregateLimit = useFileTableState((e) => e.aggregateLimit);
   const limit = useFileTableState((e) => e.limit);
   const setTotal = useFileTableState((e) => e.setTotal);
   const searchQuery = useFileTableState((e) => e.searchQuery);
@@ -35,6 +36,7 @@ export const GlobalFiles = () => {
           offset: page * limit,
           orderBy: sortBy,
           search: `%${searchQuery}%`,
+          aggregateLimit,
         },
         fetchPolicy: 'no-cache',
       });
@@ -43,7 +45,7 @@ export const GlobalFiles = () => {
         total: data.metadata_roots_aggregate?.aggregate?.count ?? 0,
       };
     },
-    [gql],
+    [gql, aggregateLimit],
   );
 
   useEffect(() => {
@@ -58,6 +60,7 @@ export const GlobalFiles = () => {
       offset: page * limit,
       orderBy: sortBy,
       search: `%${searchQuery}%`,
+      aggregateLimit,
     },
     onCompleted: (data) => {
       setObjects(objectSummaryFromGlobalFilesQuery(data));

--- a/frontend/src/components/FileTables/GlobalFiles/index.tsx
+++ b/frontend/src/components/FileTables/GlobalFiles/index.tsx
@@ -5,11 +5,7 @@ import { useCallback, useEffect } from 'react';
 import { FileTable, FileActionButtons } from '../common/FileTable';
 import { NoUploadsPlaceholder } from '../common/NoUploadsPlaceholder';
 import { SearchBar } from 'components/SearchBar';
-import {
-  GetGlobalFilesDocument,
-  GetGlobalFilesQuery,
-  useGetGlobalFilesQuery,
-} from 'gql/graphql';
+import { GetGlobalFilesDocument, GetGlobalFilesQuery } from 'gql/graphql';
 import { objectSummaryFromGlobalFilesQuery } from './utils';
 import { Fetcher, useFileTableState } from '../state';
 import { useNetwork } from 'contexts/network';
@@ -19,12 +15,7 @@ import { ToBeReviewedFiles } from '../../FilesToBeReviewed';
 export const GlobalFiles = () => {
   const setObjects = useFileTableState((e) => e.setObjects);
   const setFetcher = useFileTableState((e) => e.setFetcher);
-  const sortBy = useFileTableState((e) => e.sortBy);
-  const page = useFileTableState((e) => e.page);
   const aggregateLimit = useFileTableState((e) => e.aggregateLimit);
-  const limit = useFileTableState((e) => e.limit);
-  const setTotal = useFileTableState((e) => e.setTotal);
-  const searchQuery = useFileTableState((e) => e.searchQuery);
   const { gql } = useNetwork();
 
   const fetcher: Fetcher = useCallback(
@@ -52,22 +43,6 @@ export const GlobalFiles = () => {
     setObjects(null);
     setFetcher(fetcher);
   }, [fetcher, gql, setFetcher, setObjects]);
-
-  useGetGlobalFilesQuery({
-    fetchPolicy: 'cache-and-network',
-    variables: {
-      limit,
-      offset: page * limit,
-      orderBy: sortBy,
-      search: `%${searchQuery}%`,
-      aggregateLimit,
-    },
-    onCompleted: (data) => {
-      setObjects(objectSummaryFromGlobalFilesQuery(data));
-      setTotal(data.metadata_roots_aggregate?.aggregate?.count ?? 0);
-    },
-    pollInterval: 30_000,
-  });
 
   return (
     <div className='flex w-full'>

--- a/frontend/src/components/FileTables/GlobalFiles/query.graphql
+++ b/frontend/src/components/FileTables/GlobalFiles/query.graphql
@@ -1,8 +1,9 @@
 query GetGlobalFiles(
+  $aggregateLimit: Int!
   $limit: Int!
   $offset: Int!
   $orderBy: [metadata_roots_order_by!]
-  $search: String!
+  $search: String
 ) {
   metadata_roots(
     where: {
@@ -63,6 +64,7 @@ query GetGlobalFiles(
     }
   }
   metadata_roots_aggregate(
+    limit: $aggregateLimit
     where: {
       inner_metadata: { object_ownership: { is_admin: { _eq: true } } }
       _or: [{ head_cid: { _ilike: $search } }, { name: { _ilike: $search } }]

--- a/frontend/src/components/FileTables/GlobalFiles/query.graphql
+++ b/frontend/src/components/FileTables/GlobalFiles/query.graphql
@@ -5,7 +5,14 @@ query GetGlobalFiles(
   $orderBy: [metadata_roots_order_by!]
   $search: String
 ) {
-  metadata_roots(limit: $limit, offset: $offset, order_by: $orderBy) {
+  metadata_roots(
+    where: {
+      _or: [{ head_cid: { _ilike: $search } }, { name: { _ilike: $search } }]
+    }
+    limit: $limit
+    offset: $offset
+    order_by: $orderBy
+  ) {
     cid: head_cid
     tags
     type: metadata(path: "type")

--- a/frontend/src/components/FileTables/GlobalFiles/query.graphql
+++ b/frontend/src/components/FileTables/GlobalFiles/query.graphql
@@ -5,15 +5,7 @@ query GetGlobalFiles(
   $orderBy: [metadata_roots_order_by!]
   $search: String
 ) {
-  metadata_roots(
-    where: {
-      inner_metadata: { object_ownership: { is_admin: { _eq: true } } }
-      _or: [{ head_cid: { _ilike: $search } }, { name: { _ilike: $search } }]
-    }
-    limit: $limit
-    offset: $offset
-    order_by: $orderBy
-  ) {
+  metadata_roots(limit: $limit, offset: $offset, order_by: $orderBy) {
     cid: head_cid
     tags
     type: metadata(path: "type")

--- a/frontend/src/components/FileTables/SharedFiles/index.tsx
+++ b/frontend/src/components/FileTables/SharedFiles/index.tsx
@@ -2,11 +2,7 @@
 import { FileActionButtons, FileTable } from '../common/FileTable';
 import { NoSharedFilesPlaceholder } from './NoSharedFilesPlaceholder';
 import { useCallback, useEffect } from 'react';
-import {
-  GetSharedFilesDocument,
-  GetSharedFilesQuery,
-  useGetSharedFilesQuery,
-} from 'gql/graphql';
+import { GetSharedFilesDocument, GetSharedFilesQuery } from 'gql/graphql';
 import { objectSummaryFromSharedFilesQuery } from './utils';
 import { Fetcher, useFileTableState } from '../state';
 import { useNetwork } from 'contexts/network';
@@ -15,13 +11,10 @@ import { useUserStore } from 'globalStates/user';
 export const SharedFiles = () => {
   const setObjects = useFileTableState((e) => e.setObjects);
   const setFetcher = useFileTableState((e) => e.setFetcher);
-  const setTotal = useFileTableState((e) => e.setTotal);
-  const limit = useFileTableState((e) => e.limit);
-  const page = useFileTableState((e) => e.page);
-  const sortBy = useFileTableState((e) => e.sortBy);
   const aggregateLimit = useFileTableState((e) => e.aggregateLimit);
   const user = useUserStore((state) => state.user);
   const { gql } = useNetwork();
+
   const fetcher: Fetcher = useCallback(
     async (page: number, limit: number, sortBy) => {
       const { data } = await gql.query<GetSharedFilesQuery>({
@@ -49,23 +42,6 @@ export const SharedFiles = () => {
     setObjects(null);
     setFetcher(fetcher);
   }, [fetcher, gql, setFetcher, setObjects]);
-
-  useGetSharedFilesQuery({
-    fetchPolicy: 'cache-and-network',
-    variables: {
-      limit,
-      offset: page * limit,
-      orderBy: sortBy,
-      oauthUserId: user?.oauthUserId ?? '',
-      oauthProvider: user?.oauthProvider ?? '',
-      aggregateLimit,
-    },
-    onCompleted: (data) => {
-      setObjects(objectSummaryFromSharedFilesQuery(data));
-      setTotal(data.metadata_roots_aggregate?.aggregate?.count ?? 0);
-    },
-    pollInterval: 30_000,
-  });
 
   return (
     <div className='flex w-full'>

--- a/frontend/src/components/FileTables/SharedFiles/index.tsx
+++ b/frontend/src/components/FileTables/SharedFiles/index.tsx
@@ -19,6 +19,7 @@ export const SharedFiles = () => {
   const limit = useFileTableState((e) => e.limit);
   const page = useFileTableState((e) => e.page);
   const sortBy = useFileTableState((e) => e.sortBy);
+  const aggregateLimit = useFileTableState((e) => e.aggregateLimit);
   const user = useUserStore((state) => state.user);
   const { gql } = useNetwork();
   const fetcher: Fetcher = useCallback(
@@ -31,6 +32,7 @@ export const SharedFiles = () => {
           oauthUserId: user?.oauthUserId ?? '',
           oauthProvider: user?.oauthProvider ?? '',
           orderBy: sortBy,
+          aggregateLimit,
         },
         fetchPolicy: 'no-cache',
       });
@@ -40,7 +42,7 @@ export const SharedFiles = () => {
         total: data.metadata_roots_aggregate?.aggregate?.count ?? 0,
       };
     },
-    [gql, user?.oauthProvider, user?.oauthUserId],
+    [gql, user?.oauthProvider, user?.oauthUserId, aggregateLimit],
   );
 
   useEffect(() => {
@@ -56,6 +58,7 @@ export const SharedFiles = () => {
       orderBy: sortBy,
       oauthUserId: user?.oauthUserId ?? '',
       oauthProvider: user?.oauthProvider ?? '',
+      aggregateLimit,
     },
     onCompleted: (data) => {
       setObjects(objectSummaryFromSharedFilesQuery(data));

--- a/frontend/src/components/FileTables/SharedFiles/query.graphql
+++ b/frontend/src/components/FileTables/SharedFiles/query.graphql
@@ -4,6 +4,7 @@ query GetSharedFiles(
   $limit: Int!
   $offset: Int!
   $orderBy: [metadata_roots_order_by!]
+  $aggregateLimit: Int!
 ) {
   metadata_roots(
     where: {
@@ -72,6 +73,7 @@ query GetSharedFiles(
     }
   }
   metadata_roots_aggregate(
+    limit: $aggregateLimit
     where: {
       inner_metadata: {
         object_ownership: {

--- a/frontend/src/components/FileTables/TrashFiles/index.tsx
+++ b/frontend/src/components/FileTables/TrashFiles/index.tsx
@@ -22,6 +22,7 @@ export const TrashFiles = () => {
   const setTotal = useFileTableState((e) => e.setTotal);
   const sortBy = useFileTableState((e) => e.sortBy);
   const user = useUserStore((state) => state.user);
+  const aggregateLimit = useFileTableState((e) => e.aggregateLimit);
 
   const { gql } = useNetwork();
 
@@ -35,6 +36,7 @@ export const TrashFiles = () => {
           oauthUserId: user?.oauthUserId ?? '',
           oauthProvider: user?.oauthProvider ?? '',
           orderBy: sortBy,
+          aggregateLimit,
         },
         fetchPolicy: 'no-cache',
       });
@@ -44,7 +46,7 @@ export const TrashFiles = () => {
         total: data.metadata_roots_aggregate?.aggregate?.count ?? 0,
       };
     },
-    [gql, user?.oauthProvider, user?.oauthUserId],
+    [gql, user?.oauthProvider, user?.oauthUserId, aggregateLimit],
   );
 
   useEffect(() => {
@@ -61,6 +63,7 @@ export const TrashFiles = () => {
       orderBy: sortBy,
       oauthUserId: user?.oauthUserId ?? '',
       oauthProvider: user?.oauthProvider ?? '',
+      aggregateLimit,
     },
     onCompleted: (data) => {
       setObjects(objectSummaryFromTrashedFilesQuery(data));

--- a/frontend/src/components/FileTables/TrashFiles/index.tsx
+++ b/frontend/src/components/FileTables/TrashFiles/index.tsx
@@ -4,11 +4,7 @@
 import { NoFilesInTrashPlaceholder } from './NoFilesInTrashPlaceholder';
 import { FileActionButtons, FileTable } from '../common/FileTable';
 import { useCallback, useEffect } from 'react';
-import {
-  GetTrashedFilesDocument,
-  GetTrashedFilesQuery,
-  useGetTrashedFilesQuery,
-} from 'gql/graphql';
+import { GetTrashedFilesDocument, GetTrashedFilesQuery } from 'gql/graphql';
 import { useUserStore } from 'globalStates/user';
 import { objectSummaryFromTrashedFilesQuery } from './utils';
 import { Fetcher, useFileTableState } from '../state';
@@ -17,10 +13,6 @@ import { useNetwork } from 'contexts/network';
 export const TrashFiles = () => {
   const setObjects = useFileTableState((e) => e.setObjects);
   const setFetcher = useFileTableState((e) => e.setFetcher);
-  const page = useFileTableState((e) => e.page);
-  const limit = useFileTableState((e) => e.limit);
-  const setTotal = useFileTableState((e) => e.setTotal);
-  const sortBy = useFileTableState((e) => e.sortBy);
   const user = useUserStore((state) => state.user);
   const aggregateLimit = useFileTableState((e) => e.aggregateLimit);
 
@@ -53,24 +45,6 @@ export const TrashFiles = () => {
     setObjects(null);
     setFetcher(fetcher);
   }, [fetcher, gql, setFetcher, setObjects]);
-
-  useGetTrashedFilesQuery({
-    fetchPolicy: 'cache-and-network',
-    skip: !user,
-    variables: {
-      limit,
-      offset: page * limit,
-      orderBy: sortBy,
-      oauthUserId: user?.oauthUserId ?? '',
-      oauthProvider: user?.oauthProvider ?? '',
-      aggregateLimit,
-    },
-    onCompleted: (data) => {
-      setObjects(objectSummaryFromTrashedFilesQuery(data));
-      setTotal(data.metadata_roots_aggregate?.aggregate?.count ?? 0);
-    },
-    pollInterval: 30_000,
-  });
 
   return (
     <div className='flex w-full'>

--- a/frontend/src/components/FileTables/TrashFiles/query.graphql
+++ b/frontend/src/components/FileTables/TrashFiles/query.graphql
@@ -4,6 +4,7 @@ query GetTrashedFiles(
   $limit: Int!
   $offset: Int!
   $orderBy: [metadata_roots_order_by!]
+  $aggregateLimit: Int!
 ) {
   metadata_roots(
     where: {
@@ -74,7 +75,7 @@ query GetTrashedFiles(
     }
   }
   metadata_roots_aggregate(
-    distinct_on: root_cid
+    limit: $aggregateLimit
     where: {
       inner_metadata: {
         object_ownership: {

--- a/frontend/src/components/FileTables/UserFiles/index.tsx
+++ b/frontend/src/components/FileTables/UserFiles/index.tsx
@@ -9,11 +9,7 @@ import {
   FileTable,
 } from '@/components/FileTables/common/FileTable';
 import { NoUploadsPlaceholder } from '@/components/FileTables/common/NoUploadsPlaceholder';
-import {
-  GetMyFilesDocument,
-  GetMyFilesQuery,
-  useGetMyFilesQuery,
-} from 'gql/graphql';
+import { GetMyFilesDocument, GetMyFilesQuery } from 'gql/graphql';
 import { objectSummaryFromUserFilesQuery } from './utils';
 import { Fetcher, useFileTableState } from '../state';
 import { useNetwork } from 'contexts/network';
@@ -23,13 +19,8 @@ import { ToBeReviewedFiles } from '../../FilesToBeReviewed';
 
 export const UserFiles = () => {
   const setObjects = useFileTableState((e) => e.setObjects);
-  const setTotal = useFileTableState((e) => e.setTotal);
   const setFetcher = useFileTableState((e) => e.setFetcher);
-  const limit = useFileTableState((e) => e.limit);
-  const page = useFileTableState((e) => e.page);
-  const sortBy = useFileTableState((e) => e.sortBy);
   const user = useUserStore((state) => state.user);
-  const searchQuery = useFileTableState((e) => e.searchQuery);
   const aggregateLimit = useFileTableState((e) => e.aggregateLimit);
   const { gql } = useNetwork();
 
@@ -61,25 +52,6 @@ export const UserFiles = () => {
     setObjects(null);
     setFetcher(fetcher);
   }, [fetcher, gql, setFetcher, setObjects]);
-
-  useGetMyFilesQuery({
-    fetchPolicy: 'cache-and-network',
-    skip: !user,
-    variables: {
-      limit,
-      offset: page * limit,
-      orderBy: sortBy,
-      oauthUserId: user?.oauthUserId ?? '',
-      oauthProvider: user?.oauthProvider ?? '',
-      search: `%${searchQuery}%`,
-      aggregateLimit,
-    },
-    onCompleted: (data) => {
-      setObjects(objectSummaryFromUserFilesQuery(data));
-      setTotal(data.metadata_roots_aggregate?.aggregate?.count ?? 0);
-    },
-    pollInterval: 30_000,
-  });
 
   return (
     <div className='flex w-full'>

--- a/frontend/src/components/FileTables/UserFiles/index.tsx
+++ b/frontend/src/components/FileTables/UserFiles/index.tsx
@@ -30,6 +30,7 @@ export const UserFiles = () => {
   const sortBy = useFileTableState((e) => e.sortBy);
   const user = useUserStore((state) => state.user);
   const searchQuery = useFileTableState((e) => e.searchQuery);
+  const aggregateLimit = useFileTableState((e) => e.aggregateLimit);
   const { gql } = useNetwork();
 
   const fetcher: Fetcher = useCallback(
@@ -43,6 +44,7 @@ export const UserFiles = () => {
           oauthProvider: user?.oauthProvider ?? '',
           orderBy: sortBy,
           search: `%${searchQuery}%`,
+          aggregateLimit,
         },
         fetchPolicy: 'no-cache',
       });
@@ -52,7 +54,7 @@ export const UserFiles = () => {
         total: data.metadata_roots_aggregate?.aggregate?.count ?? 0,
       };
     },
-    [gql, user?.oauthProvider, user?.oauthUserId],
+    [gql, user?.oauthProvider, user?.oauthUserId, aggregateLimit],
   );
 
   useEffect(() => {
@@ -70,6 +72,7 @@ export const UserFiles = () => {
       oauthUserId: user?.oauthUserId ?? '',
       oauthProvider: user?.oauthProvider ?? '',
       search: `%${searchQuery}%`,
+      aggregateLimit,
     },
     onCompleted: (data) => {
       setObjects(objectSummaryFromUserFilesQuery(data));

--- a/frontend/src/components/FileTables/UserFiles/query.graphql
+++ b/frontend/src/components/FileTables/UserFiles/query.graphql
@@ -5,6 +5,7 @@ query GetMyFiles(
   $offset: Int!
   $orderBy: [metadata_roots_order_by!]
   $search: String!
+  $aggregateLimit: Int!
 ) {
   metadata_roots(
     where: {
@@ -77,6 +78,7 @@ query GetMyFiles(
     }
   }
   metadata_roots_aggregate(
+    limit: $aggregateLimit
     where: {
       inner_metadata: {
         object_ownership: {

--- a/frontend/src/components/FileTables/common/FileTable/TablePaginator.tsx
+++ b/frontend/src/components/FileTables/common/FileTable/TablePaginator.tsx
@@ -23,6 +23,7 @@ export const TablePaginator = () => {
     total,
     isInitialized,
     initFromUrl,
+    aggregateLimit,
   } = useFileTableState();
 
   const router = useRouter();
@@ -33,7 +34,12 @@ export const TablePaginator = () => {
     getDisplayPageNumber(page),
   );
 
-  const totalPages = getTotalPages(total, limit);
+  const isLimitUnknown = aggregateLimit === total;
+
+  const offset = page * limit;
+  const effectiveTotal = isLimitUnknown ? aggregateLimit + offset : total;
+
+  const totalPages = getTotalPages(effectiveTotal, limit);
 
   // Initialize from URL params on mount
   useEffect(() => {
@@ -88,8 +94,8 @@ export const TablePaginator = () => {
       </div>
       <div>
         <span>
-          {total > 0
-            ? `${page * limit + 1}-${Math.min(page * limit + limit, total)} of ${total} items`
+          {effectiveTotal > 0
+            ? `${page * limit + 1}-${Math.min(page * limit + limit, effectiveTotal)} of ${isLimitUnknown ? `${effectiveTotal}+` : effectiveTotal} items`
             : '0 items'}
         </span>
       </div>
@@ -120,7 +126,7 @@ export const TablePaginator = () => {
             className='w-12 rounded border border-gray-300 p-1.5 text-center focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:bg-darkWhite dark:text-darkBlack'
             aria-label='Page number'
           />
-          <span>of {totalPages}</span>
+          <span>of {isLimitUnknown ? `${totalPages}+` : totalPages}</span>
         </div>
         <button
           disabled={page >= totalPages - 1}

--- a/frontend/src/components/FileTables/state.tsx
+++ b/frontend/src/components/FileTables/state.tsx
@@ -25,6 +25,7 @@ interface FileTableStore {
   total: number;
   page: number;
   limit: number;
+  aggregateLimit: number;
   fetcher: Fetcher | null;
   setObjects: (objects: ObjectSummary[] | null) => void;
   setFetcher: (fetcher: Fetcher) => void;
@@ -47,6 +48,7 @@ export const useFileTableState = create<FileTableStore>()((set, get) => {
     sortBy: defaultParams.sortBy,
     page: defaultParams.page,
     limit: defaultParams.limit,
+    aggregateLimit: 1_000,
     isInitialized: false,
     isLoading: true,
     objects: null,

--- a/frontend/src/utils/async.ts
+++ b/frontend/src/utils/async.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-this-alias */
 export const asyncByChunk = async function* (
   iterable: AsyncIterable<Buffer>,
   chunkSize: number,

--- a/frontend/src/utils/async.ts
+++ b/frontend/src/utils/async.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 export const asyncByChunk = async function* (
   iterable: AsyncIterable<Buffer>,
   chunkSize: number,
@@ -21,3 +22,26 @@ export const bufferToIterable = (buffer: Buffer): AsyncIterable<Buffer> => {
     yield buffer;
   })();
 };
+
+export function memoizePromise<
+  F extends (...args: any[]) => Promise<any> | any,
+>(fn: F, ttl: number) {
+  let sharedPromise: Promise<Awaited<ReturnType<F>>> | null = null;
+  let timestamp: number | null = null;
+
+  return function throttled(
+    this: any,
+    ...args: Parameters<F>
+  ): Promise<Awaited<ReturnType<F>>> {
+    if (!sharedPromise || (timestamp && Date.now() - timestamp > ttl)) {
+      sharedPromise = Promise.resolve(
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore - apply variadic args
+        fn.apply(this, args),
+      ) as Promise<Awaited<ReturnType<F>>>;
+      timestamp = Date.now();
+    }
+
+    return sharedPromise as Promise<Awaited<ReturnType<F>>>;
+  };
+}

--- a/frontend/src/utils/auth.ts
+++ b/frontend/src/utils/auth.ts
@@ -4,9 +4,14 @@ import { authOptions } from 'app/api/auth/[...nextauth]/config';
 import { memoizePromise } from '@/utils/async';
 
 const internalGetAuthSession = async (): Promise<Session | null> => {
+  const memoizedFrontend = memoizePromise(
+    () => import('next-auth/react').then((m) => m.getSession()),
+    50,
+  );
+
   const internalSession = await (typeof window === 'undefined'
     ? import('next-auth').then((m) => m.getServerSession(authOptions))
-    : import('next-auth/react').then((m) => m.getSession()));
+    : memoizedFrontend());
 
   if (!internalSession) {
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions

--- a/frontend/src/utils/auth.ts
+++ b/frontend/src/utils/auth.ts
@@ -1,8 +1,9 @@
 import { type Session } from 'next-auth';
 import { redirect } from 'next/navigation';
 import { authOptions } from 'app/api/auth/[...nextauth]/config';
+import { memoizePromise } from '@/utils/async';
 
-export const getAuthSession = async (): Promise<Session | null> => {
+const internalGetAuthSession = async (): Promise<Session | null> => {
   const internalSession = await (typeof window === 'undefined'
     ? import('next-auth').then((m) => m.getServerSession(authOptions))
     : import('next-auth/react').then((m) => m.getSession()));
@@ -17,3 +18,8 @@ export const getAuthSession = async (): Promise<Session | null> => {
 
   return internalSession;
 };
+
+const getAuthSessionThrottled = memoizePromise(internalGetAuthSession, 500);
+
+export const getAuthSession = async (): Promise<Session | null> =>
+  getAuthSessionThrottled();

--- a/frontend/src/utils/auth.ts
+++ b/frontend/src/utils/auth.ts
@@ -24,7 +24,5 @@ const internalGetAuthSession = async (): Promise<Session | null> => {
   return internalSession;
 };
 
-const getAuthSessionThrottled = memoizePromise(internalGetAuthSession, 500);
-
 export const getAuthSession = async (): Promise<Session | null> =>
-  getAuthSessionThrottled();
+  internalGetAuthSession();


### PR DESCRIPTION
This PR tackles some of the performance issues described at #449 

The following changes have been made:

- **Memoized auth session (during 500ms) tokens for reducing the number of calls to auth service**
- **Apply limit to total count of files**: Queries are composed by two parts fetching the N next files + getting the count of total files. This second part had poor performance due to the big amount of files already stored ~90k in taurus. We implemented a dynamic limit that will explore until `10_000` files or `1000` pages beyond the current page, showing `1000+ pages` if that limit is reached.