### PR TITLE
Update dark mode class names in components

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -19,3 +19,10 @@ body {
     text-wrap: balance;
   }
 }
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: #252525; /* matches darkWhite */
+    --foreground: #ffffff; /* matches darkBlack */
+  }
+}

--- a/frontend/src/components/AccountInformation/index.tsx
+++ b/frontend/src/components/AccountInformation/index.tsx
@@ -25,11 +25,11 @@ export const AccountInformation = ({
   const downloadPercentage = (downloadUsed / downloadLimit) * 100;
 
   return (
-    <div className='mx-auto w-full max-w-sm overflow-hidden rounded-lg bg-white dark:bg-darkWhite dark:text-darkBlack'>
+    <div className='mx-auto w-full max-w-sm overflow-hidden rounded-lg bg-background text-foreground'>
       <div className='py-2'>
         <div className='space-y-6'>
           <div>
-            <div className='mb-1 flex justify-between text-sm text-gray-600 dark:text-darkBlack'>
+            <div className='mb-1 flex justify-between text-sm text-gray-600 text-foreground'>
               <span>
                 <span>{bytes(Number(uploadUsed))}</span>/
                 <span>{bytes(Number(uploadLimit))}</span>
@@ -51,10 +51,10 @@ export const AccountInformation = ({
           </div>
 
           <div>
-            <div className='mb-1 flex justify-between text-sm text-gray-600 text-primary dark:text-darkBlack'>
+            <div className='mb-1 flex justify-between text-sm text-gray-600 text-primary text-foreground'>
               <span>
                 <span>{bytes(downloadUsed)}</span>/
-                <span className='text-gray-500 dark:text-darkBlack'>
+                <span className='text-gray-500 text-foreground'>
                   {bytes(downloadLimit)}
                 </span>
               </span>
@@ -75,7 +75,7 @@ export const AccountInformation = ({
           </div>
         </div>
         <div className='mt-2 flex flex-col text-center'>
-          <span className='text-sm text-gray-400 dark:text-darkBlack'>
+          <span className='text-sm text-gray-400 text-foreground'>
             Renews in {utcToLocalRelativeTime(renewalDate.toISOString())}
           </span>
         </div>
@@ -84,7 +84,7 @@ export const AccountInformation = ({
             target='_blank'
             rel='noreferrer'
             href='https://forms.gle/EAPzicXcbP7gH2uT6'
-            className='text-sm text-black hover:underline'
+            className='text-sm text-foreground hover:underline'
           >
             <Button variant='primary'>Ask for more credits</Button>
           </a>

--- a/frontend/src/components/AdminPanel/UserTable/CreditsUpdateModal.tsx
+++ b/frontend/src/components/AdminPanel/UserTable/CreditsUpdateModal.tsx
@@ -92,10 +92,10 @@ export const CreditsUpdateModal = ({
               leaveFrom='opacity-100 scale-100'
               leaveTo='opacity-0 scale-95'
             >
-              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all dark:bg-darkWhite'>
+              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-background p-6 text-left align-middle shadow-xl transition-all bg-background'>
                 <DialogTitle
                   as='h3'
-                  className='text-lg font-medium leading-6 text-black dark:text-darkBlack'
+                  className='text-lg font-medium leading-6 text-foreground'
                 >
                   Update credits
                 </DialogTitle>
@@ -110,7 +110,7 @@ export const CreditsUpdateModal = ({
                         onChange={(e) => setDownloadCredits(e.target.value)}
                       />
                       <select
-                        className='rounded border border-gray-300 bg-white px-2 py-1 text-black dark:bg-darkWhite dark:text-darkBlack dark:ring-1 dark:ring-darkWhiteHover'
+                        className='rounded border border-gray-300 bg-background px-2 py-1 text-foreground bg-background text-foreground dark:ring-1 dark:ring-darkWhiteHover'
                         value={downloadCreditsUnit}
                         onChange={(e) =>
                           setDownloadCreditsUnit(Number(e.target.value))
@@ -130,7 +130,7 @@ export const CreditsUpdateModal = ({
                         onChange={(e) => setUploadCredits(e.target.value)}
                       />
                       <select
-                        className='rounded border border-gray-300 bg-white px-2 py-1 text-black dark:bg-darkWhite dark:text-darkBlack dark:ring-1 dark:ring-darkWhiteHover'
+                        className='rounded border border-gray-300 bg-background px-2 py-1 text-foreground bg-background text-foreground dark:ring-1 dark:ring-darkWhiteHover'
                         value={uploadCreditsUnit}
                         onChange={(e) =>
                           setUploadCreditsUnit(Number(e.target.value))

--- a/frontend/src/components/AdminPanel/UserTable/UpdateRoleModal.tsx
+++ b/frontend/src/components/AdminPanel/UserTable/UpdateRoleModal.tsx
@@ -59,10 +59,10 @@ export const UpdateRoleModal = ({
               leaveFrom='opacity-100 scale-100'
               leaveTo='opacity-0 scale-95'
             >
-              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all dark:bg-darkWhite'>
+              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-background p-6 text-left align-middle shadow-xl transition-all bg-background'>
                 <DialogTitle
                   as='h3'
-                  className='text-lg font-medium leading-6 text-black dark:text-darkBlack'
+                  className='text-lg font-medium leading-6 text-foreground'
                 >
                   Update user role
                 </DialogTitle>
@@ -70,7 +70,7 @@ export const UpdateRoleModal = ({
                   <div className='space-y-4'>
                     <div>
                       <select
-                        className='rounded border border-gray-300 bg-white px-2 py-1 text-black dark:bg-darkWhite dark:text-darkBlack dark:ring-1 dark:ring-darkWhiteHover'
+                        className='rounded border border-gray-300 bg-background px-2 py-1 text-foreground bg-background text-foreground dark:ring-1 dark:ring-darkWhiteHover'
                         value={role}
                         onChange={(e) => setRole(e.target.value as UserRole)}
                       >

--- a/frontend/src/components/AdminPanel/UserTable/UserTableRow.tsx
+++ b/frontend/src/components/AdminPanel/UserTable/UserTableRow.tsx
@@ -54,7 +54,7 @@ export const UserTableRow = ({ subscriptionWithUser }: UserTableRowProps) => {
           role='button'
           tabIndex={0}
           onKeyDown={handleEnterOrSpace(copyToClipboard)}
-          className='flex cursor-pointer items-center gap-2 text-sm text-black transition-colors duration-200 hover:text-blue-500 dark:text-darkBlack'
+          className='flex cursor-pointer items-center gap-2 text-sm text-foreground transition-colors duration-200 hover:text-blue-500 text-foreground'
           onClick={copyToClipboard}
         >
           {shortenString(subscriptionWithUser.user.publicId!, 16)}{' '}
@@ -62,43 +62,43 @@ export const UserTableRow = ({ subscriptionWithUser }: UserTableRowProps) => {
         </div>
       </TableBodyCell>
       <TableBodyCell>
-        <div className='text-sm text-black dark:text-darkBlack'>
+        <div className='text-sm text-foreground'>
           {subscriptionWithUser.user.oauthProvider}
         </div>
       </TableBodyCell>
       <TableBodyCell>
-        <div className='flex items-center gap-2 text-sm text-black dark:text-darkBlack'>
+        <div className='flex items-center gap-2 text-sm text-foreground'>
           {subscriptionWithUser.user.role}
         </div>
       </TableBodyCell>
       <TableBodyCell>
-        <div className='text-sm text-black dark:text-darkBlack'>
+        <div className='text-sm text-foreground'>
           {granularity}
         </div>
       </TableBodyCell>
       <TableBodyCell>
-        <div className='text-sm text-black dark:text-darkBlack'>
+        <div className='text-sm text-foreground'>
           {bytes(Number(subscriptionWithUser.uploadLimit), {
             unitSeparator: ' ',
           })}
         </div>
       </TableBodyCell>
       <TableBodyCell>
-        <div className='text-sm text-black dark:text-darkBlack'>
+        <div className='text-sm text-foreground'>
           {bytes(Number(subscriptionWithUser.pendingUploadCredits || 0), {
             unitSeparator: ' ',
           })}
         </div>
       </TableBodyCell>
       <TableBodyCell>
-        <div className='text-sm text-black dark:text-darkBlack'>
+        <div className='text-sm text-foreground'>
           {bytes(Number(subscriptionWithUser.downloadLimit), {
             unitSeparator: ' ',
           })}
         </div>
       </TableBodyCell>
       <TableBodyCell>
-        <div className='text-sm text-black dark:text-darkBlack'>
+        <div className='text-sm text-foreground'>
           {bytes(Number(subscriptionWithUser.pendingDownloadCredits || 0), {
             unitSeparator: ' ',
           })}

--- a/frontend/src/components/AdminPanel/UserTable/index.tsx
+++ b/frontend/src/components/AdminPanel/UserTable/index.tsx
@@ -62,7 +62,7 @@ export const UserSubscriptionsTable = ({
                   <TableBodyRow>
                     <TableBodyCell
                       colSpan={9}
-                      className='whitespace-nowrap px-6 py-4 text-center text-sm text-black dark:text-darkBlack'
+                      className='whitespace-nowrap px-6 py-4 text-center text-sm text-foreground'
                     >
                       <span className='flex items-center justify-center'>
                         <Loader className='h-4 w-4 animate-spin' />
@@ -77,7 +77,7 @@ export const UserSubscriptionsTable = ({
       </div>
 
       {/* Pagination Controls */}
-      <div className='mt-4 flex items-center justify-between border-t border-gray-200 bg-white px-4 py-3 sm:px-6 dark:bg-gray-800'>
+      <div className='mt-4 flex items-center justify-between border-t border-gray-200 bg-background px-4 py-3 sm:px-6 dark:bg-gray-800'>
         <div className='flex items-center'>
           <label
             htmlFor='itemsPerPage'
@@ -116,7 +116,7 @@ export const UserSubscriptionsTable = ({
           <button
             onClick={() => onPageChange(currentPage - 1)}
             disabled={currentPage === 1}
-            className='relative inline-flex items-center rounded-md border border-gray-300 bg-white px-2 py-1 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300'
+            className='relative inline-flex items-center rounded-md border border-gray-300 bg-background px-2 py-1 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300'
           >
             <ChevronLeft className='h-4 w-4' />
           </button>
@@ -126,7 +126,7 @@ export const UserSubscriptionsTable = ({
           <button
             onClick={() => onPageChange(currentPage + 1)}
             disabled={currentPage === totalPages || totalPages === 0}
-            className='relative inline-flex items-center rounded-md border border-gray-300 bg-white px-2 py-1 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300'
+            className='relative inline-flex items-center rounded-md border border-gray-300 bg-background px-2 py-1 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300'
           >
             <ChevronRight className='h-4 w-4' />
           </button>

--- a/frontend/src/components/Developers/ApiKeysTable/ApiKeyCreationModal.tsx
+++ b/frontend/src/components/Developers/ApiKeysTable/ApiKeyCreationModal.tsx
@@ -79,10 +79,10 @@ export const ApiKeyCreationModal = ({
               leaveFrom='opacity-100 scale-100'
               leaveTo='opacity-0 scale-95'
             >
-              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all dark:bg-backgroundDark dark:bg-darkWhite'>
+              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-background p-6 text-left align-middle shadow-xl transition-all dark:bg-backgroundDark bg-background'>
                 <DialogTitle
                   as='h3'
-                  className='text-center text-lg font-medium leading-6 text-black dark:text-darkBlack'
+                  className='text-center text-lg font-medium leading-6 text-foreground'
                 >
                   Create API Key
                 </DialogTitle>

--- a/frontend/src/components/Developers/ApiKeysTable/DeleteApiKeyModal.tsx
+++ b/frontend/src/components/Developers/ApiKeysTable/DeleteApiKeyModal.tsx
@@ -64,7 +64,7 @@ export const DeleteApiKeyModal = ({
               leaveFrom='opacity-100 scale-100'
               leaveTo='opacity-0 scale-95'
             >
-              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left text-center align-middle shadow-xl transition-all dark:bg-darkWhite'>
+              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-background p-6 text-left text-center align-middle shadow-xl transition-all bg-background'>
                 <DialogTitle
                   as='h3'
                   className='text-lg font-medium leading-6 text-gray-900 dark:text-white'

--- a/frontend/src/components/FAQs/questions.tsx
+++ b/frontend/src/components/FAQs/questions.tsx
@@ -19,10 +19,10 @@ export const FAQ: FC = () => {
           {faqs.map((question, index) => (
             <div key={index} className='m-4'>
               <button
-                className='w-full rounded-lg bg-white p-8 text-left text-backgroundDark shadow-md dark:border-none dark:bg-darkWhite dark:text-darkBlack dark:text-white'
+                className='w-full rounded-lg bg-background p-8 text-left text-backgroundDark shadow-md dark:border-none bg-background text-foreground dark:text-white'
                 onClick={() => toggleFAQ(index)}
               >
-                <span className='text-xl font-semibold text-black dark:text-darkBlack'>
+                <span className='text-xl font-semibold text-foreground'>
                   {index + 1}. {question.question}
                 </span>
                 <span className='float-right'>
@@ -30,8 +30,8 @@ export const FAQ: FC = () => {
                 </span>
               </button>
               {openIndex === index && (
-                <div className='mt-2 rounded-lg bg-gray-100 p-4 dark:bg-darkWhiteHover'>
-                  <p className='whitespace-pre-line text-black dark:text-darkBlack'>
+                <div className='mt-2 rounded-lg bg-gray-100 p-4 bg-background'>
+                  <p className='whitespace-pre-line text-foreground'>
                     {question.answer}
                   </p>
                 </div>

--- a/frontend/src/components/FileTables/SharedFiles/NoSharedFilesPlaceholder.tsx
+++ b/frontend/src/components/FileTables/SharedFiles/NoSharedFilesPlaceholder.tsx
@@ -1,6 +1,6 @@
 export const NoSharedFilesPlaceholder = () => {
   return (
-    <div className='dark:bg-darkWhite mx-auto max-w-2xl rounded-lg bg-white p-6'>
+    <div className='bg-background mx-auto max-w-2xl rounded-lg bg-background p-6'>
       <h2 className='mb-4 text-center text-2xl font-bold'>
         No files have been shared with you yet
       </h2>

--- a/frontend/src/components/FileTables/TrashFiles/NoFilesInTrashPlaceholder.tsx
+++ b/frontend/src/components/FileTables/TrashFiles/NoFilesInTrashPlaceholder.tsx
@@ -1,6 +1,6 @@
 export const NoFilesInTrashPlaceholder = () => {
   return (
-    <div className='dark:bg-darkWhite mx-auto max-w-2xl rounded-lg bg-white p-6'>
+    <div className='bg-background mx-auto max-w-2xl rounded-lg bg-background p-6'>
       <h2 className='mb-4 text-center text-2xl font-bold'>No files in trash</h2>
       <p className='mb-6 text-center'>Files you remove will appear here.</p>
     </div>

--- a/frontend/src/components/FileTables/common/FileTable/FileTableRow.tsx
+++ b/frontend/src/components/FileTables/common/FileTable/FileTableRow.tsx
@@ -227,13 +227,13 @@ export const FileTableRow = ({
                 {isRowExpanded ? (
                   <DisplayerIcon className='rotate-90 text-accent' />
                 ) : (
-                  <DisplayerIcon className='text-black dark:text-darkBlack' />
+                  <DisplayerIcon className='text-foreground' />
                 )}
               </button>
             )}
             <Link
               href={ROUTES.objectDetails(network.id, file.headCid)}
-              className='relative ml-2 flex flex-row items-center text-sm font-medium text-gray-900 dark:text-darkBlack'
+              className='relative ml-2 flex flex-row items-center text-sm font-medium text-gray-900 text-foreground'
             >
               {file.type === 'folder' ? (
                 <Folder className='mr-2 h-5 w-5 text-gray-400' />
@@ -302,7 +302,7 @@ export const FileTableRow = ({
 
             {showActionsMenu && (
               <div
-                className='absolute right-0 top-full z-10 mt-1 w-36 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 dark:bg-darkWhite'
+                className='absolute right-0 top-full z-10 mt-1 w-36 rounded-md bg-background shadow-lg ring-1 ring-black ring-opacity-5 bg-background'
                 ref={actionsMenuRef}
               >
                 <div className='py-1' role='menu' aria-orientation='vertical'>

--- a/frontend/src/components/FileTables/common/FileTable/TablePaginator.tsx
+++ b/frontend/src/components/FileTables/common/FileTable/TablePaginator.tsx
@@ -77,11 +77,11 @@ export const TablePaginator = () => {
   };
 
   return (
-    <div className='flex w-full items-center justify-between p-4 text-sm text-light-gray dark:text-darkBlack'>
+    <div className='flex w-full items-center justify-between p-4 text-sm text-light-gray text-foreground'>
       <div className='flex items-center'>
         <span className='mr-2'>Items per page:</span>
         <select
-          className='rounded border border-gray-300 bg-gray-100 p-1 pr-1 dark:bg-darkWhite'
+          className='rounded border border-gray-300 bg-gray-100 p-1 pr-1 bg-background'
           value={limit}
           onChange={(e) => setLimit(parseInt(e.target.value))}
         >
@@ -102,7 +102,7 @@ export const TablePaginator = () => {
       <div className='flex items-center gap-2'>
         <button
           disabled={page === 0}
-          className='cursor-pointer rounded-md border border-light-gray p-2 text-black transition-all hover:scale-[102%] disabled:opacity-50 dark:text-darkBlack'
+          className='cursor-pointer rounded-md border border-light-gray p-2 text-foreground transition-all hover:scale-[102%] disabled:opacity-50 text-foreground'
           onClick={() => setInternalPage(0)}
           title='First page'
         >
@@ -110,7 +110,7 @@ export const TablePaginator = () => {
         </button>
         <button
           disabled={page === 0}
-          className='cursor-pointer rounded-md border border-light-gray p-2 text-black transition-all hover:scale-[102%] disabled:opacity-50 dark:text-darkBlack'
+          className='cursor-pointer rounded-md border border-light-gray p-2 text-foreground transition-all hover:scale-[102%] disabled:opacity-50 text-foreground'
           onClick={() => setInternalPage(page - 1)}
           title='Previous page'
         >
@@ -123,14 +123,14 @@ export const TablePaginator = () => {
             onChange={handlePageInputChange}
             onBlur={goToPage}
             onKeyDown={handleKeyDown}
-            className='w-12 rounded border border-gray-300 p-1.5 text-center focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:bg-darkWhite dark:text-darkBlack'
+            className='w-12 rounded border border-gray-300 p-1.5 text-center focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 bg-background text-foreground'
             aria-label='Page number'
           />
           <span>of {isLimitUnknown ? `${totalPages}+` : totalPages}</span>
         </div>
         <button
           disabled={page >= totalPages - 1}
-          className='cursor-pointer rounded-md border border-light-gray p-2 text-black transition-all hover:scale-[102%] disabled:opacity-50 dark:text-darkBlack'
+          className='cursor-pointer rounded-md border border-light-gray p-2 text-foreground transition-all hover:scale-[102%] disabled:opacity-50 text-foreground'
           onClick={() => setInternalPage(page + 1)}
           title='Next page'
         >
@@ -138,7 +138,7 @@ export const TablePaginator = () => {
         </button>
         <button
           disabled={page >= totalPages - 1}
-          className='cursor-pointer rounded-md border border-light-gray p-2 text-black transition-all hover:scale-[102%] disabled:opacity-50 dark:text-darkBlack'
+          className='cursor-pointer rounded-md border border-light-gray p-2 text-foreground transition-all hover:scale-[102%] disabled:opacity-50 text-foreground'
           onClick={() => setInternalPage(totalPages - 1)}
           title='Last page'
         >

--- a/frontend/src/components/FileTables/common/Metadata.tsx
+++ b/frontend/src/components/FileTables/common/Metadata.tsx
@@ -8,27 +8,27 @@ import { ROUTES } from 'constants/routes';
 export const Metadata = ({ object }: { object: ObjectSummary }) => {
   const { network } = useNetwork();
   return (
-    <div className='rounded-lg border border-[#202124] border-opacity-20 bg-white p-4 text-xs dark:bg-darkWhiteHover dark:text-darkBlack'>
+    <div className='rounded-lg border border-[#202124] border-opacity-20 bg-background p-4 text-xs bg-background text-foreground'>
       <div className='mb-4 flex flex-col'>
         <div className='flex justify-between'>
-          <h4 className='text-wrap text-sm font-medium text-black dark:text-darkBlack'>
+          <h4 className='text-wrap text-sm font-medium text-foreground'>
             {object.name}
           </h4>
           {object.uploadState.archivedNodes ===
             object.uploadState.totalNodes && (
-            <span className='h-fit rounded-md bg-green-300 px-2 py-1 font-semibold text-black'>
+            <span className='h-fit rounded-md bg-green-300 px-2 py-1 font-semibold text-foreground'>
               ARCHIVED
             </span>
           )}
         </div>
-        <p className='text-gray-500 dark:text-darkBlack'>
+        <p className='text-gray-500 text-foreground'>
           Size: {bytes(Number(object.size))}
         </p>
         <p>
           CID: <span className='text-blue-500'>{object.headCid}</span>
         </p>
       </div>
-      <div className='grid grid-cols-2 gap-x-4 gap-y-2 font-light text-black dark:text-darkBlack'>
+      <div className='grid grid-cols-2 gap-x-4 gap-y-2 font-light text-foreground'>
         <div className='flex'>
           <span>Type:</span>
           <span className='ml-[4px]'>{getTypeFromMetadata(object)}</span>
@@ -66,7 +66,7 @@ export const Metadata = ({ object }: { object: ObjectSummary }) => {
       </div>
       <div className='flex justify-end'>
         <InternalLink href={ROUTES.objectDetails(network.id, object.headCid)}>
-          <span className='mt-4 font-semibold text-primary hover:cursor-pointer dark:text-darkBlack'>
+          <span className='mt-4 font-semibold text-primary hover:cursor-pointer text-foreground'>
             See more
           </span>
         </InternalLink>

--- a/frontend/src/components/FileTables/common/NoUploadsPlaceholder.tsx
+++ b/frontend/src/components/FileTables/common/NoUploadsPlaceholder.tsx
@@ -2,7 +2,7 @@ import { Disclaimer } from 'components/common/Disclaimer';
 
 export const NoUploadsPlaceholder = () => {
   return (
-    <div className='mx-auto max-w-2xl rounded-lg bg-white p-6 dark:bg-darkWhite'>
+    <div className='mx-auto max-w-2xl rounded-lg bg-background p-6 bg-background'>
       <h2 className='mb-4 text-center text-2xl font-bold'>
         Make your first upload
       </h2>

--- a/frontend/src/components/FileTables/common/ObjectDeleteModal.tsx
+++ b/frontend/src/components/FileTables/common/ObjectDeleteModal.tsx
@@ -80,7 +80,7 @@ export const ObjectDeleteModal = ({
               leaveFrom='opacity-100 scale-100'
               leaveTo='opacity-0 scale-95'
             >
-              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all dark:bg-darkWhite'>
+              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-background p-6 text-left align-middle shadow-xl transition-all bg-background'>
                 <DialogTitle
                   as='h3'
                   className='text-lg font-medium leading-6 text-gray-900 dark:text-gray-100'

--- a/frontend/src/components/FileTables/common/ObjectDownloadModal.tsx
+++ b/frontend/src/components/FileTables/common/ObjectDownloadModal.tsx
@@ -230,7 +230,7 @@ export const ObjectDownloadModal = ({
               leaveFrom='opacity-100 scale-100'
               leaveTo='opacity-0 scale-95'
             >
-              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all dark:bg-darkWhite'>
+              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-background p-6 text-left align-middle shadow-xl transition-all bg-background'>
                 {view}
               </DialogPanel>
             </TransitionChild>

--- a/frontend/src/components/FileTables/common/ObjectReportModal.tsx
+++ b/frontend/src/components/FileTables/common/ObjectReportModal.tsx
@@ -62,7 +62,7 @@ export const ObjectReportModal = ({
               leaveFrom='opacity-100 scale-100'
               leaveTo='opacity-0 scale-95'
             >
-              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all dark:bg-darkWhite'>
+              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-background p-6 text-left align-middle shadow-xl transition-all bg-background'>
                 <DialogTitle
                   as='h3'
                   className='text-center text-lg font-medium leading-6 text-gray-900 dark:text-gray-100'

--- a/frontend/src/components/FileTables/common/ObjectRestoreModal.tsx
+++ b/frontend/src/components/FileTables/common/ObjectRestoreModal.tsx
@@ -56,7 +56,7 @@ export const ObjectRestoreModal = ({
               leaveFrom='opacity-100 scale-100'
               leaveTo='opacity-0 scale-95'
             >
-              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all dark:bg-darkWhite'>
+              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-background p-6 text-left align-middle shadow-xl transition-all bg-background'>
                 <DialogTitle
                   as='h3'
                   className='text-center text-lg font-medium leading-6 text-gray-900'

--- a/frontend/src/components/FileTables/common/ObjectShareModal.tsx
+++ b/frontend/src/components/FileTables/common/ObjectShareModal.tsx
@@ -88,10 +88,10 @@ export const ObjectShareModal = ({
               leaveFrom='opacity-100 scale-100'
               leaveTo='opacity-0 scale-95'
             >
-              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all dark:bg-darkWhite'>
+              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-background p-6 text-left align-middle shadow-xl transition-all bg-background'>
                 <DialogTitle
                   as='h3'
-                  className='text-lg font-medium leading-6 text-gray-900 dark:text-darkBlack'
+                  className='text-lg font-medium leading-6 text-gray-900 text-foreground'
                 >
                   Share &quot;{metadata?.metadata.name}&quot;
                 </DialogTitle>

--- a/frontend/src/components/FileTables/common/RecentActivities.tsx
+++ b/frontend/src/components/FileTables/common/RecentActivities.tsx
@@ -17,7 +17,7 @@ export const RecentActivities = ({
   activities?: Activity[];
 }) => {
   return (
-    <div className='dark:bg-darkWhite max-w-md rounded-lg bg-white p-6'>
+    <div className='bg-background max-w-md rounded-lg bg-background p-6'>
       <h2 className='mb-4 text-xl font-semibold'>Recent Global Activities:</h2>
       <ul className='space-y-2'>
         {activities.map((activity, index) => (

--- a/frontend/src/components/FileTables/common/UploadingFileModal.tsx
+++ b/frontend/src/components/FileTables/common/UploadingFileModal.tsx
@@ -182,7 +182,7 @@ export const UploadingFileModal = ({
     <Transition show={!!files && files.length > 0}>
       <Dialog as='div' onClose={handleClose}>
         <div className='fixed inset-0 flex items-center justify-center bg-black/25 bg-opacity-50 dark:bg-darkBlack/25'>
-          <div className='min-w-[400px] max-w-[600px] transform rounded-lg bg-white p-6 shadow-lg transition-transform dark:bg-darkWhite'>
+          <div className='min-w-[400px] max-w-[600px] transform rounded-lg bg-background p-6 shadow-lg transition-transform bg-background'>
             {tooManyFiles ? (
               <div className='p-4'>
                 <div className='mb-4 text-center font-medium text-red-500'>
@@ -271,7 +271,7 @@ export const UploadingFileModal = ({
             ) : (
               <div>
                 <div className='flex flex-col gap-2 p-4'>
-                  <span className='text-md block text-center font-semibold text-gray-700 dark:text-darkBlack'>
+                  <span className='text-md block text-center font-semibold text-gray-700 text-foreground'>
                     Enter Encrypting Password
                   </span>
                   {totalFiles > 1 ? (

--- a/frontend/src/components/FileTables/common/UploadingFolderModal.tsx
+++ b/frontend/src/components/FileTables/common/UploadingFolderModal.tsx
@@ -54,8 +54,8 @@ export const UploadingFolderModal = ({
     <Transition show={!!data}>
       <Dialog as='div' onClose={onClose}>
         <div className='fixed inset-0 flex items-center justify-center bg-black/25 dark:bg-darkBlack/25'>
-          <div className='min-w-[25%] transform rounded-lg bg-white p-6 shadow-lg transition-transform dark:bg-darkWhite'>
-            <h3 className='mb-4 text-center text-lg font-medium dark:text-darkBlack'>
+          <div className='min-w-[25%] transform rounded-lg bg-background p-6 shadow-lg transition-transform bg-background'>
+            <h3 className='mb-4 text-center text-lg font-medium text-foreground'>
               Uploading Folder
             </h3>
             {passwordConfirmed ? (
@@ -78,7 +78,7 @@ export const UploadingFolderModal = ({
             ) : (
               <div>
                 <div className='flex flex-col gap-2 p-4'>
-                  <span className='text-md block text-center font-semibold text-gray-700 dark:text-darkBlack'>
+                  <span className='text-md block text-center font-semibold text-gray-700 text-foreground'>
                     Enter Encrypting Password
                   </span>
                   <input

--- a/frontend/src/components/FilesToBeReviewed/ReviewFilesRow.tsx
+++ b/frontend/src/components/FilesToBeReviewed/ReviewFilesRow.tsx
@@ -143,7 +143,7 @@ export const ToBeReviewedFileRow = ({ headCid }: { headCid: string }) => {
                 leaveFrom='opacity-100 scale-100'
                 leaveTo='opacity-0 scale-95'
               >
-                <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all dark:bg-darkWhite'>
+                <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-background p-6 text-left align-middle shadow-xl transition-all bg-background'>
                   <DialogTitle
                     as='h3'
                     className='text-lg font-medium leading-6 text-gray-900 dark:text-gray-100'
@@ -199,7 +199,7 @@ export const ToBeReviewedFileRow = ({ headCid }: { headCid: string }) => {
                 leaveFrom='opacity-100 scale-100'
                 leaveTo='opacity-0 scale-95'
               >
-                <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all dark:bg-darkWhite'>
+                <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-background p-6 text-left align-middle shadow-xl transition-all bg-background'>
                   <DialogTitle
                     as='h3'
                     className='text-lg font-medium leading-6 text-gray-900 dark:text-gray-100'

--- a/frontend/src/components/FilesToBeReviewed/index.tsx
+++ b/frontend/src/components/FilesToBeReviewed/index.tsx
@@ -103,7 +103,7 @@ export const ToBeReviewedFiles = () => {
               leaveFrom='opacity-100 scale-100'
               leaveTo='opacity-0 scale-95'
             >
-              <DialogPanel className='inline-block flex h-[60vh] w-full max-w-md transform flex-col justify-between overflow-y-scroll rounded-2xl bg-backgroundLight bg-white p-6 text-left align-middle shadow-xl transition-all dark:bg-darkWhiteHover'>
+              <DialogPanel className='inline-block flex h-[60vh] w-full max-w-md transform flex-col justify-between overflow-y-scroll rounded-2xl bg-backgroundLight bg-background p-6 text-left align-middle shadow-xl transition-all bg-background'>
                 <div>
                   <DialogTitle
                     as='h3'

--- a/frontend/src/components/Footer/index.tsx
+++ b/frontend/src/components/Footer/index.tsx
@@ -6,7 +6,7 @@ import { LogoIcon } from 'components/common/LogoIcon';
 const Footer: FC = () => {
   return (
     <footer className='container mb-[50px] px-4 sm:mx-auto xl:px-0'>
-      <div className='body-font rounded-xl bg-backgroundDarker p-10 text-white dark:bg-darkBlack dark:bg-darkWhiteHover dark:text-whiteOpaque'>
+      <div className='body-font rounded-xl bg-backgroundDarker p-10 text-white dark:bg-darkBlack bg-background dark:text-whiteOpaque'>
         <div className='md:grid md:grid-cols-2'>
           <div className='mb-20 flex justify-center md:mb-0 md:justify-start'>
             <div className='flex flex-col md:justify-between'>

--- a/frontend/src/components/Home/SignInButtons.tsx
+++ b/frontend/src/components/Home/SignInButtons.tsx
@@ -62,7 +62,7 @@ export const SigningInButtons = () => {
     <div className='flex flex-col gap-2 py-2'>
       <button
         onClick={handleGoogleAuth}
-        className='flex w-full max-w-xs transform items-center justify-center gap-2 rounded-full border-2 border-backgroundDarker bg-white px-6 py-3 font-bold text-backgroundDarker transition duration-300 ease-in-out hover:-translate-y-1 hover:scale-105 hover:opacity-80 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 dark:border-darkBlack dark:bg-darkWhite dark:text-darkBlack'
+        className='flex w-full max-w-xs transform items-center justify-center gap-2 rounded-full border-2 border-backgroundDarker bg-background px-6 py-3 font-bold text-backgroundDarker transition duration-300 ease-in-out hover:-translate-y-1 hover:scale-105 hover:opacity-80 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 border-foreground bg-background text-foreground'
         aria-label='Sign in with Google'
       >
         <GoogleIcon />
@@ -71,7 +71,7 @@ export const SigningInButtons = () => {
       </button>
       <button
         onClick={handleDiscordAuth}
-        className='flex w-full max-w-xs transform items-center justify-center gap-2 rounded-full border-2 border-backgroundDarker bg-white px-6 py-3 font-bold text-backgroundDarker transition duration-300 ease-in-out hover:-translate-y-1 hover:scale-105 hover:opacity-80 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 dark:border-darkBlack dark:bg-darkWhite dark:text-darkBlack'
+        className='flex w-full max-w-xs transform items-center justify-center gap-2 rounded-full border-2 border-backgroundDarker bg-background px-6 py-3 font-bold text-backgroundDarker transition duration-300 ease-in-out hover:-translate-y-1 hover:scale-105 hover:opacity-80 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 border-foreground bg-background text-foreground'
         aria-label='Sign in with Discord'
       >
         <DiscordIcon fillColor='#5865F2' />
@@ -80,7 +80,7 @@ export const SigningInButtons = () => {
       </button>
       <button
         onClick={handleGithubAuth}
-        className='flex w-full max-w-xs transform items-center justify-center gap-2 rounded-full border-2 border-backgroundDarker bg-white px-6 py-3 font-bold text-backgroundDarker transition duration-300 ease-in-out hover:-translate-y-1 hover:scale-105 hover:opacity-80 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 dark:border-darkBlack dark:bg-darkWhite dark:text-darkBlack'
+        className='flex w-full max-w-xs transform items-center justify-center gap-2 rounded-full border-2 border-backgroundDarker bg-background px-6 py-3 font-bold text-backgroundDarker transition duration-300 ease-in-out hover:-translate-y-1 hover:scale-105 hover:opacity-80 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2 border-foreground bg-background text-foreground'
         aria-label='Sign in with Github'
       >
         <GithubIcon fillColor='currentColor' />
@@ -89,7 +89,7 @@ export const SigningInButtons = () => {
       </button>
       <button
         onClick={handleAutoEVM}
-        className='flex w-full max-w-xs transform items-center justify-center rounded-full border-2 border-backgroundDarker bg-white px-6 py-3 font-bold text-backgroundDarker transition duration-300 ease-in-out hover:-translate-y-1 hover:scale-105 hover:opacity-80 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2'
+        className='flex w-full max-w-xs transform items-center justify-center rounded-full border-2 border-backgroundDarker bg-background px-6 py-3 font-bold text-backgroundDarker transition duration-300 ease-in-out hover:-translate-y-1 hover:scale-105 hover:opacity-80 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2'
         aria-label='Sign in with Wallet'
       >
         <WalletIcon />

--- a/frontend/src/components/Home/index.tsx
+++ b/frontend/src/components/Home/index.tsx
@@ -13,10 +13,10 @@ export const Home = () => {
   getSession();
 
   return (
-    <div className='flex min-h-screen flex-col items-center justify-between gap-2 bg-gradient-to-b from-backgroundLight to-backgroundDark dark:bg-darkWhite dark:from-backgroundDark dark:to-backgroundDarkest dark:text-darkBlack'>
+    <div className='flex min-h-screen flex-col items-center justify-between gap-2 bg-gradient-to-b from-backgroundLight to-backgroundDark bg-background dark:from-backgroundDark dark:to-backgroundDarkest text-foreground'>
       <LandingHeader />
-      <div className='mt-5 flex min-h-[50vh] w-[90%] flex-col items-center justify-center gap-4 overflow-hidden rounded-3xl rounded-xl bg-white py-8 md:w-[60%] md:flex-row md:gap-0 md:py-0 dark:bg-darkWhite'>
-        <div className='flex h-full w-full flex-col items-center justify-center gap-4 rounded-3xl bg-white px-4 dark:bg-darkWhite'>
+      <div className='mt-5 flex min-h-[50vh] w-[90%] flex-col items-center justify-center gap-4 overflow-hidden rounded-3xl rounded-xl bg-background py-8 md:w-[60%] md:flex-row md:gap-0 md:py-0 bg-background'>
+        <div className='flex h-full w-full flex-col items-center justify-center gap-4 rounded-3xl bg-background px-4 bg-background'>
           <h1 className='margin-0 bg-gradient-to-b from-backgroundDark to-backgroundDarker bg-clip-text text-center text-4xl font-semibold text-transparent dark:from-backgroundLight dark:to-backgroundDark'>
             Auto Drive
           </h1>
@@ -26,7 +26,7 @@ export const Home = () => {
           </p>
           <SigningInButtons />
         </div>
-        <div className='flex h-full w-full grow flex-col items-center justify-center gap-4 rounded-3xl bg-white px-4 dark:bg-darkWhite'>
+        <div className='flex h-full w-full grow flex-col items-center justify-center gap-4 rounded-3xl bg-background px-4 bg-background'>
           <Image
             className='w-full rounded-3xl border-2 border-gray-200'
             src='/preview.png'
@@ -36,11 +36,11 @@ export const Home = () => {
           />
         </div>
       </div>
-      <h2 className='my-8 text-center text-4xl font-bold text-backgroundDarker dark:text-darkBlack'>
+      <h2 className='my-8 text-center text-4xl font-bold text-backgroundDarker text-foreground'>
         Upload Once, Access Forever.
       </h2>
-      <div className='mt-5 flex min-h-[50vh] w-[90%] flex-col items-center justify-center gap-4 overflow-hidden rounded-3xl rounded-xl bg-white py-8 md:w-[60%] md:flex-row md:gap-0 md:py-0 dark:bg-darkWhite'>
-        <div className='flex h-full w-full grow flex-col items-center justify-center gap-4 rounded-3xl bg-white px-4 dark:bg-darkWhite'>
+      <div className='mt-5 flex min-h-[50vh] w-[90%] flex-col items-center justify-center gap-4 overflow-hidden rounded-3xl rounded-xl bg-background py-8 md:w-[60%] md:flex-row md:gap-0 md:py-0 bg-background'>
+        <div className='flex h-full w-full grow flex-col items-center justify-center gap-4 rounded-3xl bg-background px-4 bg-background'>
           <Image
             className='w-full rounded-3xl border-2 border-gray-200'
             src='/images/drag-drop-or-select-files-folders.png.png'
@@ -49,7 +49,7 @@ export const Home = () => {
             height={272}
           />
         </div>
-        <div className='flex h-full w-full flex-col items-center justify-center gap-4 rounded-3xl bg-white px-4 dark:bg-darkWhite'>
+        <div className='flex h-full w-full flex-col items-center justify-center gap-4 rounded-3xl bg-background px-4 bg-background'>
           <h1 className='margin-0 bg-gradient-to-b from-backgroundDark to-backgroundDarker bg-clip-text text-center text-4xl font-semibold text-transparent dark:from-backgroundLight dark:to-backgroundDark'>
             Upload Files & Folders
           </h1>
@@ -60,11 +60,11 @@ export const Home = () => {
           </p>
         </div>
       </div>
-      <h2 className='my-8 text-center text-4xl font-bold text-backgroundDarker dark:text-darkBlack'>
+      <h2 className='my-8 text-center text-4xl font-bold text-backgroundDarker text-foreground'>
         Your Drive into Permanent Decentralized Storage.
       </h2>
-      <div className='mt-5 flex min-h-[50vh] w-[90%] flex-col items-center justify-center gap-4 overflow-hidden rounded-3xl rounded-xl bg-white py-8 md:w-[60%] md:flex-row md:gap-0 md:py-0 dark:bg-darkWhite'>
-        <div className='flex h-full w-full flex-col items-center justify-center gap-4 rounded-3xl bg-white px-4 dark:bg-darkWhite'>
+      <div className='mt-5 flex min-h-[50vh] w-[90%] flex-col items-center justify-center gap-4 overflow-hidden rounded-3xl rounded-xl bg-background py-8 md:w-[60%] md:flex-row md:gap-0 md:py-0 bg-background'>
+        <div className='flex h-full w-full flex-col items-center justify-center gap-4 rounded-3xl bg-background px-4 bg-background'>
           <h1 className='margin-0 bg-gradient-to-b from-backgroundDark to-backgroundDarker bg-clip-text text-center text-4xl font-semibold text-transparent dark:from-backgroundLight dark:to-backgroundDark'>
             Secure End-to-End Encryption (E2EE)
           </h1>
@@ -75,7 +75,7 @@ export const Home = () => {
             putting you in complete control of your data security.
           </p>
         </div>
-        <div className='flex h-full w-full grow flex-col items-center justify-center gap-4 rounded-3xl bg-white px-4 dark:bg-darkWhite'>
+        <div className='flex h-full w-full grow flex-col items-center justify-center gap-4 rounded-3xl bg-background px-4 bg-background'>
           <Image
             className='w-full rounded-3xl border-2 border-gray-200'
             src='/images/upload-with-encryption-or-without.png'
@@ -85,11 +85,11 @@ export const Home = () => {
           />
         </div>
       </div>
-      <h2 className='my-8 text-center text-4xl font-bold text-backgroundDarker dark:text-darkBlack'>
+      <h2 className='my-8 text-center text-4xl font-bold text-backgroundDarker text-foreground'>
         Seamless Integration & Developer-Friendly
       </h2>
-      <div className='mt-5 flex min-h-[50vh] w-[90%] flex-col items-center justify-center gap-4 overflow-hidden rounded-3xl rounded-xl bg-white py-8 md:w-[60%] md:flex-row md:gap-0 md:py-0 dark:bg-darkWhite'>
-        <div className='flex h-full w-full grow flex-col items-center justify-center gap-4 rounded-3xl bg-white px-4 dark:bg-darkWhite'>
+      <div className='mt-5 flex min-h-[50vh] w-[90%] flex-col items-center justify-center gap-4 overflow-hidden rounded-3xl rounded-xl bg-background py-8 md:w-[60%] md:flex-row md:gap-0 md:py-0 bg-background'>
+        <div className='flex h-full w-full grow flex-col items-center justify-center gap-4 rounded-3xl bg-background px-4 bg-background'>
           <Image
             className='w-full rounded-3xl border-2 border-gray-200'
             src='/images/api-support.png'
@@ -98,7 +98,7 @@ export const Home = () => {
             height={272}
           />
         </div>
-        <div className='flex h-full w-full flex-col items-center justify-center gap-4 rounded-3xl bg-white px-4 dark:bg-darkWhite'>
+        <div className='flex h-full w-full flex-col items-center justify-center gap-4 rounded-3xl bg-background px-4 bg-background'>
           <h1 className='margin-0 bg-gradient-to-b from-backgroundDark to-backgroundDarker bg-clip-text text-center text-4xl font-semibold text-transparent dark:from-backgroundLight dark:to-backgroundDark'>
             Create API Keys
           </h1>
@@ -126,11 +126,11 @@ export const Home = () => {
           </p>
         </div>
       </div>
-      <h2 className='text-backgroundDarkers my-8 text-center text-4xl font-bold dark:text-darkBlack'>
+      <h2 className='text-backgroundDarkers my-8 text-center text-4xl font-bold text-foreground'>
         TypeScript & JavaScript Support with Full Type Safety
       </h2>
-      <div className='mt-5 flex min-h-[50vh] w-[90%] flex-col items-center justify-center gap-4 overflow-hidden rounded-3xl rounded-xl bg-white py-8 md:w-[60%] md:flex-row md:gap-0 md:py-0 dark:bg-darkWhite'>
-        <div className='flex h-full w-full flex-col items-center justify-center gap-4 rounded-3xl bg-white px-4 dark:bg-darkWhite'>
+      <div className='mt-5 flex min-h-[50vh] w-[90%] flex-col items-center justify-center gap-4 overflow-hidden rounded-3xl rounded-xl bg-background py-8 md:w-[60%] md:flex-row md:gap-0 md:py-0 bg-background'>
+        <div className='flex h-full w-full flex-col items-center justify-center gap-4 rounded-3xl bg-background px-4 bg-background'>
           <h1 className='margin-0 bg-gradient-to-b from-backgroundDark to-backgroundDarker bg-clip-text text-center text-4xl font-semibold text-transparent dark:from-backgroundLight dark:to-backgroundDark'>
             @autonomys/auto-drive
           </h1>
@@ -160,7 +160,7 @@ export const Home = () => {
             </Link>
           </p>
         </div>
-        <div className='flex h-full w-full grow flex-col items-center justify-center gap-4 rounded-3xl bg-white px-4 dark:bg-darkWhite'>
+        <div className='flex h-full w-full grow flex-col items-center justify-center gap-4 rounded-3xl bg-background px-4 bg-background'>
           <Link
             href='https://www.npmjs.com/package/@autonomys/auto-drive'
             className='text-accent'
@@ -177,11 +177,11 @@ export const Home = () => {
           </Link>
         </div>
       </div>
-      <h2 className='my-8 text-center text-4xl font-bold text-backgroundDarker dark:text-darkBlack'>
+      <h2 className='my-8 text-center text-4xl font-bold text-backgroundDarker text-foreground'>
         Scalable Data Structure for Decentralized Storage
       </h2>
-      <div className='mt-5 flex min-h-[50vh] w-[90%] flex-col items-center justify-center gap-4 overflow-hidden rounded-3xl rounded-xl bg-white py-8 md:w-[60%] md:flex-row md:gap-0 md:py-0 dark:bg-darkWhite'>
-        <div className='flex h-full w-full grow flex-col items-center justify-center gap-4 rounded-3xl bg-white px-4 dark:bg-darkWhite'>
+      <div className='mt-5 flex min-h-[50vh] w-[90%] flex-col items-center justify-center gap-4 overflow-hidden rounded-3xl rounded-xl bg-background py-8 md:w-[60%] md:flex-row md:gap-0 md:py-0 bg-background'>
+        <div className='flex h-full w-full grow flex-col items-center justify-center gap-4 rounded-3xl bg-background px-4 bg-background'>
           <Link
             href='https://www.npmjs.com/package/@autonomys/auto-dag-data'
             className='text-accent'
@@ -197,7 +197,7 @@ export const Home = () => {
             />
           </Link>
         </div>
-        <div className='flex h-full w-full flex-col items-center justify-center gap-4 rounded-3xl bg-white px-4 dark:bg-darkWhite'>
+        <div className='flex h-full w-full flex-col items-center justify-center gap-4 rounded-3xl bg-background px-4 bg-background'>
           <h1 className='margin-0 bg-gradient-to-b from-backgroundDark to-backgroundDarker bg-clip-text text-center text-4xl font-semibold text-transparent dark:from-backgroundLight dark:to-backgroundDark'>
             Auto-DAG Data Structure
           </h1>
@@ -209,11 +209,11 @@ export const Home = () => {
           </p>
         </div>
       </div>
-      <h2 className='my-8 text-center text-4xl font-bold text-backgroundDarker dark:text-darkBlack'>
+      <h2 className='my-8 text-center text-4xl font-bold text-backgroundDarker text-foreground'>
         Join Us Today and Experience the Future of Storage!
       </h2>
-      <div className='mt-5 flex min-h-[50vh] w-[90%] flex-col items-center justify-center gap-4 overflow-hidden rounded-3xl rounded-xl bg-white py-8 md:w-[60%] md:flex-row md:gap-0 md:py-0 dark:bg-darkWhite'>
-        <div className='flex h-full w-full grow flex-col items-center justify-center gap-4 rounded-3xl bg-white px-4 dark:bg-darkWhite'>
+      <div className='mt-5 flex min-h-[50vh] w-[90%] flex-col items-center justify-center gap-4 overflow-hidden rounded-3xl rounded-xl bg-background py-8 md:w-[60%] md:flex-row md:gap-0 md:py-0 bg-background'>
+        <div className='flex h-full w-full grow flex-col items-center justify-center gap-4 rounded-3xl bg-background px-4 bg-background'>
           <Image
             className='w-full rounded-3xl border-2 border-gray-200'
             src='/preview.png'
@@ -222,7 +222,7 @@ export const Home = () => {
             height={272}
           />
         </div>
-        <div className='flex h-full w-full flex-col items-center justify-center gap-4 rounded-3xl bg-white px-4 dark:bg-darkWhite'>
+        <div className='flex h-full w-full flex-col items-center justify-center gap-4 rounded-3xl bg-background px-4 bg-background'>
           <h1 className='margin-0 bg-gradient-to-b from-backgroundDark to-backgroundDarker bg-clip-text text-center text-4xl font-semibold text-transparent dark:from-backgroundLight dark:to-backgroundDark'>
             Auto Drive
           </h1>

--- a/frontend/src/components/Navbar/NavItem.tsx
+++ b/frontend/src/components/Navbar/NavItem.tsx
@@ -15,7 +15,7 @@ export const NavItem = ({
 }: NavItemProps) => (
   <InternalLink className='contents' href={href}>
     <button
-      className={`mb-2 flex items-center space-x-2 text-black hover:text-blue-600 dark:hover:text-darkPrimary ${isActive ? 'text-darkPrimary' : 'dark:text-darkBlack'}`}
+      className={`mb-2 flex items-center space-x-2 text-foreground hover:text-blue-600 dark:hover:text-darkPrimary ${isActive ? 'text-darkPrimary' : 'text-foreground'}`}
     >
       <Icon className='h-5 w-5' />
       <span className='hidden md:block'>{label}</span>

--- a/frontend/src/components/Navbar/ProfileDropdown.tsx
+++ b/frontend/src/components/Navbar/ProfileDropdown.tsx
@@ -43,7 +43,7 @@ export const ProfileDropdown: React.FC = () => {
               className='h-9 w-9 rounded-full border border-gray-100 shadow-lg dark:border-gray-500'
             />
           ) : (
-            <div className='flex h-9 w-9 items-center justify-center rounded-full border border-gray-100 bg-gray-300 text-white shadow-lg dark:border-gray-500 dark:bg-darkWhite'>
+            <div className='flex h-9 w-9 items-center justify-center rounded-full border border-gray-100 bg-gray-300 text-white shadow-lg dark:border-gray-500 bg-background'>
               <UserRoundIcon className='h-6 w-6' />
             </div>
           )}
@@ -51,7 +51,7 @@ export const ProfileDropdown: React.FC = () => {
       </button>
 
       {isOpen && (
-        <div className='absolute right-0 z-50 mt-2 w-48 origin-top-right rounded-md border border-gray-200 bg-white shadow-lg dark:border-gray-500 dark:bg-darkWhite'>
+        <div className='absolute right-0 z-50 mt-2 w-48 origin-top-right rounded-md border border-gray-200 bg-background shadow-lg dark:border-gray-500 bg-background'>
           <div className='border-b border-gray-100 px-4 py-3 dark:border-gray-700'>
             <p className='break-words text-sm font-medium'>
               {user?.oauthUsername || 'Anonymous'}

--- a/frontend/src/components/NetworkDropdown/index.tsx
+++ b/frontend/src/components/NetworkDropdown/index.tsx
@@ -27,7 +27,7 @@ export const NetworkDropdown: FC<{
   return (
     <Listbox value={selected} onChange={onChange}>
       <div className='relative mt-1 w-36'>
-        <ListboxButton className='relative w-full cursor-default rounded-lg bg-white py-2 pl-3 pr-10 text-left shadow-md focus:outline-none focus-visible:border-indigo-500 focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 focus-visible:ring-offset-2 focus-visible:ring-offset-orange-300 sm:text-sm dark:bg-darkWhite dark:ring-1 dark:ring-darkBlackHover'>
+        <ListboxButton className='relative w-full cursor-default rounded-lg bg-background py-2 pl-3 pr-10 text-left shadow-md focus:outline-none focus-visible:border-indigo-500 focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 focus-visible:ring-offset-2 focus-visible:ring-offset-orange-300 sm:text-sm bg-background dark:ring-1 dark:ring-darkBlackHover'>
           <div className='flex items-center space-x-2'>
             <AutonomysSymbol />
             <span className='ml-2 block'>{selected.name}</span>
@@ -45,12 +45,12 @@ export const NetworkDropdown: FC<{
           leaveFrom='opacity-100'
           leaveTo='opacity-0'
         >
-          <ListboxOptions className='absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm dark:bg-darkWhite'>
+          <ListboxOptions className='absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-background py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm bg-background'>
             {Object.values(networks).map((network, personIdx) => (
               <ListboxOption
                 key={personIdx}
                 className={cn(
-                  'relative flex cursor-default select-none items-center justify-start gap-2 bg-white py-2 pl-4 pr-4 dark:bg-darkWhite',
+                  'relative flex cursor-default select-none items-center justify-start gap-2 bg-background py-2 pl-4 pr-4 bg-background',
                   isActive(selected, network) ? 'bg-gray-100' : '',
                 )}
                 value={network}

--- a/frontend/src/components/Onboarding/index.tsx
+++ b/frontend/src/components/Onboarding/index.tsx
@@ -22,20 +22,20 @@ export const Onboarding = () => {
   }, []);
 
   return (
-    <div className='flex h-screen flex-col items-center justify-center bg-white dark:bg-darkWhite'>
+    <div className='flex h-screen flex-col items-center justify-center bg-background'>
       <header className='mb-8 flex flex-col items-center justify-between gap-4 md:flex-row md:gap-0'>
-        <div className='flex items-center space-x-2 text-black dark:text-darkBlack'>
+        <div className='flex items-center space-x-2 text-foreground'>
           <AutonomysSymbol />
           <span className='text-xl font-semibold'>Auto Drive</span>
         </div>
       </header>
-      <div className='flex flex-col items-center gap-4 dark:text-darkBlack'>
+      <div className='flex flex-col items-center gap-4 text-foreground'>
         <Disclaimer />
         <div className='flex items-center gap-2'>
           <Checkbox
             checked={accepted}
             onChange={() => setAccepted((e) => !e)}
-            className='group relative block size-4 rounded border bg-white data-[checked]:bg-blue-500 dark:bg-darkWhite'
+            className='group relative block size-4 rounded border bg-background data-[checked]:bg-blue-500 bg-background'
           >
             <CheckIcon className='absolute left-1/2 top-1/2 h-2 w-2 -translate-x-1/2 -translate-y-1/2 stroke-white opacity-0 group-data-[checked]:opacity-100' />
           </Checkbox>

--- a/frontend/src/components/Profile/DefaultPasswordModal/index.tsx
+++ b/frontend/src/components/Profile/DefaultPasswordModal/index.tsx
@@ -70,7 +70,7 @@ export const DefaultPasswordModal = ({
               leaveFrom='opacity-100 scale-100'
               leaveTo='opacity-0 scale-95'
             >
-              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all dark:bg-darkWhite'>
+              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-background p-6 text-left align-middle shadow-xl transition-all bg-background'>
                 <DialogTitle
                   as='h3'
                   className='text-lg font-medium leading-6 text-gray-900 dark:text-gray-100'
@@ -87,14 +87,14 @@ export const DefaultPasswordModal = ({
                   value={newPassword}
                   onChange={(e) => setNewPassword(e.target.value)}
                   placeholder='New Password'
-                  className='mt-2 block w-full rounded-md border border-gray-300 p-2 shadow-sm dark:border-gray-600 dark:bg-darkWhite dark:text-gray-100'
+                  className='mt-2 block w-full rounded-md border border-gray-300 p-2 shadow-sm dark:border-gray-600 bg-background dark:text-gray-100'
                 />
                 <input
                   type='password'
                   value={confirmPassword}
                   onChange={(e) => setConfirmPassword(e.target.value)}
                   placeholder='Confirm Password'
-                  className='mt-2 block w-full rounded-md border border-gray-300 p-2 shadow-sm dark:border-gray-600 dark:bg-darkWhite dark:text-gray-100'
+                  className='mt-2 block w-full rounded-md border border-gray-300 p-2 shadow-sm dark:border-gray-600 bg-background dark:text-gray-100'
                 />
                 <div className='mt-4 flex justify-center gap-2'>
                   <Button

--- a/frontend/src/components/SearchBar/index.tsx
+++ b/frontend/src/components/SearchBar/index.tsx
@@ -23,12 +23,12 @@ export const SearchBar = ({ scope }: { scope: 'global' | 'user' }) => {
   }, [scope]);
 
   return (
-    <div className='w-full max-w-md dark:text-darkBlack'>
+    <div className='w-full max-w-md text-foreground'>
       <div className='relative mt-1'>
         <div className='relative h-fit min-w-80'>
           <input
             type='text'
-            className='w-full rounded-lg border border-[#BCC1CA] bg-white py-[.65rem] pl-3 pr-10 text-sm leading-5 text-black text-gray-900 placeholder:text-black focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:bg-darkWhite dark:text-darkBlack dark:placeholder:text-darkBlack'
+            className='w-full rounded-lg border border-[#BCC1CA] bg-background py-[.65rem] pl-3 pr-10 text-sm leading-5 text-foreground text-gray-900 placeholder:text-foreground focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 bg-background text-foreground placeholder:text-foreground'
             value={inputValue}
             onChange={(e) => {
               setInputValue(e.target.value);

--- a/frontend/src/components/SearchResult/index.tsx
+++ b/frontend/src/components/SearchResult/index.tsx
@@ -23,7 +23,7 @@ export const SearchResult = ({ objects }: { objects: BaseMetadata[] }) => {
           />
         ))
       ) : (
-        <div className='flex h-[50%] w-full flex-col items-center justify-center text-center text-xl text-gray-500 dark:text-darkBlack'>
+        <div className='flex h-[50%] w-full flex-col items-center justify-center text-center text-xl text-gray-500 text-foreground'>
           No objects found!
         </div>
       )}

--- a/frontend/src/components/UploadButton/index.tsx
+++ b/frontend/src/components/UploadButton/index.tsx
@@ -63,7 +63,7 @@ export const UploadButton = () => {
           </Button>
         </PopoverButton>
         <PopoverPanel className='relative'>
-          <div className='absolute left-0 top-1 flex text-nowrap rounded-md bg-white text-black shadow-lg ring-1 ring-black ring-opacity-5 dark:bg-darkWhiteHover dark:text-darkBlack'>
+          <div className='absolute left-0 top-1 flex text-nowrap rounded-md bg-background text-foreground shadow-lg ring-1 ring-black ring-opacity-5 bg-background text-foreground'>
             <div className='p-1'>
               <button
                 onClick={openFileDialog}

--- a/frontend/src/components/UploadedObjectInformation/index.tsx
+++ b/frontend/src/components/UploadedObjectInformation/index.tsx
@@ -234,7 +234,7 @@ export const UploadedObjectInformation = ({
         </div>
       </div>
       <div className='grid grid-cols-1 gap-6 md:grid-cols-2'>
-        <div className='rounded-lg border border-gray-200 p-6 dark:border-gray-200 dark:bg-darkWhite'>
+        <div className='rounded-lg border border-gray-200 p-6 dark:border-gray-200 bg-background'>
           <h2 className='mb-4 flex items-center text-lg font-medium text-gray-900 dark:text-gray-100'>
             <IconWithTooltip
               icon={
@@ -325,7 +325,7 @@ export const UploadedObjectInformation = ({
             </div>
           </div>
         </div>
-        <div className='rounded-lg border border-gray-200 p-6 dark:bg-darkWhite'>
+        <div className='rounded-lg border border-gray-200 p-6 bg-background'>
           <h2 className='mb-4 flex items-center text-lg font-medium text-gray-900 dark:text-gray-100'>
             <IconWithTooltip
               icon={<CloudArrowUpIcon className='mr-2 h-5 w-5 text-gray-500' />}
@@ -383,7 +383,7 @@ export const UploadedObjectInformation = ({
           </div>
         </div>
       </div>
-      <div className='rounded-lg border border-gray-200 p-6 dark:border-gray-200 dark:bg-darkWhite'>
+      <div className='rounded-lg border border-gray-200 p-6 dark:border-gray-200 bg-background'>
         <h2 className='mb-4 flex items-center text-lg font-medium text-gray-900 dark:text-gray-100'>
           <IconWithTooltip
             icon={
@@ -430,7 +430,7 @@ export const UploadedObjectInformation = ({
           </div>
         </div>
       </div>
-      <div className='rounded-lg border border-gray-200 p-6 dark:bg-darkWhite'>
+      <div className='rounded-lg border border-gray-200 p-6 bg-background'>
         <h2 className='mb-4 text-lg font-medium text-gray-900 dark:text-gray-100'>
           Preview
         </h2>

--- a/frontend/src/components/UserAsyncDownloads/index.tsx
+++ b/frontend/src/components/UserAsyncDownloads/index.tsx
@@ -117,7 +117,7 @@ export const UserAsyncDownloads = () => {
               leaveFrom='opacity-100 scale-100'
               leaveTo='opacity-0 scale-95'
             >
-              <DialogPanel className='inline-block flex h-[60vh] w-full max-w-md transform flex-col justify-between overflow-y-scroll rounded-2xl bg-backgroundLight bg-white p-6 text-left align-middle shadow-xl transition-all dark:bg-darkWhiteHover'>
+              <DialogPanel className='inline-block flex h-[60vh] w-full max-w-md transform flex-col justify-between overflow-y-scroll rounded-2xl bg-backgroundLight bg-background p-6 text-left align-middle shadow-xl transition-all bg-background'>
                 <div>
                   <DialogTitle
                     as='h3'

--- a/frontend/src/components/common/Button.tsx
+++ b/frontend/src/components/common/Button.tsx
@@ -29,7 +29,7 @@ export const buttonVariantClasses: Record<ButtonVariant, string> = {
   lightDanger: `${baseClasses} font-medium bg-light-danger text-red-900 hover:bg-red-300 dark:bg-red-200 dark:hover:bg-red-300 disabled:opacity-50 disabled:hover disabled:hover:cursor-default`,
   danger: `${baseClasses} font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2 bg-red-400 hover:bg-red-600 dark:bg-red-500 dark:hover:bg-red-400 text-white font-semibold disabled:opacity-50 disabled:hover disabled:hover:cursor-default`,
   grayscale: `${baseClasses} bg-gray-button text-white opacity-80 hover:opacity-100 font-extralight disabled:opacity-50 disabled:hover disabled:hover:cursor-default`,
-  primaryOutline: `${baseClasses} bg-transparent text-primary border border-primary hover:border-primary-dark disabled:opacity-50 disabled:hover disabled:hover:cursor-default dark:bg-darkWhite hover:bg-primaryHover hover:text-white dark:text-darkBlack dark:hover:bg-darkWhiteHover dark:border-darkBlack dark:text-darkBlack dark:hover:bg-darkWhiteHover dark:border-darkBlack`,
+  primaryOutline: `${baseClasses} bg-transparent text-primary border border-primary hover:border-primary-dark disabled:opacity-50 disabled:hover disabled:hover:cursor-default bg-background hover:bg-primaryHover hover:text-white text-foreground dark:hover:bg-darkWhiteHover border-foreground text-foreground dark:hover:bg-darkWhiteHover border-foreground`,
 };
 
 const mapVariantToDarkModeVariant: Record<ButtonVariant, ButtonVariant> = {

--- a/frontend/src/components/common/CopiableText.tsx
+++ b/frontend/src/components/common/CopiableText.tsx
@@ -42,7 +42,7 @@ export const CopiableText = ({
           <Check className='h-4 w-4 text-green-500' />
         ) : (
           <Copy
-            className='h-4 w-4 text-gray-400 hover:text-gray-700 dark:text-darkBlack dark:hover:text-gray-100'
+            className='h-4 w-4 text-gray-400 hover:text-gray-700 text-foreground dark:hover:text-gray-100'
             onClick={(e) => {
               e.stopPropagation();
               onClick();

--- a/frontend/src/components/common/Disclaimer.tsx
+++ b/frontend/src/components/common/Disclaimer.tsx
@@ -1,6 +1,6 @@
 export const Disclaimer = () => {
   return (
-    <div className='dark:text-darkBlack relative rounded-lg border border-red-300 bg-red-50 bg-opacity-60 p-4 dark:bg-red-400'>
+    <div className='text-foreground relative rounded-lg border border-red-300 bg-red-50 bg-opacity-60 p-4 dark:bg-red-400'>
       <h3 className='mb-2 font-semibold'>Please, note:</h3>
       <ul className='list-inside list-disc space-y-1 text-sm font-bold'>
         <li>Uploaded content will be visible and searchable by everyone</li>

--- a/frontend/src/components/common/FileCard.tsx
+++ b/frontend/src/components/common/FileCard.tsx
@@ -90,14 +90,14 @@ export const FileCard = ({
         cid={isDownloadModalOpen ? cid : null}
         onClose={() => setIsDownloadModalOpen(false)}
       />
-      <div className='relative flex max-w-sm flex-1 flex-col text-ellipsis rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:bg-darkWhite'>
+      <div className='relative flex max-w-sm flex-1 flex-col text-ellipsis rounded-lg border border-gray-200 bg-background p-4 shadow-sm bg-background'>
         <div className='mb-4 flex items-start justify-between'>
           {objectIcon}
           <PopoverButton>
             <MoreVertical size={20} />
           </PopoverButton>
         </div>
-        <h2 className='mb-2 text-lg font-semibold text-gray-800 dark:text-darkBlack'>
+        <h2 className='mb-2 text-lg font-semibold text-gray-800 text-foreground'>
           {name ? shortenString(name, 20) : shortenString(cid, 20)}
         </h2>
         <p className='mb-4 text-gray-500'>Size: {bytes(Number(size))}</p>
@@ -117,10 +117,10 @@ export const FileCard = ({
             Open
           </button>
         )}
-        <PopoverPanel className='w-fit-content absolute right-0 top-0 divide-y divide-gray-200 rounded-xl bg-white text-sm/6 ring-1 ring-gray-200 transition duration-200 ease-in-out [--anchor-gap:var(--spacing-5)] data-[closed]:-translate-y-1 data-[closed]:opacity-0 dark:bg-darkWhite'>
+        <PopoverPanel className='w-fit-content absolute right-0 top-0 divide-y divide-gray-200 rounded-xl bg-background text-sm/6 ring-1 ring-gray-200 transition duration-200 ease-in-out [--anchor-gap:var(--spacing-5)] data-[closed]:-translate-y-1 data-[closed]:opacity-0 bg-background'>
           <div className='flex w-40 flex-col gap-2 p-3'>
             <span
-              className='flex items-center gap-2 font-semibold text-black dark:text-darkBlack'
+              className='flex items-center gap-2 font-semibold text-foreground'
               onClick={handleDownloadClick}
               role='button'
               tabIndex={0}
@@ -135,7 +135,7 @@ export const FileCard = ({
                 role='button'
                 tabIndex={0}
                 onKeyDown={handleNavigateKeyDown}
-                className='flex items-center gap-2 font-semibold text-black dark:text-darkBlack'
+                className='flex items-center gap-2 font-semibold text-foreground'
                 onClick={handleNavigateClick}
               >
                 <FolderIcon size={16} />

--- a/frontend/src/components/common/LandingHeader/index.tsx
+++ b/frontend/src/components/common/LandingHeader/index.tsx
@@ -11,8 +11,8 @@ export const LandingHeader = () => {
     (path: string) => {
       return `rounded-lg px-8 py-2 font-medium ${
         pathname === path
-          ? 'bg-white dark:bg-darkWhite dark:text-darkBlack'
-          : 'bg-transparent hover:cursor-pointer dark:text-darkBlack'
+          ? 'bg-background text-foreground'
+          : 'bg-transparent hover:cursor-pointer text-foreground'
       }`;
     },
     [pathname],

--- a/frontend/src/components/common/Table/TableBody.tsx
+++ b/frontend/src/components/common/Table/TableBody.tsx
@@ -17,7 +17,7 @@ export const TableBodyRow = ({
   return (
     <tr
       className={cn(
-        'w-full border-t border-gray-200 bg-white hover:bg-gray-50 dark:bg-darkWhite dark:hover:bg-darkWhiteHover',
+        'w-full border-t border-gray-200 bg-background hover:bg-gray-50 bg-background dark:hover:bg-darkWhiteHover',
         className,
       )}
       onClick={onClick}
@@ -39,7 +39,7 @@ export const TableBodyCell = ({
   return (
     <td
       className={cn(
-        'px-6 py-4 text-sm text-gray-700 dark:text-darkBlack',
+        'px-6 py-4 text-sm text-gray-700 text-foreground',
         className,
       )}
       colSpan={colSpan}

--- a/frontend/src/components/common/Table/TableHead.tsx
+++ b/frontend/src/components/common/Table/TableHead.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from 'react';
 import { cn } from '@/utils/cn';
 export const TableHead = ({ children }: { children: ReactNode }) => {
   return (
-    <thead className='rounded-lg bg-white font-semibold text-primary dark:bg-darkWhite'>
+    <thead className='rounded-lg bg-background font-semibold text-primary bg-background'>
       {children}
     </thead>
   );
@@ -25,7 +25,7 @@ export const TableHeadCell = ({
     <th
       scope='col'
       className={cn(
-        'rounded-lg px-6 py-3 text-left text-xs uppercase tracking-wider dark:text-darkBlack',
+        'rounded-lg px-6 py-3 text-left text-xs uppercase tracking-wider text-foreground',
         className,
       )}
       onClick={onClick}


### PR DESCRIPTION
Refactor dark mode styling to use unified `bg-background` and `text-foreground` tokens.

This PR unifies dark mode classnames by introducing CSS variables for `--background` and `--foreground` in `globals.css` and replacing legacy `dark:bg-darkWhite`, `dark:text-darkBlack`, `bg-white`, and `text-black` classes with the new unified tokens across components.

---
<a href="https://cursor.com/background-agent?bcId=bc-44de293a-54bf-4a4f-9d6d-c0dfdf01bfdc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-44de293a-54bf-4a4f-9d6d-c0dfdf01bfdc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

