### PR TITLE
Support `one_off` granularity

### DIFF
--- a/apps/backend/src/app/controllers/subscriptions.ts
+++ b/apps/backend/src/app/controllers/subscriptions.ts
@@ -8,6 +8,8 @@ import {
   handleInternalErrorResult,
 } from '../../shared/utils/neverthrow.js'
 import { handleError } from '../../errors/index.js'
+import { SubscriptionGranularity } from '@auto-drive/models'
+import { z } from 'zod'
 
 const logger = createLogger('http:controllers:subscriptions')
 
@@ -98,8 +100,10 @@ subscriptionController.post(
       return
     }
 
-    if (granularity !== 'monthly') {
-      // TODO: support other granularities
+    const safeGranularity = z
+      .nativeEnum(SubscriptionGranularity)
+      .safeParse(granularity)
+    if (!safeGranularity.success) {
       res.status(400).json({
         error: 'Invalid granularity',
       })
@@ -110,7 +114,7 @@ subscriptionController.post(
       SubscriptionsUseCases.updateSubscription(
         executor,
         publicId,
-        granularity,
+        safeGranularity.data,
         uploadLimit,
         downloadLimit,
       ),

--- a/apps/backend/src/config.ts
+++ b/apps/backend/src/config.ts
@@ -1,4 +1,5 @@
 import 'dotenv/config'
+import { SubscriptionGranularity } from '@auto-drive/models'
 import { optionalBoolEnvironmentVariable, env } from './shared/utils/misc.js'
 
 const DEFAULT_MAX_CACHE_SIZE = BigInt(10 * 1024 ** 3)
@@ -66,7 +67,10 @@ export const config = {
     ),
     optionalAuth: env('OPTIONAL_AUTH', 'false') === 'true',
     defaultSubscription: {
-      granularity: env('DEFAULT_SUBSCRIPTION_GRANULARITY', 'monthly'),
+      granularity: env(
+        'DEFAULT_SUBSCRIPTION_GRANULARITY',
+        SubscriptionGranularity.OneOff,
+      ),
       uploadLimit: Number(
         env('DEFAULT_SUBSCRIPTION_UPLOAD_LIMIT', ONE_HUNDRED_MiB.toString()),
       ),

--- a/apps/backend/src/core/users/subscriptions.ts
+++ b/apps/backend/src/core/users/subscriptions.ts
@@ -120,7 +120,11 @@ const getPendingCreditsBySubscriptionAndType = async (
   type: InteractionType,
 ): Promise<number> => {
   const end = new Date()
-  const start = new Date(end.getFullYear(), end.getMonth(), 1, 0, 0, 0, 0)
+  const start =
+    subscription.granularity === SubscriptionGranularity.Monthly
+      ? new Date(end.getFullYear(), end.getMonth(), 1, 0, 0, 0, 0)
+      : new Date(0)
+
   const interactions =
     await interactionsRepository.getInteractionsBySubscriptionIdAndTypeInTimeRange(
       subscription.id,

--- a/apps/backend/src/docs/reference/subscriptions.ts
+++ b/apps/backend/src/docs/reference/subscriptions.ts
@@ -51,7 +51,7 @@ export const subscriptions = {
           organizationId: { type: 'string' },
           uploadLimit: { type: 'number' },
           downloadLimit: { type: 'number' },
-          granularity: { type: 'string', enum: ['monthly'] },
+          granularity: { type: 'string', enum: ['monthly', 'one_off'] },
           pendingUploadCredits: { type: 'number' },
           pendingDownloadCredits: { type: 'number' },
         },

--- a/apps/frontend/src/components/molecules/AccountInformation/index.tsx
+++ b/apps/frontend/src/components/molecules/AccountInformation/index.tsx
@@ -1,13 +1,16 @@
 import bytes from 'bytes';
 import { utcToLocalRelativeTime } from '../../../utils/time';
+import { SubscriptionGranularity } from '@auto-drive/models';
 
 interface CreditLimitsProps {
   uploadPending: number;
   uploadLimit: number;
   renewalDate: Date;
+  granularity: SubscriptionGranularity;
 }
 
 export const AccountInformation = ({
+  granularity,
   uploadPending = 0,
   uploadLimit = 1000,
   renewalDate,
@@ -18,7 +21,7 @@ export const AccountInformation = ({
 
   return (
     <div className='space-y-2'>
-      <div className='text-muted-foreground text-xs'>Upload usage</div>
+      <div className='text-xs text-muted-foreground'>Upload usage</div>
       <div className='space-y-1'>
         <div className='flex justify-between text-xs'>
           <span>{bytes(uploadPending)} left</span>
@@ -26,16 +29,18 @@ export const AccountInformation = ({
             {bytes(uploadUsed)}/{bytes(uploadLimit)}
           </span>
         </div>
-        <div className='bg-muted h-1.5 w-full rounded-full'>
+        <div className='h-1.5 w-full rounded-full bg-muted'>
           <div
             className='h-1.5 rounded-full bg-primary'
             style={{ width: `${uploadPercentage}%` }}
           ></div>
         </div>
       </div>
-      <p className='text-muted-foreground space-y-2 text-xs'>
-        Renews in {utcToLocalRelativeTime(renewalDate.toISOString())}
-      </p>
+      {granularity === SubscriptionGranularity.Monthly && (
+        <p className='space-y-2 text-xs text-muted-foreground'>
+          Renews in {utcToLocalRelativeTime(renewalDate.toISOString())}
+        </p>
+      )}
     </div>
   );
 };

--- a/apps/frontend/src/components/organisms/SideNavBar/index.tsx
+++ b/apps/frontend/src/components/organisms/SideNavBar/index.tsx
@@ -7,7 +7,7 @@ import {
   SidebarContent,
 } from '../../molecules/Sidebar';
 import { useUserStore } from '../../../globalStates/user';
-import { UserRole } from '@auto-drive/models';
+import { SubscriptionGranularity, UserRole } from '@auto-drive/models';
 import { AutonomysSymbol, Button, NetworkId } from '@auto-drive/ui';
 import { AccountInformation } from '../../molecules/AccountInformation';
 import dayjs from 'dayjs';
@@ -78,6 +78,7 @@ export const SideNavbar = ({ networkId }: SideNavbarProps) => {
       <SidebarFooter className='p-4'>
         {isLoggedIn && (
           <AccountInformation
+            granularity={subscription?.granularity ?? SubscriptionGranularity.OneOff}
             renewalDate={renewalDate}
             uploadLimit={subscription?.uploadLimit ?? 0}
             uploadPending={subscription?.pendingUploadCredits ?? 0}

--- a/apps/frontend/src/components/organisms/UserTable/CreditsUpdateModal.tsx
+++ b/apps/frontend/src/components/organisms/UserTable/CreditsUpdateModal.tsx
@@ -10,6 +10,7 @@ import {
 import { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
 import toast from 'react-hot-toast';
 import { useNetwork } from 'contexts/network';
+import { SubscriptionGranularity } from '@auto-drive/models';
 
 export const CreditsUpdateModal = ({
   userHandle,
@@ -24,6 +25,9 @@ export const CreditsUpdateModal = ({
   );
   const [uploadCredits, setUploadCredits] = useState<string>('');
   const [uploadCreditsUnit, setUploadCreditsUnit] = useState<number>(1024 ** 2);
+  const [granularity, setGranularity] = useState<SubscriptionGranularity>(
+    SubscriptionGranularity.Monthly,
+  );
 
   const network = useNetwork();
 
@@ -32,6 +36,7 @@ export const CreditsUpdateModal = ({
     setUploadCredits('');
     setDownloadCreditsUnit(1024 ** 2);
     setUploadCreditsUnit(1024 ** 2);
+    setGranularity(SubscriptionGranularity.Monthly);
   }, [userHandle]);
 
   const updateCredits = useCallback(async () => {
@@ -40,7 +45,7 @@ export const CreditsUpdateModal = ({
       const uploadBytes = Number(uploadCredits) * uploadCreditsUnit;
       await network.api.updateSubscription(
         userHandle,
-        'monthly',
+        granularity,
         uploadBytes,
         downloadBytes,
       );
@@ -54,6 +59,7 @@ export const CreditsUpdateModal = ({
     downloadCreditsUnit,
     uploadCredits,
     uploadCreditsUnit,
+    granularity,
     onClose,
   ]);
 
@@ -78,7 +84,7 @@ export const CreditsUpdateModal = ({
           leaveFrom='opacity-100'
           leaveTo='opacity-0'
         >
-          <div className='fixed inset-0 bg-black dark:bg-darkBlack/25' />
+          <div className='dark:bg-darkBlack/25 fixed inset-0 bg-black' />
         </TransitionChild>
 
         <div className='fixed inset-0 overflow-y-auto'>
@@ -92,15 +98,40 @@ export const CreditsUpdateModal = ({
               leaveFrom='opacity-100 scale-100'
               leaveTo='opacity-0 scale-95'
             >
-              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all dark:bg-darkWhite'>
+              <DialogPanel className='dark:bg-darkWhite w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all'>
                 <DialogTitle
                   as='h3'
-                  className='text-lg font-medium leading-6 text-black dark:text-darkBlack'
+                  className='dark:text-darkBlack text-lg font-medium leading-6 text-black'
                 >
                   Update credits
                 </DialogTitle>
                 <div className='mt-2'>
                   <div className='space-y-4'>
+                    <div className='flex items-center space-x-2'>
+                      <label
+                        htmlFor='granularity'
+                        className='dark:text-darkBlack min-w-[110px] text-left text-black'
+                      >
+                        Granularity
+                      </label>
+                      <select
+                        className='dark:bg-darkWhite dark:text-darkBlack dark:ring-darkWhiteHover w-full rounded border border-gray-300 bg-white px-2 py-1 text-black dark:ring-1'
+                        id='granularity'
+                        value={granularity}
+                        onChange={(e) =>
+                          setGranularity(
+                            e.target.value as SubscriptionGranularity,
+                          )
+                        }
+                      >
+                        <option value={SubscriptionGranularity.Monthly}>
+                          Monthly
+                        </option>
+                        <option value={SubscriptionGranularity.OneOff}>
+                          One-off
+                        </option>
+                      </select>
+                    </div>
                     <div className='flex items-center space-x-2'>
                       <input
                         type='text'
@@ -110,7 +141,7 @@ export const CreditsUpdateModal = ({
                         onChange={(e) => setDownloadCredits(e.target.value)}
                       />
                       <select
-                        className='rounded border border-gray-300 bg-white px-2 py-1 text-black dark:bg-darkWhite dark:text-darkBlack dark:ring-1 dark:ring-darkWhiteHover'
+                        className='dark:bg-darkWhite dark:text-darkBlack dark:ring-darkWhiteHover rounded border border-gray-300 bg-white px-2 py-1 text-black dark:ring-1'
                         value={downloadCreditsUnit}
                         onChange={(e) =>
                           setDownloadCreditsUnit(Number(e.target.value))
@@ -130,7 +161,7 @@ export const CreditsUpdateModal = ({
                         onChange={(e) => setUploadCredits(e.target.value)}
                       />
                       <select
-                        className='rounded border border-gray-300 bg-white px-2 py-1 text-black dark:bg-darkWhite dark:text-darkBlack dark:ring-1 dark:ring-darkWhiteHover'
+                        className='dark:bg-darkWhite dark:text-darkBlack dark:ring-darkWhiteHover rounded border border-gray-300 bg-white px-2 py-1 text-black dark:ring-1'
                         value={uploadCreditsUnit}
                         onChange={(e) =>
                           setUploadCreditsUnit(Number(e.target.value))

--- a/packages/models/src/users/subscription.ts
+++ b/packages/models/src/users/subscription.ts
@@ -8,7 +8,10 @@ export type Subscription = {
   granularity: SubscriptionGranularity;
 };
 
-export type SubscriptionGranularity = "monthly";
+export enum SubscriptionGranularity {
+  Monthly = "monthly",
+  OneOff = "one_off",
+}
 
 export type SubscriptionInfoWithUser = SubscriptionInfo & {
   user: User;


### PR DESCRIPTION
Previous status: 

We have a `granularity` field in subscriptions hard coded to monthly.

What's implemented: 

- We implemented `one_off` granularity for supporting this kind of plan and making it default. 
- Admins can now update a user's subscription granularity.
- Small updates in frontend that removes reference to subscription (e.g removed "credits renews in x days")

This is the first of the steps needed for implementing #465