### PR TITLE
Added versioning to local files cache for enabling invalidating

### DIFF
--- a/apps/frontend/src/utils/indexedb.ts
+++ b/apps/frontend/src/utils/indexedb.ts
@@ -1,4 +1,4 @@
-export const openDatabase = () => {
+export const openDatabase = (storeName: string) => {
   return new Promise<IDBDatabase>((resolve, reject) => {
     // Check if running in a browser environment
     if (typeof window === 'undefined' || typeof indexedDB === 'undefined') {
@@ -11,7 +11,7 @@ export const openDatabase = () => {
     dbRequest.onerror = () => reject('Error opening database');
     dbRequest.onupgradeneeded = () => {
       const db = dbRequest.result;
-      db.createObjectStore('files', {
+      db.createObjectStore(storeName, {
         keyPath: 'cid',
       });
     };


### PR DESCRIPTION
## Problem

Sometimes we experience issues in the downloading service leading to files being downloaded with the incorrect content. This is particularly sensitive because we cache locally files using `IndexedDB` so when a file is downloaded incorrectly any subsequent download of that file is using that incorrect copy. 

## Solution

Adding a namespace to the `IndexedDB` database for invalidating data once a issue on the download service has been detected.