### PR TITLE
Chore: add infisical and tool-version to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ yarn-error.log*
 .env
 .env.local
 .env.*.local
+.infisical.json
+.tool-versions
 
 # IDE files
 .vscode/


### PR DESCRIPTION
This PR expands the gitignore file to include the infisical setup file and the tool-versions file