### PR TITLE
Ensure API keys used for authorized downloads

### DIFF
--- a/apps/backend/src/infrastructure/services/auth/express.ts
+++ b/apps/backend/src/infrastructure/services/auth/express.ts
@@ -39,9 +39,20 @@ export const handleOptionalAuth = async (
   req: Request,
   res: Response,
 ): Promise<UserWithOrganization | boolean | null> => {
-  if (config.params.optionalAuth) {
-    return true
+  const accessToken = req.headers.authorization?.split(' ')[1]
+  const providerHeader = req.headers['x-auth-provider']
+  const hasAuthHeaders =
+    typeof accessToken === 'string' && typeof providerHeader === 'string'
+
+  // If credentials are provided, always attempt to authenticate the user,
+  // regardless of OPTIONAL_AUTH flag. This ensures API keys and tokens are honored.
+  if (hasAuthHeaders) {
+    return handleAuth(req, res)
   }
+
+  // If OPTIONAL_AUTH is enabled and no credentials are provided,
+  // allow anonymous access by returning true.
+  if (config.params.optionalAuth) return true
 
   return handleAuth(req, res)
 }

--- a/apps/frontend/src/services/api.ts
+++ b/apps/frontend/src/services/api.ts
@@ -333,10 +333,13 @@ export const createApiService = ({
     cid: string,
     password?: string,
   ): Promise<AsyncIterable<Buffer>> => {
+    const session = await getAuthSession();
+   
     const api = createAutoDriveApi({
       downloadServiceUrl: downloadApiUrl,
       apiUrl: apiBaseUrl,
-      apiKey: null,
+      apiKey: session?.accessToken ?? null,
+      provider: (session?.authProvider as AuthProvider | undefined) ?? undefined,
     });
 
     return api.downloadFile(cid, password);


### PR DESCRIPTION
### Summary
Fixes API-key requests being treated as anonymous when `OPTIONAL_AUTH=true`, which caused 402 on >100 MiB. If auth headers are present, we authenticate; only no-credential requests fall back to anonymous.

### Change
- In `handleOptionalAuth`, try `handleAuth` when `Authorization` and `X-Auth-Provider` exist; otherwise, return anonymous only if `OPTIONAL_AUTH=true`.

### Impact
- Authenticated downloads now use account limits/credits.
- Invalid creds return 401 (no silent anonymous fallback).
- Anonymous behavior unchanged.