### PR TITLE
Remove taurus from auto-drive networks

### DIFF
--- a/packages/ui/.eslintrc.json
+++ b/packages/ui/.eslintrc.json
@@ -1,0 +1,44 @@
+{
+  "root": true,
+  "env": {
+    "es2021": true,
+    "node": true
+  },
+  "plugins": ["@typescript-eslint", "prettier", "require-extensions"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:require-extensions/recommended",
+    "prettier"
+  ],
+  "parserOptions": {
+    "ecmaFeatures": {
+      "jsx": true
+    },
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "parser": "@typescript-eslint/parser",
+  "rules": {
+    "react/react-in-jsx-scope": "off",
+    "spaced-comment": "error",
+    "quotes": ["error", "single"],
+    "no-duplicate-imports": "error"
+  },
+  "ignorePatterns": [
+    "dist/**/*",
+    "build/**/*",
+    "node_modules/**/*",
+    "migrations/**/*",
+    "jest.config.ts"
+  ],
+  "settings": {
+    "import/resolver": {
+      "typescript": {
+        "alwaysTryTypes": true,
+        "project": "./tsconfig.json"
+      }
+    }
+  }
+}

--- a/packages/ui/.prettierrc
+++ b/packages/ui/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "semi": false,
+  "tabWidth": 2,
+  "printWidth": 80,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "jsxSingleQuote": true,
+  "bracketSpacing": true,
+  "plugins": [],
+  "extends": ["eslint:recommended", "plugin:prettier/recommended"]
+}

--- a/packages/ui/src/constants/networks.ts
+++ b/packages/ui/src/constants/networks.ts
@@ -1,50 +1,50 @@
 export enum NetworkId {
-  MAINNET = "mainnet",
-  LOCAL = "local",
+  MAINNET = 'mainnet',
+  LOCAL = 'local',
 }
 
 export interface Network {
-  id: NetworkId;
-  name: string;
-  download: string;
-  http: string;
-  gql: string;
+  id: NetworkId
+  name: string
+  download: string
+  http: string
+  gql: string
 }
 
-export const defaultNetworkId = NetworkId.MAINNET;
+export const defaultNetworkId = NetworkId.MAINNET
 
 export const networks: Partial<Record<NetworkId, Network>> = {
   [NetworkId.MAINNET]: {
     id: NetworkId.MAINNET,
-    name: "Mainnet",
+    name: 'Mainnet',
     http:
       process.env.NEXT_PUBLIC_MAINNET_HTTP_URL ||
-      "https://mainnet.auto-drive.autonomys.xyz/api",
+      'https://mainnet.auto-drive.autonomys.xyz/api',
     download:
       process.env.NEXT_PUBLIC_MAINNET_DOWNLOAD_URL ||
-      "https://public.auto-drive.autonomys.xyz/api",
+      'https://public.auto-drive.autonomys.xyz/api',
     gql:
       process.env.NEXT_PUBLIC_MAINNET_GQL_URL ||
-      "https://mainnet.auto-drive.autonomys.xyz/hasura/v1/graphql",
+      'https://mainnet.auto-drive.autonomys.xyz/hasura/v1/graphql',
   },
-};
+}
 
-if (process.env.NEXT_PUBLIC_ENV === "local") {
+if (process.env.NEXT_PUBLIC_ENV === 'local') {
   networks[NetworkId.LOCAL] = {
     id: NetworkId.LOCAL,
-    name: "Local",
-    http: process.env.NEXT_PUBLIC_LOCAL_RPC_URL || "http://localhost:3000",
+    name: 'Local',
+    http: process.env.NEXT_PUBLIC_LOCAL_RPC_URL || 'http://localhost:3000',
     download:
-      process.env.NEXT_PUBLIC_LOCAL_DOWNLOAD_URL || "http://localhost:3030",
+      process.env.NEXT_PUBLIC_LOCAL_DOWNLOAD_URL || 'http://localhost:3030',
     gql:
       process.env.NEXT_PUBLIC_LOCAL_GQL_URL ||
-      "http://localhost:6565/v1/graphql",
-  };
+      'http://localhost:6565/v1/graphql',
+  }
 }
 
 export const getNetwork = (networkId: NetworkId) => {
   if (!networks[networkId]) {
-    throw new Error(`Network ${networkId} not found`);
+    throw new Error(`Network ${networkId} not found`)
   }
-  return networks[networkId];
-};
+  return networks[networkId]
+}

--- a/packages/ui/src/constants/networks.ts
+++ b/packages/ui/src/constants/networks.ts
@@ -1,7 +1,6 @@
 export enum NetworkId {
-  TAURUS = 'taurus',
-  MAINNET = 'mainnet',
-  LOCAL = 'local',
+  MAINNET = "mainnet",
+  LOCAL = "local",
 }
 
 export interface Network {
@@ -15,44 +14,31 @@ export interface Network {
 export const defaultNetworkId = NetworkId.MAINNET;
 
 export const networks: Partial<Record<NetworkId, Network>> = {
-  [NetworkId.TAURUS]: {
-    id: NetworkId.TAURUS,
-    name: 'Taurus',
-    http:
-      process.env.NEXT_PUBLIC_TAURUS_HTTP_URL ||
-      'https://demo.auto-drive.autonomys.xyz/api',
-    download:
-      process.env.NEXT_PUBLIC_TAURUS_DOWNLOAD_URL ||
-      'https://public.taurus.auto-drive.autonomys.xyz/api',
-    gql:
-      process.env.NEXT_PUBLIC_TAURUS_GQL_URL ||
-      'https://demo.auto-drive.autonomys.xyz/hasura/v1/graphql',
-  },
   [NetworkId.MAINNET]: {
     id: NetworkId.MAINNET,
-    name: 'Mainnet',
+    name: "Mainnet",
     http:
       process.env.NEXT_PUBLIC_MAINNET_HTTP_URL ||
-      'https://mainnet.auto-drive.autonomys.xyz/api',
+      "https://mainnet.auto-drive.autonomys.xyz/api",
     download:
       process.env.NEXT_PUBLIC_MAINNET_DOWNLOAD_URL ||
-      'https://public.auto-drive.autonomys.xyz/api',
+      "https://public.auto-drive.autonomys.xyz/api",
     gql:
       process.env.NEXT_PUBLIC_MAINNET_GQL_URL ||
-      'https://mainnet.auto-drive.autonomys.xyz/hasura/v1/graphql',
+      "https://mainnet.auto-drive.autonomys.xyz/hasura/v1/graphql",
   },
 };
 
-if (process.env.NEXT_PUBLIC_ENV === 'local') {
+if (process.env.NEXT_PUBLIC_ENV === "local") {
   networks[NetworkId.LOCAL] = {
     id: NetworkId.LOCAL,
-    name: 'Local',
-    http: process.env.NEXT_PUBLIC_LOCAL_RPC_URL || 'http://localhost:3000',
+    name: "Local",
+    http: process.env.NEXT_PUBLIC_LOCAL_RPC_URL || "http://localhost:3000",
     download:
-      process.env.NEXT_PUBLIC_LOCAL_DOWNLOAD_URL || 'http://localhost:3030',
+      process.env.NEXT_PUBLIC_LOCAL_DOWNLOAD_URL || "http://localhost:3030",
     gql:
       process.env.NEXT_PUBLIC_LOCAL_GQL_URL ||
-      'http://localhost:6565/v1/graphql',
+      "http://localhost:6565/v1/graphql",
   };
 }
 


### PR DESCRIPTION
## Description

Removes from the network dropdown taurus instance connections. 

Implements the first step of #488 