### PR TITLE
chore(ansible): remove stdout_callback configuration from ansible.cfg

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -7,7 +7,6 @@ fact_caching = memory
 retry_files_enabled = False
 deprecation_warnings = False
 callback_whitelist = profile_tasks
-stdout_callback = yaml
 
 [ssh_connection]
 ssh_args = -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ControlMaster=auto -o ControlPersist=60s


### PR DESCRIPTION
## Summary
- Removes deprecated `stdout_callback = yaml` configuration from `ansible.cfg` to fix CI failures with ansible-core 2.20.0

## Context

The CI pipeline was failing with the error:

```
Error: : The 'community.general.yaml' callback plugin has been removed. The plugin has been superseded by the option `result_format=yaml` in callback plugin ansible.builtin.default from ansible-core 2.13 onwards. This feature was removed from collection 'community.general' version 12.0.0.
```

The `stdout_callback = yaml` setting was referencing the now-removed `community.general.yaml` callback plugin. Since ansible-core 2.13+, the built-in default callback plugin supports YAML output via `result_format=yaml`, making the community plugin unnecessary.

## Changes

Removed the `stdout_callback = yaml` line from `ansible/ansible.cfg`. The default callback plugin will now be used for output formatting.
