### PR TITLE
fix: memoized frontend session retrieval

### DIFF
--- a/frontend/src/utils/auth.ts
+++ b/frontend/src/utils/auth.ts
@@ -3,12 +3,12 @@ import { redirect } from 'next/navigation';
 import { authOptions } from 'app/api/auth/[...nextauth]/config';
 import { memoizePromise } from '@/utils/async';
 
-const internalGetAuthSession = async (): Promise<Session | null> => {
-  const memoizedFrontend = memoizePromise(
-    () => import('next-auth/react').then((m) => m.getSession()),
-    50,
-  );
+const memoizedFrontend = memoizePromise(
+  () => import('next-auth/react').then((m) => m.getSession()),
+  500,
+);
 
+const internalGetAuthSession = async (): Promise<Session | null> => {
   const internalSession = await (typeof window === 'undefined'
     ? import('next-auth').then((m) => m.getServerSession(authOptions))
     : memoizedFrontend());


### PR DESCRIPTION
When I updated the memoization of session in frontend I introduced a bug, creating a memoized callback for each time I called effectively not caching anything.