### PR TITLE
fix: byte range handling

### DIFF
--- a/apps/backend/src/core/downloads/sync.ts
+++ b/apps/backend/src/core/downloads/sync.ts
@@ -24,12 +24,11 @@ const getCalculatedResultingByteRange = (
   metadata: OffchainMetadata,
   byteRange?: ByteRange,
 ): [number, number] => {
+  // Byte ranges are 0-indexed and inclusive, so max valid index is totalSize - 1
+  const maxEndByte = Number(metadata.totalSize) - 1
   return [
     byteRange?.[0] ?? 0,
-    Math.min(
-      byteRange?.[1] ?? Number(metadata.totalSize),
-      Number(metadata.totalSize),
-    ),
+    Math.min(byteRange?.[1] ?? maxEndByte, maxEndByte),
   ]
 }
 
@@ -81,8 +80,9 @@ const downloadObjectByUser = async (
     reader.oauthUserId,
   )
 
+  // Byte ranges are inclusive, so length = end - start + 1
   const totalSize = BigInt(
-    resultingByteRange[1] - resultingByteRange[0],
+    resultingByteRange[1] - resultingByteRange[0] + 1,
   ).valueOf()
 
   return ok({

--- a/apps/backend/src/core/objects/files/index.ts
+++ b/apps/backend/src/core/objects/files/index.ts
@@ -98,7 +98,8 @@ const retrieveFileByteRange = async (
   })
 
   const offsetWithinFirstNode = byteRange[0] - firstNodeFileOffset
-  const upperBound = byteRange[1] ?? Number(metadata.totalSize)
+  // Byte ranges are 0-indexed and inclusive, so max valid index is totalSize - 1
+  const upperBound = byteRange[1] ?? Number(metadata.totalSize) - 1
   const length = upperBound - byteRange[0] + 1
 
   logger.info(


### PR DESCRIPTION
This pull request makes small but important corrections to how byte ranges are calculated and handled in file download logic. The changes ensure that byte ranges are consistently treated as 0-indexed and inclusive, preventing off-by-one errors when accessing file data.

Key corrections to byte range calculations:

* Updated the calculation of the maximum valid byte index in `getCalculatedResultingByteRange` to be `totalSize - 1`, ensuring that byte ranges are 0-indexed and inclusive.
* Adjusted the default upper bound in `retrieveFileByteRange` to also use `totalSize - 1`, maintaining consistency with the inclusive, 0-indexed byte range convention.