### PR TITLE
[FrontEnd] Fix callback on network change

### DIFF
--- a/frontend/src/components/organisms/TopNavbar.tsx
+++ b/frontend/src/components/organisms/TopNavbar.tsx
@@ -28,7 +28,7 @@ export const TopNavbar = ({ networkId }: TopNavbarProps) => {
           <NetworkDropdown
             selected={network}
             onChange={(value) => {
-              window.location.assign(`/${value.id}/drive`);
+              window.location.assign(`/${value.id}/drive/global`);
             }}
           />
           {user && <ProfileDropdown />}


### PR DESCRIPTION


The problem is that previously the default tab in auto-drive dashboard was "My Files" but since now users may not be logged in should be "File Explorer"

Solution: On network change to "File Explorer" route