### PR TITLE
Remove all `AutoDriveNetworkId.Taurus` references

### DIFF
--- a/apps/frontend/src/components/molecules/FilePreview/index.tsx
+++ b/apps/frontend/src/components/molecules/FilePreview/index.tsx
@@ -34,8 +34,6 @@ export const FilePreview = ({ metadata }: { metadata: OffchainMetadata }) => {
       case AutoDriveNetworkId.LOCAL:
       case AutoDriveNetworkId.MAINNET:
         return AutoUtilsNetworkId.MAINNET;
-      case AutoDriveNetworkId.TAURUS:
-        return AutoUtilsNetworkId.TAURUS;
       default:
         return AutoUtilsNetworkId.MAINNET;
     }


### PR DESCRIPTION
## Problem

There were still references to `AutoDriveNetworkId.Taurus` which provoked build failures

## Impact 

Will disable Taurus from the available networks in [auto-drive frontend](https://explorer.ai3.storage)