### PR TITLE
Refactor metric tagging in object reporting and request tracing

### DIFF
--- a/apps/backend/src/app/controllers/object.ts
+++ b/apps/backend/src/app/controllers/object.ts
@@ -11,6 +11,7 @@ import {
 } from '../../shared/utils/neverthrow.js'
 import { handleError } from '../../errors/index.js'
 import { sendMetricToVictoria } from '../../infrastructure/drivers/vmetrics.js'
+import { config } from '../../config.js'
 
 const logger = createLogger('http:controllers:object')
 
@@ -448,9 +449,13 @@ objectController.post(
     const { cid } = req.params
 
     logger.info('Reporting object', { cid })
+    const tags = {
+      chain: config.monitoring.metricEnvironmentTag,
+      ip: req.ip?.toString() ?? 'unknown',
+    }
     sendMetricToVictoria({
       measurement: 'object_report',
-      tag: req.ip?.toString() ?? 'unknown',
+      tags,
       fields: {
         cid,
         ip: req.ip?.toString() ?? 'unknown',

--- a/apps/backend/src/app/middlewares/requestTrace.ts
+++ b/apps/backend/src/app/middlewares/requestTrace.ts
@@ -23,13 +23,9 @@ export const requestTrace: RequestHandler = (req, res) => {
     provider,
   }
 
-  const tag = Object.entries(tags)
-    .map(([key, value]) => `${key}=${value}`)
-    .join(',')
-
   const metric: Metric = {
     measurement: 'auto_drive_api_request',
-    tag,
+    tags,
     fields: {
       status: res.statusCode,
       method,

--- a/apps/backend/src/core/objects/interactions.ts
+++ b/apps/backend/src/core/objects/interactions.ts
@@ -17,13 +17,9 @@ const createMetric = (type: InteractionType, size: bigint): Metric => {
     type,
   }
 
-  const tag = Object.entries(tags)
-    .map(([key, value]) => `${key}=${value}`)
-    .join(',')
-
   return {
     measurement: 'auto_drive_interactions',
-    tag,
+    tags,
     fields: {
       size,
     },
@@ -47,7 +43,7 @@ const createInteraction = async (
     logger.trace(
       'Sending metric to Victoria (measurement=%s, tag=%s)',
       metric.measurement,
-      metric.tag,
+      JSON.stringify(metric.tags),
     )
     sendMetricToVictoria(metric)
 


### PR DESCRIPTION
### Problem

There was some requests malformed to `vmetrics` because the `tag` value had `undefined` values sometimes that are not admisible.

### Solution

Generate correctly `tag` value and unified in `vmetrics` driver the generation of `tag` value from a set of tags so.