### PR TITLE
chore: remove gateway from image generation

### DIFF
--- a/.github/workflows/image-generations.yml
+++ b/.github/workflows/image-generations.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        app: [backend, gateway]
+        app: [backend]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
When removed `gateway` it was still in the image generation workflow leading to errors