### PR TITLE
fix(backend): resolve frontendWorker memory leaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,15 @@
     "packages/*",
     "submodules/*"
   ],
+  "resolutions": {
+    "@polkadot/util": "13.5.6",
+    "@polkadot/util-crypto": "13.5.6",
+    "@polkadot/keyring": "13.5.6",
+    "@polkadot/wasm-crypto": "7.5.1",
+    "@polkadot/wasm-bridge": "7.5.1",
+    "@polkadot/wasm-util": "7.5.1",
+    "@polkadot/wasm-crypto-wasm": "7.5.1"
+  },
   "scripts": {
     "build:backend": "yarn workspace backend build",
     "build:frontend": "yarn workspace frontend build",


### PR DESCRIPTION
## Problem
The frontendWorker processes were consuming excessive memory (~6.5GB each), causing high RAM usage with multiple worker instances.

## Root Causes

1. **Memory leak in intents.ts getPrice()**
   - Every call to getPrice() created a new ApiPromise with WsProvider
   - These connections were never closed, accumulating WebSocket connections, WASM crypto modules, and type registries in memory

2. **Duplicate @polkadot/* package versions**
   - Multiple versions of @polkadot/util (13.5.6, 13.5.9), @polkadot/wasm-crypto (7.5.1, 7.5.4), and other packages were being loaded
   - Each duplicate loads its own WASM modules and internal state

## Fixes

1. **Singleton API pattern for price queries**
   - Created getPriceApi() that maintains a single ApiPromise instance
   - Handles disconnection/error events to reset and reconnect on next query
   - Prevents accumulation of orphaned WebSocket connections

2. **Package resolutions for @polkadot/* deduplication**
   - Added resolutions in root package.json to force single versions: - @polkadot/util, util-crypto, keyring: 13.5.6 - @polkadot/wasm-*: 7.5.1
   - Eliminates duplicate WASM module loading

## Impact
- Significantly reduced memory footprint per worker process
- Eliminated WebSocket connection accumulation
- Reduced initial load time due to single WASM initialization