### PR TITLE
fix: metadata endpoint

### DIFF
--- a/apps/backend/src/app/controllers/object.ts
+++ b/apps/backend/src/app/controllers/object.ts
@@ -183,7 +183,7 @@ objectController.get(
   asyncSafeHandler(async (req, res) => {
     const { cid } = req.params
 
-    const metadataResult = await handleInternalError(
+    const metadataResult = await handleInternalErrorResult(
       ObjectUseCases.getMetadata(cid),
       'Failed to get metadata',
     )
@@ -194,12 +194,6 @@ objectController.get(
     }
 
     const metadata = metadataResult.value
-    if (!metadata) {
-      res.status(404).json({
-        error: 'Metadata not found',
-      })
-      return
-    }
 
     res.json(metadata)
   }),


### PR DESCRIPTION
## Problem

I misused the `handleInternalError` when it applied to `handleInternalErrorResult` this created a double nested Result object. The returning value of the endpoint was `{value: OffchainMetadata}` when the SDK is expecting just `OffchainMetadata`

## Solution 

Update the error handler `handleInternalErrorResult` for getting a single `Result` object so the returned value is the expected by the SDK