### PR TITLE
Make backend encoding the default for downloads through `gateway.autonomys.xyz`

### DIFF
--- a/nginx/backend.mainnet.public.conf
+++ b/nginx/backend.mainnet.public.conf
@@ -89,7 +89,7 @@ server {
             return 204;
         }
 
-        rewrite /file/(.*) /downloads/$1  break;
+        rewrite ^/file/(.*)$ /downloads/$1?ignoreEncoding=false break;
     }
 
     location /folder {
@@ -123,7 +123,7 @@ server {
             return 204;
         }
 
-        rewrite /folder/(.*) /downloads/$1  break;
+        rewrite /folder/(.*) /downloads/$1?ignoreEncoding=false break;
     }
 
 


### PR DESCRIPTION
## Problem

Multi-network gateway besides from routing to between chains depending on CID, also used as default backend encoding handling. This behaviour was not migrated correctly to new setup so in some cases encoding was being supposed to happen on the client, which is not desired on `gateway.autonomys.xyz`

## Solution

Update nginx config for using backend encoding as default