### PR TITLE
feat: make optional allowlists

### DIFF
--- a/apps/backend/src/config.ts
+++ b/apps/backend/src/config.ts
@@ -113,11 +113,11 @@ export const config = {
         staffOnly: optionalBoolEnvironmentVariable('BUY_CREDITS_STAFF_ONLY'),
       } as FeatureFlag,
     },
-    allowlistedUsernames: env('STAFF_USERNAME_ALLOWLIST', '')
+    allowlistedUsernames: env('STAFF_USERNAME_ALLOWLIST', '<none>')
       .split(',')
       .filter((username) => username)
       .map((username) => username.toLowerCase()),
-    staffDomains: env('STAFF_DOMAINS', '')
+    staffDomains: env('STAFF_DOMAINS', '<none>')
       .split(',')
       // Remove empty strings
       .filter((domain) => domain)


### PR DESCRIPTION
Makes `STAFF_USERNAME_ALLOWLIST` and `STAFF_DOMAINS` environment variables, so an error is not triggered in the case they're not setup