### PR TITLE
Unify dark mode styling with background and foreground tokens

### DIFF
--- a/frontend/src/app/[chain]/drive/layout.tsx
+++ b/frontend/src/app/[chain]/drive/layout.tsx
@@ -30,13 +30,13 @@ export default function AppLayout({
   }
 
   return (
-    <div className='flex min-h-screen bg-white dark:bg-darkWhite'>
+    <div className='flex min-h-screen bg-background'>
       <SessionProvider>
         <NetworkProvider network={network}>
           <SessionEnsurer>
             <SidebarProvider className='contents'>
               <SideNavbar networkId={params.chain} />
-              <div className='flex h-screen flex-1 flex-col rounded-lg bg-white dark:bg-darkWhite dark:text-white'>
+              <div className='flex h-screen flex-1 flex-col rounded-lg bg-background dark:text-white'>
                 <TopNavbar networkId={params.chain} />
                 <div className='flex flex-1 overflow-hidden'>
                   <main className='flex-1 overflow-auto px-6 pb-6'>

--- a/frontend/src/components/atoms/CopiableText.tsx
+++ b/frontend/src/components/atoms/CopiableText.tsx
@@ -42,7 +42,7 @@ export const CopiableText = ({
           <Check className='h-4 w-4 text-green-500' />
         ) : (
           <Copy
-            className='h-4 w-4 text-gray-400 hover:text-gray-700 dark:text-darkBlack dark:hover:text-gray-100'
+            className='h-4 w-4 text-gray-400 hover:text-gray-700 text-foreground dark:hover:text-gray-100'
             onClick={(e) => {
               e.stopPropagation();
               onClick();

--- a/frontend/src/components/atoms/Disclaimer.tsx
+++ b/frontend/src/components/atoms/Disclaimer.tsx
@@ -1,6 +1,6 @@
 export const Disclaimer = () => {
   return (
-    <div className='relative rounded-lg border border-red-300 bg-red-50 bg-opacity-60 p-4 dark:bg-red-400 dark:text-darkBlack'>
+    <div className='relative rounded-lg border border-red-300 bg-red-50 bg-opacity-60 p-4 dark:bg-red-400 text-foreground'>
       <h3 className='mb-2 font-semibold'>Please, note:</h3>
       <ul className='list-inside list-disc space-y-1 text-sm font-bold'>
         <li>Uploaded content will be visible and searchable by everyone</li>

--- a/frontend/src/components/atoms/NavItem.tsx
+++ b/frontend/src/components/atoms/NavItem.tsx
@@ -16,7 +16,7 @@ export const NavItem = ({
   <InternalLink className='contents' href={href}>
     <div className='flex w-[80%] items-center justify-start rounded-md hover:bg-gray-100'>
       <button
-        className={`mb-2 flex items-center space-x-2 text-black hover:text-blue-600 dark:hover:text-darkPrimary ${isActive ? 'text-darkPrimary' : 'dark:text-darkBlack'}`}
+        className={`mb-2 flex items-center space-x-2 text-foreground hover:text-blue-600 dark:hover:text-darkPrimary ${isActive ? 'text-darkPrimary' : ''}`}
       >
         <Icon className='h-5 w-5' />
         <span className='hidden md:block'>{label}</span>

--- a/frontend/src/components/molecules/ApiKeyCreationModal.tsx
+++ b/frontend/src/components/molecules/ApiKeyCreationModal.tsx
@@ -79,10 +79,10 @@ export const ApiKeyCreationModal = ({
               leaveFrom='opacity-100 scale-100'
               leaveTo='opacity-0 scale-95'
             >
-              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all dark:bg-backgroundDark dark:bg-darkWhite'>
+              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-background p-6 text-left align-middle shadow-xl transition-all'>
                 <DialogTitle
                   as='h3'
-                  className='text-center text-lg font-medium leading-6 text-black dark:text-darkBlack'
+                  className='text-center text-lg font-medium leading-6 text-foreground'
                 >
                   Create API Key
                 </DialogTitle>

--- a/frontend/src/components/molecules/AuthModal.tsx
+++ b/frontend/src/components/molecules/AuthModal.tsx
@@ -42,7 +42,7 @@ export const AuthModal = ({ isOpen, onClose }: AuthModalProps) => {
               leaveFrom='opacity-100 scale-100'
               leaveTo='opacity-0 scale-95'
             >
-              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all dark:bg-darkWhite'>
+              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-background p-6 text-left align-middle shadow-xl transition-all'>
                 <div className='space-y-2'>
                   <DialogTitle className='text-center text-2xl font-bold'>
                     Welcome to Auto Drive

--- a/frontend/src/components/molecules/DefaultPasswordModal/index.tsx
+++ b/frontend/src/components/molecules/DefaultPasswordModal/index.tsx
@@ -70,7 +70,7 @@ export const DefaultPasswordModal = ({
               leaveFrom='opacity-100 scale-100'
               leaveTo='opacity-0 scale-95'
             >
-              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all dark:bg-darkWhite'>
+              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-background p-6 text-left align-middle shadow-xl transition-all'>
                 <DialogTitle
                   as='h3'
                   className='text-lg font-medium leading-6 text-gray-900 dark:text-gray-100'
@@ -87,14 +87,14 @@ export const DefaultPasswordModal = ({
                   value={newPassword}
                   onChange={(e) => setNewPassword(e.target.value)}
                   placeholder='New Password'
-                  className='mt-2 block w-full rounded-md border border-gray-300 p-2 shadow-sm dark:border-gray-600 dark:bg-darkWhite dark:text-gray-100'
+                  className='mt-2 block w-full rounded-md border border-gray-300 p-2 shadow-sm dark:border-gray-600 bg-background text-foreground'
                 />
                 <input
                   type='password'
                   value={confirmPassword}
                   onChange={(e) => setConfirmPassword(e.target.value)}
                   placeholder='Confirm Password'
-                  className='mt-2 block w-full rounded-md border border-gray-300 p-2 shadow-sm dark:border-gray-600 dark:bg-darkWhite dark:text-gray-100'
+                  className='mt-2 block w-full rounded-md border border-gray-300 p-2 shadow-sm dark:border-gray-600 bg-background text-foreground'
                 />
                 <div className='mt-4 flex justify-center gap-2'>
                   <Button

--- a/frontend/src/components/molecules/DeleteApiKeyModal.tsx
+++ b/frontend/src/components/molecules/DeleteApiKeyModal.tsx
@@ -64,7 +64,7 @@ export const DeleteApiKeyModal = ({
               leaveFrom='opacity-100 scale-100'
               leaveTo='opacity-0 scale-95'
             >
-              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left text-center align-middle shadow-xl transition-all dark:bg-darkWhite'>
+              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-background p-6 text-left text-center align-middle shadow-xl transition-all'>
                 <DialogTitle
                   as='h3'
                   className='text-lg font-medium leading-6 text-gray-900 dark:text-white'

--- a/frontend/src/components/molecules/FAQs/questions.tsx
+++ b/frontend/src/components/molecules/FAQs/questions.tsx
@@ -19,10 +19,10 @@ export const FAQ: FC = () => {
           {faqs.map((question, index) => (
             <div key={index} className='m-4'>
               <button
-                className='w-full rounded-lg bg-white p-8 text-left text-backgroundDark shadow-md dark:border-none dark:bg-darkWhite dark:text-darkBlack dark:text-white'
+                className='w-full rounded-lg bg-background p-8 text-left text-backgroundDark shadow-md dark:border-none dark:text-white'
                 onClick={() => toggleFAQ(index)}
               >
-                <span className='text-xl font-semibold text-black dark:text-darkBlack'>
+                <span className='text-xl font-semibold text-foreground'>
                   {index + 1}. {question.question}
                 </span>
                 <span className='float-right'>
@@ -31,7 +31,7 @@ export const FAQ: FC = () => {
               </button>
               {openIndex === index && (
                 <div className='mt-2 rounded-lg bg-gray-100 p-4 dark:bg-darkWhiteHover'>
-                  <p className='whitespace-pre-line text-black dark:text-darkBlack'>
+                  <p className='whitespace-pre-line text-foreground'>
                     {question.answer}
                   </p>
                 </div>

--- a/frontend/src/components/molecules/FileCard.tsx
+++ b/frontend/src/components/molecules/FileCard.tsx
@@ -90,14 +90,14 @@ export const FileCard = ({
         cid={isDownloadModalOpen ? cid : null}
         onClose={() => setIsDownloadModalOpen(false)}
       />
-      <div className='relative flex max-w-sm flex-1 flex-col text-ellipsis rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:bg-darkWhite'>
+      <div className='relative flex max-w-sm flex-1 flex-col text-ellipsis rounded-lg border border-gray-200 bg-background p-4 shadow-sm'>
         <div className='mb-4 flex items-start justify-between'>
           {objectIcon}
           <PopoverButton>
             <MoreVertical size={20} />
           </PopoverButton>
         </div>
-        <h2 className='mb-2 text-lg font-semibold text-gray-800 dark:text-darkBlack'>
+        <h2 className='mb-2 text-lg font-semibold text-gray-800 text-foreground'>
           {name ? shortenString(name, 20) : shortenString(cid, 20)}
         </h2>
         <p className='mb-4 text-gray-500'>Size: {bytes(Number(size))}</p>
@@ -117,10 +117,10 @@ export const FileCard = ({
             Open
           </button>
         )}
-        <PopoverPanel className='w-fit-content absolute right-0 top-0 divide-y divide-gray-200 rounded-xl bg-white text-sm/6 ring-1 ring-gray-200 transition duration-200 ease-in-out [--anchor-gap:var(--spacing-5)] data-[closed]:-translate-y-1 data-[closed]:opacity-0 dark:bg-darkWhite'>
+        <PopoverPanel className='w-fit-content absolute right-0 top-0 divide-y divide-gray-200 rounded-xl bg-background text-sm/6 ring-1 ring-gray-200 transition duration-200 ease-in-out [--anchor-gap:var(--spacing-5)] data-[closed]:-translate-y-1 data-[closed]:opacity-0'>
           <div className='flex w-40 flex-col gap-2 p-3'>
             <span
-              className='flex items-center gap-2 font-semibold text-black dark:text-darkBlack'
+              className='flex items-center gap-2 font-semibold text-foreground'
               onClick={handleDownloadClick}
               role='button'
               tabIndex={0}
@@ -135,7 +135,7 @@ export const FileCard = ({
                 role='button'
                 tabIndex={0}
                 onKeyDown={handleNavigateKeyDown}
-                className='flex items-center gap-2 font-semibold text-black dark:text-darkBlack'
+                className='flex items-center gap-2 font-semibold text-foreground'
                 onClick={handleNavigateClick}
               >
                 <FolderIcon size={16} />

--- a/frontend/src/components/molecules/NetworkDropdown/index.tsx
+++ b/frontend/src/components/molecules/NetworkDropdown/index.tsx
@@ -27,7 +27,7 @@ export const NetworkDropdown: FC<{
   return (
     <Listbox value={selected} onChange={onChange}>
       <div className='relative mt-1 w-36'>
-        <ListboxButton className='relative w-full cursor-default rounded-lg bg-white py-2 pl-3 pr-10 text-left shadow-md focus:outline-none focus-visible:border-indigo-500 focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 focus-visible:ring-offset-2 focus-visible:ring-offset-orange-300 sm:text-sm dark:bg-darkWhite dark:ring-1 dark:ring-darkBlackHover'>
+        <ListboxButton className='relative w-full cursor-default rounded-lg bg-background py-2 pl-3 pr-10 text-left shadow-md focus:outline-none focus-visible:border-indigo-500 focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 focus-visible:ring-offset-2 focus-visible:ring-offset-orange-300 sm:text-sm dark:ring-1 dark:ring-darkBlackHover'>
           <div className='flex items-center space-x-2'>
             <AutonomysSymbol />
             <span className='ml-2 block'>{selected.name}</span>
@@ -45,12 +45,12 @@ export const NetworkDropdown: FC<{
           leaveFrom='opacity-100'
           leaveTo='opacity-0'
         >
-          <ListboxOptions className='absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm dark:bg-darkWhite'>
+          <ListboxOptions className='absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-background py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm'>
             {Object.values(networks).map((network, personIdx) => (
               <ListboxOption
                 key={personIdx}
                 className={cn(
-                  'relative flex cursor-default select-none items-center justify-start gap-2 bg-white py-2 pl-4 pr-4 dark:bg-darkWhite',
+                  'relative flex cursor-default select-none items-center justify-start gap-2 bg-background py-2 pl-4 pr-4',
                   isActive(selected, network) ? 'bg-gray-100' : '',
                 )}
                 value={network}

--- a/frontend/src/components/molecules/NoUploadsPlaceholder.tsx
+++ b/frontend/src/components/molecules/NoUploadsPlaceholder.tsx
@@ -2,7 +2,7 @@ import { Disclaimer } from '@/components/atoms/Disclaimer';
 
 export const NoUploadsPlaceholder = () => {
   return (
-    <div className='mx-auto max-w-2xl rounded-lg bg-white p-6 dark:bg-darkWhite'>
+    <div className='mx-auto max-w-2xl rounded-lg bg-background p-6'>
       <h2 className='mb-4 text-center text-2xl font-bold'>
         Make your first upload
       </h2>

--- a/frontend/src/components/molecules/ObjectDeleteModal.tsx
+++ b/frontend/src/components/molecules/ObjectDeleteModal.tsx
@@ -80,7 +80,7 @@ export const ObjectDeleteModal = ({
               leaveFrom='opacity-100 scale-100'
               leaveTo='opacity-0 scale-95'
             >
-              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all dark:bg-darkWhite'>
+              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-background p-6 text-left align-middle shadow-xl transition-all'>
                 <DialogTitle
                   as='h3'
                   className='text-lg font-medium leading-6 text-gray-900 dark:text-gray-100'

--- a/frontend/src/components/molecules/ObjectDownloadModal.tsx
+++ b/frontend/src/components/molecules/ObjectDownloadModal.tsx
@@ -228,7 +228,7 @@ export const ObjectDownloadModal = ({
               leaveFrom='opacity-100 scale-100'
               leaveTo='opacity-0 scale-95'
             >
-              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all dark:bg-darkWhite'>
+              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-background p-6 text-left align-middle shadow-xl transition-all'>
                 {view}
               </DialogPanel>
             </TransitionChild>

--- a/frontend/src/components/molecules/ObjectReportModal.tsx
+++ b/frontend/src/components/molecules/ObjectReportModal.tsx
@@ -62,7 +62,7 @@ export const ObjectReportModal = ({
               leaveFrom='opacity-100 scale-100'
               leaveTo='opacity-0 scale-95'
             >
-              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all dark:bg-darkWhite'>
+              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-background p-6 text-left align-middle shadow-xl transition-all'>
                 <DialogTitle
                   as='h3'
                   className='text-center text-lg font-medium leading-6 text-gray-900 dark:text-gray-100'

--- a/frontend/src/components/molecules/ObjectRestoreModal.tsx
+++ b/frontend/src/components/molecules/ObjectRestoreModal.tsx
@@ -56,7 +56,7 @@ export const ObjectRestoreModal = ({
               leaveFrom='opacity-100 scale-100'
               leaveTo='opacity-0 scale-95'
             >
-              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all dark:bg-darkWhite'>
+              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-background p-6 text-left align-middle shadow-xl transition-all'>
                 <DialogTitle
                   as='h3'
                   className='text-center text-lg font-medium leading-6 text-gray-900'

--- a/frontend/src/components/molecules/ObjectShareModal.tsx
+++ b/frontend/src/components/molecules/ObjectShareModal.tsx
@@ -88,10 +88,10 @@ export const ObjectShareModal = ({
               leaveFrom='opacity-100 scale-100'
               leaveTo='opacity-0 scale-95'
             >
-              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all dark:bg-darkWhite'>
+              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-background p-6 text-left align-middle shadow-xl transition-all'>
                 <DialogTitle
                   as='h3'
-                  className='text-lg font-medium leading-6 text-gray-900 dark:text-darkBlack'
+                  className='text-lg font-medium leading-6 text-gray-900 text-foreground'
                 >
                   Share &quot;{metadata?.metadata.name}&quot;
                 </DialogTitle>

--- a/frontend/src/components/molecules/ProfileDropdown.tsx
+++ b/frontend/src/components/molecules/ProfileDropdown.tsx
@@ -43,7 +43,7 @@ export const ProfileDropdown: React.FC = () => {
               className='h-9 w-9 rounded-full border border-gray-100 shadow-lg dark:border-gray-500'
             />
           ) : (
-            <div className='flex h-9 w-9 items-center justify-center rounded-full border border-gray-100 bg-gray-300 text-white shadow-lg dark:border-gray-500 dark:bg-darkWhite'>
+            <div className='flex h-9 w-9 items-center justify-center rounded-full border border-gray-100 bg-gray-300 text-white shadow-lg dark:border-gray-500'>
               <UserRoundIcon className='h-6 w-6' />
             </div>
           )}
@@ -51,7 +51,7 @@ export const ProfileDropdown: React.FC = () => {
       </button>
 
       {isOpen && (
-        <div className='absolute right-0 z-50 mt-2 w-48 origin-top-right rounded-md border border-gray-200 bg-white shadow-lg dark:border-gray-500 dark:bg-darkWhite'>
+        <div className='absolute right-0 z-50 mt-2 w-48 origin-top-right rounded-md border border-gray-200 bg-background shadow-lg dark:border-gray-500'>
           <div className='border-b border-gray-100 px-4 py-3 dark:border-gray-700'>
             <p className='break-words text-sm font-medium'>
               {user?.oauthUsername || 'Anonymous'}

--- a/frontend/src/components/molecules/SearchBar/index.tsx
+++ b/frontend/src/components/molecules/SearchBar/index.tsx
@@ -23,12 +23,12 @@ export const SearchBar = ({ scope }: { scope: 'global' | 'user' }) => {
   }, [scope]);
 
   return (
-    <div className='w-full max-w-md dark:text-darkBlack'>
+    <div className='w-full max-w-md text-foreground'>
       <div className='relative mt-1'>
         <div className='relative h-fit min-w-80'>
           <input
             type='text'
-            className='w-full rounded-lg border border-[#BCC1CA] bg-white py-[.65rem] pl-3 pr-10 text-sm leading-5 text-black text-gray-900 placeholder:text-black focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:bg-darkWhite dark:text-darkBlack dark:placeholder:text-darkBlack'
+            className='w-full rounded-lg border border-[#BCC1CA] bg-background py-[.65rem] pl-3 pr-10 text-sm leading-5 text-foreground text-gray-900 placeholder:text-foreground focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500'
             value={inputValue}
             onChange={(e) => {
               setInputValue(e.target.value);

--- a/frontend/src/components/molecules/Table/TableBody.tsx
+++ b/frontend/src/components/molecules/Table/TableBody.tsx
@@ -17,7 +17,7 @@ export const TableBodyRow = ({
   return (
     <tr
       className={cn(
-        'w-full border-t border-gray-200 bg-white hover:bg-gray-50 dark:bg-darkWhite dark:hover:bg-darkWhiteHover',
+        'w-full border-t border-gray-200 bg-background hover:bg-gray-50 dark:hover:bg-darkWhiteHover',
         className,
       )}
       onClick={onClick}
@@ -39,7 +39,7 @@ export const TableBodyCell = ({
   return (
     <td
       className={cn(
-        'px-6 py-4 text-sm text-gray-700 dark:text-darkBlack',
+        'px-6 py-4 text-sm text-gray-700 text-foreground',
         className,
       )}
       colSpan={colSpan}

--- a/frontend/src/components/molecules/Table/TableHead.tsx
+++ b/frontend/src/components/molecules/Table/TableHead.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from 'react';
 import { cn } from '@/utils/cn';
 export const TableHead = ({ children }: { children: ReactNode }) => {
   return (
-    <thead className='rounded-lg bg-white font-semibold text-primary dark:bg-darkWhite'>
+    <thead className='rounded-lg bg-background font-semibold text-primary'>
       {children}
     </thead>
   );
@@ -25,7 +25,7 @@ export const TableHeadCell = ({
     <th
       scope='col'
       className={cn(
-        'rounded-lg px-6 py-3 text-left text-xs uppercase tracking-wider dark:text-darkBlack',
+        'rounded-lg px-6 py-3 text-left text-xs uppercase tracking-wider text-foreground',
         className,
       )}
       onClick={onClick}

--- a/frontend/src/components/molecules/UploadButton/index.tsx
+++ b/frontend/src/components/molecules/UploadButton/index.tsx
@@ -63,7 +63,7 @@ export const UploadButton = () => {
           </Button>
         </PopoverButton>
         <PopoverPanel className='relative'>
-          <div className='absolute left-0 top-1 flex text-nowrap rounded-md bg-white text-black shadow-lg ring-1 ring-black ring-opacity-5 dark:bg-darkWhiteHover dark:text-darkBlack'>
+          <div className='absolute left-0 top-1 flex text-nowrap rounded-md bg-background text-foreground shadow-lg ring-1 ring-black ring-opacity-5 dark:bg-darkWhiteHover'>
             <div className='p-1'>
               <button
                 onClick={openFileDialog}

--- a/frontend/src/components/molecules/UploadingFileModal.tsx
+++ b/frontend/src/components/molecules/UploadingFileModal.tsx
@@ -182,7 +182,7 @@ export const UploadingFileModal = ({
     <Transition show={!!files && files.length > 0}>
       <Dialog as='div' onClose={handleClose}>
         <div className='fixed inset-0 flex items-center justify-center bg-black/25 bg-opacity-50 dark:bg-darkBlack/25'>
-          <div className='min-w-[400px] max-w-[600px] transform rounded-lg bg-white p-6 shadow-lg transition-transform dark:bg-darkWhite'>
+          <div className='min-w-[400px] max-w-[600px] transform rounded-lg bg-background p-6 shadow-lg transition-transform'>
             {tooManyFiles ? (
               <div className='p-4'>
                 <div className='mb-4 text-center font-medium text-red-500'>
@@ -271,7 +271,7 @@ export const UploadingFileModal = ({
             ) : (
               <div>
                 <div className='flex flex-col gap-2 p-4'>
-                  <span className='text-md block text-center font-semibold text-gray-700 dark:text-darkBlack'>
+                  <span className='text-md block text-center font-semibold text-gray-700 text-foreground'>
                     Enter Encrypting Password
                   </span>
                   {totalFiles > 1 ? (

--- a/frontend/src/components/molecules/UploadingFolderModal.tsx
+++ b/frontend/src/components/molecules/UploadingFolderModal.tsx
@@ -54,8 +54,8 @@ export const UploadingFolderModal = ({
     <Transition show={!!data}>
       <Dialog as='div' onClose={onClose}>
         <div className='fixed inset-0 flex items-center justify-center bg-black/25 dark:bg-darkBlack/25'>
-          <div className='min-w-[25%] transform rounded-lg bg-white p-6 shadow-lg transition-transform dark:bg-darkWhite'>
-            <h3 className='mb-4 text-center text-lg font-medium dark:text-darkBlack'>
+          <div className='min-w-[25%] transform rounded-lg bg-background p-6 shadow-lg transition-transform'>
+            <h3 className='mb-4 text-center text-lg font-medium text-foreground'>
               Uploading Folder
             </h3>
             {passwordConfirmed ? (
@@ -78,7 +78,7 @@ export const UploadingFolderModal = ({
             ) : (
               <div>
                 <div className='flex flex-col gap-2 p-4'>
-                  <span className='text-md block text-center font-semibold text-gray-700 dark:text-darkBlack'>
+                  <span className='text-md block text-center font-semibold text-gray-700 text-foreground'>
                     Enter Encrypting Password
                   </span>
                   <input

--- a/frontend/src/components/organisms/FileTable/FileTableRow.tsx
+++ b/frontend/src/components/organisms/FileTable/FileTableRow.tsx
@@ -232,13 +232,13 @@ export const FileTableRow = ({
                 {isRowExpanded ? (
                   <Triangle className='rotate-90 text-accent' />
                 ) : (
-                  <Triangle className='text-black dark:text-darkBlack' />
+                  <Triangle className='text-foreground' />
                 )}
               </button>
             )}
             <Link
               href={fileDetailPath(network.id, file.headCid)}
-              className='relative ml-2 flex flex-row items-center text-sm font-medium text-gray-900 dark:text-darkBlack'
+              className='relative ml-2 flex flex-row items-center text-sm font-medium text-gray-900 text-foreground'
             >
               {file.type === 'folder' ? (
                 <Folder className='mr-2 h-5 w-5 text-gray-400' />
@@ -307,7 +307,7 @@ export const FileTableRow = ({
 
             {showActionsMenu && (
               <div
-                className='absolute right-0 top-full z-10 mt-1 w-36 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 dark:bg-darkWhite'
+                className='absolute right-0 top-full z-10 mt-1 w-36 rounded-md bg-background shadow-lg ring-1 ring-black ring-opacity-5'
                 ref={actionsMenuRef}
               >
                 <div className='py-1' role='menu' aria-orientation='vertical'>

--- a/frontend/src/components/organisms/FileTable/TablePaginator.tsx
+++ b/frontend/src/components/organisms/FileTable/TablePaginator.tsx
@@ -77,11 +77,11 @@ export const TablePaginator = () => {
   };
 
   return (
-    <div className='flex w-full items-center justify-between p-4 text-sm text-light-gray dark:text-darkBlack'>
+    <div className='flex w-full items-center justify-between p-4 text-sm text-light-gray text-foreground'>
       <div className='flex items-center'>
         <span className='mr-2'>Items per page:</span>
         <select
-          className='rounded border border-gray-300 bg-gray-100 p-1 pr-1 dark:bg-darkWhite'
+          className='rounded border border-gray-300 bg-gray-100 p-1 pr-1 bg-background'
           value={limit}
           onChange={(e) => setLimit(parseInt(e.target.value))}
         >
@@ -102,7 +102,7 @@ export const TablePaginator = () => {
       <div className='flex items-center gap-2'>
         <button
           disabled={page === 0}
-          className='cursor-pointer rounded-md border border-light-gray p-2 text-black transition-all hover:scale-[102%] disabled:opacity-50 dark:text-darkBlack'
+          className='cursor-pointer rounded-md border border-light-gray p-2 text-foreground transition-all hover:scale-[102%] disabled:opacity-50'
           onClick={() => setInternalPage(0)}
           title='First page'
         >
@@ -110,7 +110,7 @@ export const TablePaginator = () => {
         </button>
         <button
           disabled={page === 0}
-          className='cursor-pointer rounded-md border border-light-gray p-2 text-black transition-all hover:scale-[102%] disabled:opacity-50 dark:text-darkBlack'
+          className='cursor-pointer rounded-md border border-light-gray p-2 text-foreground transition-all hover:scale-[102%] disabled:opacity-50'
           onClick={() => setInternalPage(page - 1)}
           title='Previous page'
         >
@@ -123,14 +123,14 @@ export const TablePaginator = () => {
             onChange={handlePageInputChange}
             onBlur={goToPage}
             onKeyDown={handleKeyDown}
-            className='w-12 rounded border border-gray-300 p-1.5 text-center focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:bg-darkWhite dark:text-darkBlack'
+            className='w-12 rounded border border-gray-300 p-1.5 text-center focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 bg-background text-foreground'
             aria-label='Page number'
           />
           <span>of {isLimitUnknown ? `${totalPages}+` : totalPages}</span>
         </div>
         <button
           disabled={page >= totalPages - 1}
-          className='cursor-pointer rounded-md border border-light-gray p-2 text-black transition-all hover:scale-[102%] disabled:opacity-50 dark:text-darkBlack'
+          className='cursor-pointer rounded-md border border-light-gray p-2 text-foreground transition-all hover:scale-[102%] disabled:opacity-50'
           onClick={() => setInternalPage(page + 1)}
           title='Next page'
         >
@@ -138,7 +138,7 @@ export const TablePaginator = () => {
         </button>
         <button
           disabled={page >= totalPages - 1}
-          className='cursor-pointer rounded-md border border-light-gray p-2 text-black transition-all hover:scale-[102%] disabled:opacity-50 dark:text-darkBlack'
+          className='cursor-pointer rounded-md border border-light-gray p-2 text-foreground transition-all hover:scale-[102%] disabled:opacity-50'
           onClick={() => setInternalPage(totalPages - 1)}
           title='Last page'
         >

--- a/frontend/src/components/organisms/FilesToBeReviewed/ReviewFilesRow.tsx
+++ b/frontend/src/components/organisms/FilesToBeReviewed/ReviewFilesRow.tsx
@@ -143,7 +143,7 @@ export const ToBeReviewedFileRow = ({ headCid }: { headCid: string }) => {
                 leaveFrom='opacity-100 scale-100'
                 leaveTo='opacity-0 scale-95'
               >
-                <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all dark:bg-darkWhite'>
+                <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-background p-6 text-left align-middle shadow-xl transition-all'>
                   <DialogTitle
                     as='h3'
                     className='text-lg font-medium leading-6 text-gray-900 dark:text-gray-100'
@@ -199,7 +199,7 @@ export const ToBeReviewedFileRow = ({ headCid }: { headCid: string }) => {
                 leaveFrom='opacity-100 scale-100'
                 leaveTo='opacity-0 scale-95'
               >
-                <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all dark:bg-darkWhite'>
+                <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-background p-6 text-left align-middle shadow-xl transition-all'>
                   <DialogTitle
                     as='h3'
                     className='text-lg font-medium leading-6 text-gray-900 dark:text-gray-100'

--- a/frontend/src/components/organisms/FilesToBeReviewed/index.tsx
+++ b/frontend/src/components/organisms/FilesToBeReviewed/index.tsx
@@ -103,7 +103,7 @@ export const ToBeReviewedFiles = () => {
               leaveFrom='opacity-100 scale-100'
               leaveTo='opacity-0 scale-95'
             >
-              <DialogPanel className='inline-block flex h-[60vh] w-full max-w-md transform flex-col justify-between overflow-y-scroll rounded-2xl bg-backgroundLight bg-white p-6 text-left align-middle shadow-xl transition-all dark:bg-darkWhiteHover'>
+              <DialogPanel className='inline-block flex h-[60vh] w-full max-w-md transform flex-col justify-between overflow-y-scroll rounded-2xl bg-backgroundLight bg-background p-6 text-left align-middle shadow-xl transition-all dark:bg-darkWhiteHover'>
                 <div>
                   <DialogTitle
                     as='h3'

--- a/frontend/src/components/organisms/ObjectDetails/ObjectUploadDetails.tsx
+++ b/frontend/src/components/organisms/ObjectDetails/ObjectUploadDetails.tsx
@@ -21,7 +21,7 @@ export const ObjectUploadDetails = ({
 
   return (
     <div className='grid grid-cols-1 gap-6 md:grid-cols-2'>
-      <div className='rounded-lg border border-gray-200 p-6 dark:border-gray-200 dark:bg-darkWhite'>
+      <div className='rounded-lg border border-gray-200 p-6 dark:border-gray-200 bg-background'>
         <h2 className='mb-4 flex items-center text-lg font-medium text-gray-900 dark:text-gray-100'>
           <IconWithTooltip
             icon={
@@ -110,7 +110,7 @@ export const ObjectUploadDetails = ({
           </div>
         </div>
       </div>
-      <div className='rounded-lg border border-gray-200 p-6 dark:bg-darkWhite'>
+      <div className='rounded-lg border border-gray-200 p-6 bg-background'>
         <h2 className='mb-4 flex items-center text-lg font-medium text-gray-900 dark:text-gray-100'>
           <IconWithTooltip
             icon={<CloudArrowUpIcon className='mr-2 h-5 w-5 text-gray-500' />}

--- a/frontend/src/components/organisms/ObjectDetails/ObjectUploadOptions.tsx
+++ b/frontend/src/components/organisms/ObjectDetails/ObjectUploadOptions.tsx
@@ -8,7 +8,7 @@ export const ObjectUploadOptions = ({
   object: ObjectInformation;
 }) => {
   return (
-    <div className='rounded-lg border border-gray-200 p-6 dark:border-gray-200 dark:bg-darkWhite'>
+    <div className='rounded-lg border border-gray-200 p-6 dark:border-gray-200 bg-background'>
       <h2 className='mb-4 flex items-center text-lg font-medium text-gray-900 dark:text-gray-100'>
         <IconWithTooltip
           icon={

--- a/frontend/src/components/organisms/ObjectDetails/index.tsx
+++ b/frontend/src/components/organisms/ObjectDetails/index.tsx
@@ -60,7 +60,7 @@ export const ObjectDetails = ({
       </div>
       <ObjectUploadDetails object={object} isOwner={isOwner} />
       <ObjectUploadOptions object={object} />
-      <div className='rounded-lg border border-gray-200 p-6 dark:bg-darkWhite'>
+      <div className='rounded-lg border border-gray-200 p-6 bg-background'>
         <h2 className='mb-4 text-lg font-medium text-gray-900 dark:text-gray-100'>
           Preview
         </h2>

--- a/frontend/src/components/organisms/UserAsyncDownloads/index.tsx
+++ b/frontend/src/components/organisms/UserAsyncDownloads/index.tsx
@@ -117,7 +117,7 @@ export const UserAsyncDownloads = () => {
               leaveFrom='opacity-100 scale-100'
               leaveTo='opacity-0 scale-95'
             >
-              <DialogPanel className='inline-block flex h-[60vh] w-full max-w-md transform flex-col justify-between overflow-y-scroll rounded-2xl bg-backgroundLight bg-white p-6 text-left align-middle shadow-xl transition-all dark:bg-darkWhiteHover'>
+              <DialogPanel className='inline-block flex h-[60vh] w-full max-w-md transform flex-col justify-between overflow-y-scroll rounded-2xl bg-backgroundLight bg-background p-6 text-left align-middle shadow-xl transition-all dark:bg-darkWhiteHover'>
                 <div>
                   <DialogTitle
                     as='h3'

--- a/frontend/src/components/organisms/UserTable/CreditsUpdateModal.tsx
+++ b/frontend/src/components/organisms/UserTable/CreditsUpdateModal.tsx
@@ -92,10 +92,10 @@ export const CreditsUpdateModal = ({
               leaveFrom='opacity-100 scale-100'
               leaveTo='opacity-0 scale-95'
             >
-              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all dark:bg-darkWhite'>
+              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-background p-6 text-left align-middle shadow-xl transition-all'>
                 <DialogTitle
                   as='h3'
-                  className='text-lg font-medium leading-6 text-black dark:text-darkBlack'
+                  className='text-lg font-medium leading-6 text-foreground'
                 >
                   Update credits
                 </DialogTitle>
@@ -110,7 +110,7 @@ export const CreditsUpdateModal = ({
                         onChange={(e) => setDownloadCredits(e.target.value)}
                       />
                       <select
-                        className='rounded border border-gray-300 bg-white px-2 py-1 text-black dark:bg-darkWhite dark:text-darkBlack dark:ring-1 dark:ring-darkWhiteHover'
+                        className='rounded border border-gray-300 bg-background px-2 py-1 text-foreground dark:ring-1 dark:ring-darkWhiteHover'
                         value={downloadCreditsUnit}
                         onChange={(e) =>
                           setDownloadCreditsUnit(Number(e.target.value))
@@ -129,8 +129,8 @@ export const CreditsUpdateModal = ({
                         value={uploadCredits}
                         onChange={(e) => setUploadCredits(e.target.value)}
                       />
-                      <select
-                        className='rounded border border-gray-300 bg-white px-2 py-1 text-black dark:bg-darkWhite dark:text-darkBlack dark:ring-1 dark:ring-darkWhiteHover'
+                                              <select
+                        className='rounded border border-gray-300 bg-background px-2 py-1 text-foreground dark:ring-1 dark:ring-darkWhiteHover'
                         value={uploadCreditsUnit}
                         onChange={(e) =>
                           setUploadCreditsUnit(Number(e.target.value))

--- a/frontend/src/components/organisms/UserTable/UpdateRoleModal.tsx
+++ b/frontend/src/components/organisms/UserTable/UpdateRoleModal.tsx
@@ -59,10 +59,10 @@ export const UpdateRoleModal = ({
               leaveFrom='opacity-100 scale-100'
               leaveTo='opacity-0 scale-95'
             >
-              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all dark:bg-darkWhite'>
+              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-background p-6 text-left align-middle shadow-xl transition-all'>
                 <DialogTitle
                   as='h3'
-                  className='text-lg font-medium leading-6 text-black dark:text-darkBlack'
+                  className='text-lg font-medium leading-6 text-foreground'
                 >
                   Update user role
                 </DialogTitle>
@@ -70,7 +70,7 @@ export const UpdateRoleModal = ({
                   <div className='space-y-4'>
                     <div>
                       <select
-                        className='rounded border border-gray-300 bg-white px-2 py-1 text-black dark:bg-darkWhite dark:text-darkBlack dark:ring-1 dark:ring-darkWhiteHover'
+                        className='rounded border border-gray-300 bg-background px-2 py-1 text-foreground dark:ring-1 dark:ring-darkWhiteHover'
                         value={role}
                         onChange={(e) => setRole(e.target.value as UserRole)}
                       >

--- a/frontend/src/components/organisms/UserTable/UserTableRow.tsx
+++ b/frontend/src/components/organisms/UserTable/UserTableRow.tsx
@@ -57,7 +57,7 @@ export const UserTableRow = ({ subscriptionWithUser }: UserTableRowProps) => {
           role='button'
           tabIndex={0}
           onKeyDown={handleEnterOrSpace(copyToClipboard)}
-          className='flex cursor-pointer items-center gap-2 text-sm text-black transition-colors duration-200 hover:text-blue-500 dark:text-darkBlack'
+          className='flex cursor-pointer items-center gap-2 text-sm text-foreground transition-colors duration-200 hover:text-blue-500'
           onClick={copyToClipboard}
         >
           {shortenString(subscriptionWithUser.user.publicId!, 16)}{' '}
@@ -65,43 +65,43 @@ export const UserTableRow = ({ subscriptionWithUser }: UserTableRowProps) => {
         </div>
       </TableBodyCell>
       <TableBodyCell>
-        <div className='text-sm text-black dark:text-darkBlack'>
+        <div className='text-sm text-foreground'>
           {subscriptionWithUser.user.oauthProvider}
         </div>
       </TableBodyCell>
       <TableBodyCell>
-        <div className='flex items-center gap-2 text-sm text-black dark:text-darkBlack'>
+        <div className='flex items-center gap-2 text-sm text-foreground'>
           {subscriptionWithUser.user.role}
         </div>
       </TableBodyCell>
       <TableBodyCell>
-        <div className='text-sm text-black dark:text-darkBlack'>
+        <div className='text-sm text-foreground'>
           {granularity}
         </div>
       </TableBodyCell>
       <TableBodyCell>
-        <div className='text-sm text-black dark:text-darkBlack'>
+        <div className='text-sm text-foreground'>
           {bytes(Number(subscriptionWithUser.uploadLimit), {
             unitSeparator: ' ',
           })}
         </div>
       </TableBodyCell>
       <TableBodyCell>
-        <div className='text-sm text-black dark:text-darkBlack'>
+        <div className='text-sm text-foreground'>
           {bytes(Number(subscriptionWithUser.pendingUploadCredits || 0), {
             unitSeparator: ' ',
           })}
         </div>
       </TableBodyCell>
       <TableBodyCell>
-        <div className='text-sm text-black dark:text-darkBlack'>
+        <div className='text-sm text-foreground'>
           {bytes(Number(subscriptionWithUser.downloadLimit), {
             unitSeparator: ' ',
           })}
         </div>
       </TableBodyCell>
       <TableBodyCell>
-        <div className='text-sm text-black dark:text-darkBlack'>
+        <div className='text-sm text-foreground'>
           {bytes(Number(subscriptionWithUser.pendingDownloadCredits || 0), {
             unitSeparator: ' ',
           })}

--- a/frontend/src/components/organisms/UserTable/index.tsx
+++ b/frontend/src/components/organisms/UserTable/index.tsx
@@ -62,7 +62,7 @@ export const UserSubscriptionsTable = ({
                   <TableBodyRow>
                     <TableBodyCell
                       colSpan={9}
-                      className='whitespace-nowrap px-6 py-4 text-center text-sm text-black dark:text-darkBlack'
+                      className='whitespace-nowrap px-6 py-4 text-center text-sm text-foreground'
                     >
                       <span className='flex items-center justify-center'>
                         <Loader className='h-4 w-4 animate-spin' />
@@ -77,7 +77,7 @@ export const UserSubscriptionsTable = ({
       </div>
 
       {/* Pagination Controls */}
-      <div className='mt-4 flex items-center justify-between border-t border-gray-200 bg-white px-4 py-3 sm:px-6 dark:bg-gray-800'>
+      <div className='mt-4 flex items-center justify-between border-t border-gray-200 bg-background px-4 py-3 sm:px-6 dark:bg-gray-800'>
         <div className='flex items-center'>
           <label
             htmlFor='itemsPerPage'
@@ -116,7 +116,7 @@ export const UserSubscriptionsTable = ({
           <button
             onClick={() => onPageChange(currentPage - 1)}
             disabled={currentPage === 1}
-            className='relative inline-flex items-center rounded-md border border-gray-300 bg-white px-2 py-1 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300'
+            className='relative inline-flex items-center rounded-md border border-gray-300 bg-background px-2 py-1 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300'
           >
             <ChevronLeft className='h-4 w-4' />
           </button>
@@ -126,7 +126,7 @@ export const UserSubscriptionsTable = ({
           <button
             onClick={() => onPageChange(currentPage + 1)}
             disabled={currentPage === totalPages || totalPages === 0}
-            className='relative inline-flex items-center rounded-md border border-gray-300 bg-white px-2 py-1 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300'
+            className='relative inline-flex items-center rounded-md border border-gray-300 bg-background px-2 py-1 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300'
           >
             <ChevronRight className='h-4 w-4' />
           </button>

--- a/frontend/src/components/views/Onboarding/index.tsx
+++ b/frontend/src/components/views/Onboarding/index.tsx
@@ -22,20 +22,20 @@ export const Onboarding = () => {
   }, []);
 
   return (
-    <div className='flex h-screen flex-col items-center justify-center bg-white dark:bg-darkWhite'>
+    <div className='flex h-screen flex-col items-center justify-center bg-background'>
       <header className='mb-8 flex flex-col items-center justify-between gap-4 md:flex-row md:gap-0'>
-        <div className='flex items-center space-x-2 text-black dark:text-darkBlack'>
+        <div className='flex items-center space-x-2 text-foreground'>
           <AutonomysSymbol />
           <span className='text-xl font-semibold'>Auto Drive</span>
         </div>
       </header>
-      <div className='flex flex-col items-center gap-4 dark:text-darkBlack'>
+      <div className='flex flex-col items-center gap-4 text-foreground'>
         <Disclaimer />
         <div className='flex items-center gap-2'>
           <Checkbox
             checked={accepted}
             onChange={() => setAccepted((e) => !e)}
-            className='group relative block size-4 rounded border bg-white data-[checked]:bg-blue-500 dark:bg-darkWhite'
+            className='group relative block size-4 rounded border bg-background data-[checked]:bg-blue-500'
           >
             <CheckIcon className='absolute left-1/2 top-1/2 h-2 w-2 -translate-x-1/2 -translate-y-1/2 stroke-white opacity-0 group-data-[checked]:opacity-100' />
           </Checkbox>

--- a/frontend/src/components/views/SearchResult/index.tsx
+++ b/frontend/src/components/views/SearchResult/index.tsx
@@ -23,7 +23,7 @@ export const SearchResult = ({ objects }: { objects: BaseMetadata[] }) => {
           />
         ))
       ) : (
-        <div className='flex h-[50%] w-full flex-col items-center justify-center text-center text-xl text-gray-500 dark:text-darkBlack'>
+        <div className='flex h-[50%] w-full flex-col items-center justify-center text-center text-xl text-gray-500 text-foreground'>
           No objects found!
         </div>
       )}

--- a/frontend/src/components/views/SharedFiles/NoSharedFilesPlaceholder.tsx
+++ b/frontend/src/components/views/SharedFiles/NoSharedFilesPlaceholder.tsx
@@ -1,6 +1,6 @@
 export const NoSharedFilesPlaceholder = () => {
   return (
-    <div className='dark:bg-darkWhite mx-auto max-w-2xl rounded-lg bg-white p-6'>
+    <div className='mx-auto max-w-2xl rounded-lg bg-background p-6'>
       <h2 className='mb-4 text-center text-2xl font-bold'>
         No files have been shared with you yet
       </h2>

--- a/frontend/src/components/views/TrashFiles/NoFilesInTrashPlaceholder.tsx
+++ b/frontend/src/components/views/TrashFiles/NoFilesInTrashPlaceholder.tsx
@@ -1,6 +1,6 @@
 export const NoFilesInTrashPlaceholder = () => {
   return (
-    <div className='dark:bg-darkWhite mx-auto max-w-2xl rounded-lg bg-white p-6'>
+    <div className='mx-auto max-w-2xl rounded-lg bg-background p-6'>
       <h2 className='mb-4 text-center text-2xl font-bold'>No files in trash</h2>
       <p className='mb-6 text-center'>Files you remove will appear here.</p>
     </div>


### PR DESCRIPTION
Unify dark mode styling by replacing legacy `bg-white`/`text-black` and `dark:bg-darkWhite`/`dark:text-darkBlack` classes with `bg-background` and `text-foreground` tokens to ensure consistent theming and improve maintainability.

---
<a href="https://cursor.com/background-agent?bcId=bc-ee8ae473-ddc2-4d2f-8b23-dba0d0a18409">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ee8ae473-ddc2-4d2f-8b23-dba0d0a18409">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

