### PR TITLE
fix(frontend): handle unhandled promise rejections in async operations

### DIFF
--- a/apps/frontend/src/components/atoms/SessionEnsurer.tsx
+++ b/apps/frontend/src/components/atoms/SessionEnsurer.tsx
@@ -20,14 +20,19 @@ export const SessionEnsurer = ({ children }: { children: React.ReactNode }) => {
     if (session.data === null) {
       setUser(null);
     } else {
-      AuthService.getMe().then((user) => {
-        if (user.onboarded) {
-          setUser(user);
-        } else {
+      AuthService.getMe()
+        .then((user) => {
+          if (user.onboarded) {
+            setUser(user);
+          } else {
+            setUser(null);
+            router.push('/onboarding');
+          }
+        })
+        .catch(() => {
+          // Session may have expired or be invalid
           setUser(null);
-          router.push('/onboarding');
-        }
-      });
+        });
     }
   }, [api, router, session, session?.data, setAccount, setUser]);
 

--- a/apps/frontend/src/components/organisms/FileTable/state.tsx
+++ b/apps/frontend/src/components/organisms/FileTable/state.tsx
@@ -85,7 +85,9 @@ export const useFileTableState = create<FileTableStore>()((set, get) => {
           }
         })
         .catch(() => {
-          // Ignore all errors, including aborted requests
+          if (requestId === get().currentRequestId) {
+            set({ isLoading: false });
+          }
         });
     },
     setLimit: (limit: number) => {

--- a/apps/frontend/src/components/organisms/UserAsyncDownloads/index.tsx
+++ b/apps/frontend/src/components/organisms/UserAsyncDownloads/index.tsx
@@ -49,12 +49,18 @@ export const UserAsyncDownloads = () => {
   }, [dismissOutdatedAsyncDownloads]);
 
   const fetcher = useCallback(async () => {
-    const { data } = await gql.query<MyUndismissedAsyncDownloadsQuery>({
-      query: MyUndismissedAsyncDownloadsDocument,
-      fetchPolicy: 'network-only',
-    });
+    try {
+      const { data } = await gql.query<MyUndismissedAsyncDownloadsQuery>({
+        query: MyUndismissedAsyncDownloadsDocument,
+        fetchPolicy: 'network-only',
+      });
 
-    return (data?.async_downloads as AsyncDownload[]) ?? [];
+      return (data?.async_downloads as AsyncDownload[]) ?? [];
+    } catch {
+      // async_downloads table may not exist in production Hasura
+      // Return empty array to avoid breaking the UI
+      return [];
+    }
   }, [gql]);
 
   useEffect(() => {

--- a/apps/frontend/src/components/organisms/UserAsyncDownloads/state.tsx
+++ b/apps/frontend/src/components/organisms/UserAsyncDownloads/state.tsx
@@ -18,9 +18,14 @@ export const useUserAsyncDownloadsStore = create<UserAsyncDownloadsStore>(
     },
     update: () => {
       const fetcher = get().fetcher?.();
-      fetcher?.then((asyncDownloads) => {
-        set({ asyncDownloads });
-      });
+      fetcher
+        ?.then((asyncDownloads) => {
+          set({ asyncDownloads });
+        })
+        .catch(() => {
+          // Silently ignore errors (e.g., async_downloads table not available)
+          // This prevents unhandled promise rejections
+        });
     },
   }),
 );

--- a/apps/frontend/src/services/gql/index.ts
+++ b/apps/frontend/src/services/gql/index.ts
@@ -1,25 +1,43 @@
-import { ApolloClient, HttpLink, InMemoryCache } from '@apollo/client';
+import { ApolloClient, HttpLink, InMemoryCache, from } from '@apollo/client';
+import { onError } from '@apollo/client/link/error';
 import { setContext } from '@apollo/client/link/context';
 import { getAuthSession } from 'utils/auth';
 import { NetworkId, getNetwork } from '@auto-drive/ui';
 
+const errorLink = onError(({ graphQLErrors, networkError }) => {
+  if (graphQLErrors) {
+    graphQLErrors.forEach(({ message, locations, path }) =>
+      console.error(
+        `[GQL] GraphQL error: ${message}`,
+        locations ? `Location: ${JSON.stringify(locations)}` : '',
+        path ? `Path: ${path}` : '',
+      ),
+    );
+  }
+  if (networkError) {
+    console.error('[GQL] Network error:', networkError);
+  }
+});
+
 const authLink = setContext(async (_, { headers }) => {
-  const token = await getAuthSession();
+  const token = await getAuthSession().catch(() => null);
+  const role = token ? 'user' : 'anonymous';
 
   return {
     headers: {
       ...headers,
       ...(token ? { authorization: `Bearer ${token.accessToken}` } : {}),
-      'X-Hasura-Role': token ? 'user' : 'anonymous',
+      'X-Hasura-Role': role,
     },
   };
 });
 
-export const createGQLClient = (apiBaseUrl: string) =>
-  new ApolloClient({
+export const createGQLClient = (apiBaseUrl: string) => {
+  return new ApolloClient({
     cache: new InMemoryCache(),
-    link: authLink.concat(new HttpLink({ uri: apiBaseUrl })),
+    link: from([errorLink, authLink, new HttpLink({ uri: apiBaseUrl })]),
   });
+};
 
 export const createGQLClientByNetwork = (networkId: NetworkId) =>
   createGQLClient(getNetwork(networkId).gql);


### PR DESCRIPTION
- Add .catch() handler to SessionEnsurer.getMe() for graceful auth failures
- Add try-catch in UserAsyncDownloads fetcher for missing async_downloads table
- Add .catch() handler in UserAsyncDownloads state to prevent unhandled rejections
- Fix FileTable error handler to properly reset loading state

These changes address potential memory issues caused by unhandled promise rejections in production.