### PR TITLE
Remove taurus from multi-network gateway

### DIFF
--- a/apps/backend/src/docs/reference/servers.ts
+++ b/apps/backend/src/docs/reference/servers.ts
@@ -3,19 +3,11 @@ export const autoDriveServers = [
     url: 'https://mainnet.auto-drive.autonomys.xyz/api',
     description: 'Mainnet Auto Drive API',
   },
-  {
-    url: 'https://taurus.auto-drive.autonomys.xyz/api',
-    description: 'Testnet Auto Drive API',
-  },
 ]
 
 export const downloadServers = [
   {
     url: 'https://public.auto-drive.autonomys.xyz/api',
     description: 'Download Auto Drive Gateway (Mainnet)',
-  },
-  {
-    url: 'https://public.taurus.auto-drive.autonomys.xyz/api',
-    description: 'Download Auto Drive Gateway (Testnet)',
   },
 ]

--- a/apps/gateway/public/index.html
+++ b/apps/gateway/public/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="A unified gateway solution designed to seamlessly connect and access files or folders permanently stored on Autonomys Mainnet & Taurus Testnet through a single, streamlined interface."
+      content="A gateway solution designed to seamlessly connect and access files or folders permanently stored on Autonomys Network."
     />
     <title>Auto Drive Gateway | Autonomys</title>
     <link
@@ -51,8 +51,8 @@
         </h2>
         <p class="text-lg md:text-xl text-muted-foreground max-w-3xl mx-auto">
           A unified gateway solution designed to seamlessly connect and access
-          files or folders permanently stored on Autonomys Mainnet & Taurus
-          Testnet through a single, streamlined interface.
+          files or folders permanently stored on Autonomys Network through a
+          single, streamlined interface.
         </p>
       </section>
 

--- a/apps/gateway/src/config.ts
+++ b/apps/gateway/src/config.ts
@@ -4,7 +4,6 @@ import { env } from "./utils";
 
 export const ApiPatternByNetwork: Partial<Record<NetworkId, string>> = {
   [NetworkId.MAINNET]: process.env.MAINNET_API_PATTERN,
-  [NetworkId.TAURUS]: process.env.TAURUS_API_PATTERN,
 };
 
 export const config = {

--- a/apps/gateway/src/networkComposer.ts
+++ b/apps/gateway/src/networkComposer.ts
@@ -4,7 +4,7 @@ import { firstNonNull } from "./utils";
 import { ApiPatternByNetwork, config } from "./config";
 
 export const getFileNetwork = async (cid: string) => {
-  const networks = [NetworkId.MAINNET, NetworkId.TAURUS] as const;
+  const networks = [NetworkId.MAINNET] as const;
 
   // Create reusable API instances to avoid memory leaks
   const apiInstances = {

--- a/apps/gateway/src/networkComposer.ts
+++ b/apps/gateway/src/networkComposer.ts
@@ -12,10 +12,6 @@ export const getFileNetwork = async (cid: string) => {
       network: NetworkId.MAINNET,
       apiKey: config.autoDriveApiKey,
     }),
-    [NetworkId.TAURUS]: createAutoDriveApi({
-      network: NetworkId.TAURUS,
-      apiKey: config.autoDriveApiKey,
-    }),
   };
 
   const promises = networks.map(async (network) => {


### PR DESCRIPTION
Removed taurus from multi-network gateway and any reference in the landing page

## Impact

Only mainnet will be available through the gateway