### PR TITLE
Feat/pay with ai3/step 01 credit batches schema

### DIFF
--- a/apps/backend/migrations/20260302000000-purchased-credits.js
+++ b/apps/backend/migrations/20260302000000-purchased-credits.js
@@ -1,0 +1,53 @@
+'use strict'
+
+var dbm
+var type
+var seed
+var fs = require('fs')
+var path = require('path')
+var Promise
+
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  var filePath = path.join(
+    __dirname,
+    'sqls',
+    '20260302000000-purchased-credits-up.sql',
+  )
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+      resolve(data)
+    })
+  }).then(function (data) {
+    return db.runSql(data)
+  })
+}
+
+exports.down = function (db) {
+  var filePath = path.join(
+    __dirname,
+    'sqls',
+    '20260302000000-purchased-credits-down.sql',
+  )
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+      resolve(data)
+    })
+  }).then(function (data) {
+    return db.runSql(data)
+  })
+}
+
+exports._meta = {
+  version: 1,
+}

--- a/apps/backend/migrations/20260302000001-interactions-source.js
+++ b/apps/backend/migrations/20260302000001-interactions-source.js
@@ -1,0 +1,53 @@
+'use strict'
+
+var dbm
+var type
+var seed
+var fs = require('fs')
+var path = require('path')
+var Promise
+
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  var filePath = path.join(
+    __dirname,
+    'sqls',
+    '20260302000001-interactions-source-up.sql',
+  )
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+      resolve(data)
+    })
+  }).then(function (data) {
+    return db.runSql(data)
+  })
+}
+
+exports.down = function (db) {
+  var filePath = path.join(
+    __dirname,
+    'sqls',
+    '20260302000001-interactions-source-down.sql',
+  )
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+      resolve(data)
+    })
+  }).then(function (data) {
+    return db.runSql(data)
+  })
+}
+
+exports._meta = {
+  version: 1,
+}

--- a/apps/backend/migrations/sqls/20260302000000-purchased-credits-down.sql
+++ b/apps/backend/migrations/sqls/20260302000000-purchased-credits-down.sql
@@ -1,0 +1,3 @@
+-- Rollback: remove the purchased_credits table and its indexes.
+-- Indexes are dropped automatically with the table.
+DROP TABLE IF EXISTS purchased_credits;

--- a/apps/backend/migrations/sqls/20260302000000-purchased-credits-up.sql
+++ b/apps/backend/migrations/sqls/20260302000000-purchased-credits-up.sql
@@ -1,0 +1,52 @@
+-- Add purchased_credits table.
+--
+-- Tracks each Pay with AI3 credit purchase as a discrete row with its own
+-- expiry date. Free-tier and one-off allocation credits are NOT stored here —
+-- they remain on accounts.upload_limit / accounts.download_limit as before.
+--
+-- When a user uploads a file the system checks this table first (FIFO by
+-- expires_at), consumes from the soonest-expiring row, and only falls back
+-- to the legacy limit-based allocation when no active purchased credits exist.
+--
+-- One row per purchase → independent expiry dates, clear audit trail,
+-- accurate FIFO consumption.
+
+CREATE TABLE purchased_credits (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  -- The account that owns these credits (accounts.id, not user publicId).
+  account_id TEXT NOT NULL REFERENCES accounts(id),
+
+  -- The payment intent that generated this row. Always set for purchased credits.
+  intent_id VARCHAR(255) NOT NULL REFERENCES intents(id),
+
+  -- Immutable snapshot of what was granted. Used for history display and
+  -- future refund calculations. Never mutated after insert.
+  upload_bytes_original   BIGINT NOT NULL CHECK (upload_bytes_original   >= 0),
+  download_bytes_original BIGINT NOT NULL CHECK (download_bytes_original >= 0),
+
+  -- Running balance decremented by the FIFO consumption logic.
+  upload_bytes_remaining   BIGINT NOT NULL CHECK (upload_bytes_remaining   >= 0),
+  download_bytes_remaining BIGINT NOT NULL CHECK (download_bytes_remaining >= 0),
+
+  -- When the credits in this purchase were paid for. Secondary FIFO sort key.
+  purchased_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+
+  -- Every purchased credit row has a hard expiry. NULL is not allowed here —
+  -- use accounts.upload_limit for non-expiring allocations.
+  expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+
+  -- Set to TRUE by the expiry background job once expires_at has passed.
+  expired BOOLEAN NOT NULL DEFAULT FALSE,
+
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT upload_remaining_lte_original   CHECK (upload_bytes_remaining   <= upload_bytes_original),
+  CONSTRAINT download_remaining_lte_original CHECK (download_bytes_remaining <= download_bytes_original)
+);
+
+-- Primary query: active credits for an account ordered soonest-expiry first.
+-- Covers: FIFO consumption, remaining balance aggregation, expiry warnings.
+CREATE INDEX idx_purchased_credits_account_expiry
+  ON purchased_credits (account_id, expired, expires_at ASC);

--- a/apps/backend/migrations/sqls/20260302000001-interactions-source-down.sql
+++ b/apps/backend/migrations/sqls/20260302000001-interactions-source-down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE interactions DROP COLUMN IF EXISTS source;

--- a/apps/backend/migrations/sqls/20260302000001-interactions-source-up.sql
+++ b/apps/backend/migrations/sqls/20260302000001-interactions-source-up.sql
@@ -1,0 +1,14 @@
+-- Add source column to interactions table.
+--
+-- Tracks whether a given interaction was charged against purchased credits
+-- or against the account's free/one-off allocation. This is required so
+-- that the free-balance calculation (upload_limit - sum(interactions)) only
+-- counts interactions that actually consumed the free allocation, not ones
+-- that were already paid for by purchased credits.
+--
+-- Existing rows are backfilled as 'free_tier' — a safe assumption because
+-- purchased credits did not exist before this migration.
+
+ALTER TABLE interactions
+  ADD COLUMN IF NOT EXISTS source VARCHAR(32) NOT NULL DEFAULT 'free_tier'
+    CHECK (source IN ('free_tier', 'purchased'));

--- a/apps/backend/src/config.ts
+++ b/apps/backend/src/config.ts
@@ -69,6 +69,18 @@ export const config = {
     checkInterval: Number(env('EVM_CHAIN_CHECK_INTERVAL', '30000')),
     priceMultiplier: Number(env('CREDITS_PRICE_MULTIPLIER', '5.00')),
   },
+  credits: {
+    // How many days a purchased credit row remains valid before expiring.
+    // Free-tier and one-off allocation credits are unaffected — they live on
+    // accounts.upload_limit / accounts.download_limit and never expire.
+    expiryDays: Number(env('CREDIT_EXPIRY_DAYS', '90')),
+    // Maximum total purchased credit balance (in bytes) per account, summed
+    // across all active purchased_credits rows.
+    // Default: 100 GiB — matches the economic protection design document.
+    maxBytesPerUser: BigInt(env('MAX_CREDITS_PER_USER', String(100 * 1024 ** 3))),
+    // How often (in ms) the credit expiry background job runs.
+    expiryCheckIntervalMs: Number(env('CREDIT_EXPIRY_CHECK_INTERVAL', '3600000')),
+  },
   params: {
     maxConcurrentUploads: Number(env('MAX_CONCURRENT_UPLOADS', '40')),
     maxAnonymousDownloadSize: Number(

--- a/apps/backend/src/infrastructure/repositories/users/index.ts
+++ b/apps/backend/src/infrastructure/repositories/users/index.ts
@@ -1,1 +1,2 @@
 export * from './accounts.js'
+export * from './purchasedCredits.js'

--- a/apps/backend/src/infrastructure/repositories/users/purchasedCredits.ts
+++ b/apps/backend/src/infrastructure/repositories/users/purchasedCredits.ts
@@ -1,0 +1,351 @@
+import {
+  PurchasedCredit,
+  PurchasedCreditSummary,
+} from '@auto-drive/models'
+import { getDatabase } from '../../drivers/pg.js'
+import { err, ok, Result } from 'neverthrow'
+import { createLogger } from '../../drivers/logger.js'
+
+const logger = createLogger('repositories:purchasedCredits')
+
+// ---------------------------------------------------------------------------
+// Internal DB row type
+// ---------------------------------------------------------------------------
+
+type DBPurchasedCredit = {
+  id: string
+  account_id: string
+  intent_id: string
+  upload_bytes_original: string
+  upload_bytes_remaining: string
+  download_bytes_original: string
+  download_bytes_remaining: string
+  purchased_at: Date
+  expires_at: Date
+  expired: boolean
+  created_at: Date
+  updated_at: Date
+}
+
+const mapRow = (row: DBPurchasedCredit): PurchasedCredit => ({
+  id: row.id,
+  accountId: row.account_id,
+  intentId: row.intent_id,
+  uploadBytesOriginal: BigInt(row.upload_bytes_original),
+  uploadBytesRemaining: BigInt(row.upload_bytes_remaining),
+  downloadBytesOriginal: BigInt(row.download_bytes_original),
+  downloadBytesRemaining: BigInt(row.download_bytes_remaining),
+  purchasedAt: row.purchased_at,
+  expiresAt: row.expires_at,
+  expired: row.expired,
+  createdAt: row.created_at,
+  updatedAt: row.updated_at,
+})
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+export class InsufficientPurchasedCreditsError extends Error {
+  constructor(
+    public readonly requested: bigint,
+    public readonly available: bigint,
+    public readonly creditType: 'upload' | 'download',
+  ) {
+    super(
+      `Insufficient purchased ${creditType} credits: requested ${requested} bytes, available ${available} bytes`,
+    )
+    this.name = 'InsufficientPurchasedCreditsError'
+  }
+}
+
+// ---------------------------------------------------------------------------
+// createPurchasedCredit
+// Called by onConfirmedIntent() once a payment is confirmed on-chain.
+// ---------------------------------------------------------------------------
+
+type CreatePurchasedCreditParams = {
+  accountId: string
+  intentId: string
+  uploadBytesOriginal: bigint
+  downloadBytesOriginal: bigint
+  expiresAt: Date
+}
+
+const createPurchasedCredit = async (
+  params: CreatePurchasedCreditParams,
+): Promise<PurchasedCredit> => {
+  const db = await getDatabase()
+  const result = await db.query<DBPurchasedCredit>(
+    `INSERT INTO purchased_credits (
+       account_id,
+       intent_id,
+       upload_bytes_original,
+       upload_bytes_remaining,
+       download_bytes_original,
+       download_bytes_remaining,
+       expires_at
+     ) VALUES ($1, $2, $3, $3, $4, $4, $5)
+     RETURNING *`,
+    [
+      params.accountId,
+      params.intentId,
+      params.uploadBytesOriginal.toString(),
+      params.downloadBytesOriginal.toString(),
+      params.expiresAt,
+    ],
+  )
+  return mapRow(result.rows[0])
+}
+
+// ---------------------------------------------------------------------------
+// getActiveByAccountId
+// Returns non-expired rows with remaining bytes, ordered FIFO:
+// soonest-expiry first, then oldest purchase within the same expiry window.
+// ---------------------------------------------------------------------------
+
+const getActiveByAccountId = async (
+  accountId: string,
+): Promise<PurchasedCredit[]> => {
+  const db = await getDatabase()
+  const result = await db.query<DBPurchasedCredit>(
+    `SELECT *
+     FROM purchased_credits
+     WHERE account_id = $1
+       AND expired = FALSE
+       AND expires_at > NOW()
+       AND (upload_bytes_remaining > 0 OR download_bytes_remaining > 0)
+     ORDER BY expires_at ASC, purchased_at ASC`,
+    [accountId],
+  )
+  return result.rows.map(mapRow)
+}
+
+// ---------------------------------------------------------------------------
+// consumeCredits
+// Deducts bytes from the account's active purchased credit rows in FIFO
+// order (soonest-expiry first). Runs in a transaction with FOR UPDATE row
+// locking to prevent concurrent uploads from double-spending the same bytes.
+//
+// Returns ok() if there were enough purchased credits to cover the full
+// request, or InsufficientPurchasedCreditsError otherwise. The caller
+// (AccountsUseCases.registerInteraction) uses the Result to decide whether
+// to fall back to the free/one-off allocation.
+// ---------------------------------------------------------------------------
+
+const consumeCredits = async (
+  accountId: string,
+  creditType: 'upload' | 'download',
+  bytes: bigint,
+): Promise<Result<void, InsufficientPurchasedCreditsError>> => {
+  const db = await getDatabase()
+  const client = await db.connect()
+
+  try {
+    await client.query('BEGIN')
+
+    const remainingCol =
+      creditType === 'upload'
+        ? 'upload_bytes_remaining'
+        : 'download_bytes_remaining'
+
+    // Lock the relevant rows for this account so concurrent requests cannot
+    // read stale remaining values and over-commit the same credits.
+    const rowsResult = await client.query<DBPurchasedCredit>(
+      `SELECT *
+       FROM purchased_credits
+       WHERE account_id = $1
+         AND expired = FALSE
+         AND expires_at > NOW()
+         AND ${remainingCol} > 0
+       ORDER BY expires_at ASC, purchased_at ASC
+       FOR UPDATE`,
+      [accountId],
+    )
+
+    const rows = rowsResult.rows
+
+    const totalAvailable = rows.reduce((sum, r) => {
+      const remaining =
+        creditType === 'upload'
+          ? r.upload_bytes_remaining
+          : r.download_bytes_remaining
+      return sum + BigInt(remaining)
+    }, BigInt(0))
+
+    if (totalAvailable < bytes) {
+      await client.query('ROLLBACK')
+      return err(
+        new InsufficientPurchasedCreditsError(bytes, totalAvailable, creditType),
+      )
+    }
+
+    let toConsume = bytes
+
+    for (const row of rows) {
+      if (toConsume <= BigInt(0)) break
+
+      const rowRemaining = BigInt(
+        creditType === 'upload'
+          ? row.upload_bytes_remaining
+          : row.download_bytes_remaining,
+      )
+
+      const deduction = toConsume < rowRemaining ? toConsume : rowRemaining
+      const newRemaining = rowRemaining - deduction
+
+      await client.query(
+        `UPDATE purchased_credits
+         SET ${remainingCol} = $1, updated_at = NOW()
+         WHERE id = $2`,
+        [newRemaining.toString(), row.id],
+      )
+
+      toConsume -= deduction
+    }
+
+    await client.query('COMMIT')
+    return ok()
+  } catch (error) {
+    await client.query('ROLLBACK')
+    logger.error(error, 'consumeCredits: transaction failed, rolled back')
+    throw error
+  } finally {
+    client.release()
+  }
+}
+
+// ---------------------------------------------------------------------------
+// getRemainingCredits
+// Single-query aggregate: total remaining purchased bytes + nearest expiry.
+// Used by cap enforcement and the credits summary API endpoint.
+// ---------------------------------------------------------------------------
+
+const getRemainingCredits = async (
+  accountId: string,
+): Promise<PurchasedCreditSummary> => {
+  const db = await getDatabase()
+  const result = await db.query<{
+    upload_bytes_remaining: string
+    download_bytes_remaining: string
+    next_expiry: Date | null
+    active_row_count: string
+  }>(
+    `SELECT
+       COALESCE(SUM(upload_bytes_remaining),   0) AS upload_bytes_remaining,
+       COALESCE(SUM(download_bytes_remaining), 0) AS download_bytes_remaining,
+       MIN(expires_at)                            AS next_expiry,
+       COUNT(*)                                   AS active_row_count
+     FROM purchased_credits
+     WHERE account_id = $1
+       AND expired = FALSE
+       AND expires_at > NOW()
+       AND (upload_bytes_remaining > 0 OR download_bytes_remaining > 0)`,
+    [accountId],
+  )
+
+  const row = result.rows[0]
+  return {
+    uploadBytesRemaining: BigInt(row.upload_bytes_remaining),
+    downloadBytesRemaining: BigInt(row.download_bytes_remaining),
+    nextExpiryDate: row.next_expiry ?? null,
+    activeRowCount: Number(row.active_row_count),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// getExpiringCredits
+// Returns active rows expiring within N days. Used by expiry warning banners.
+// ---------------------------------------------------------------------------
+
+const getExpiringCredits = async (
+  withinDays: number,
+): Promise<PurchasedCredit[]> => {
+  const db = await getDatabase()
+  const result = await db.query<DBPurchasedCredit>(
+    `SELECT *
+     FROM purchased_credits
+     WHERE expired = FALSE
+       AND expires_at > NOW()
+       AND expires_at <= NOW() + ($1 * INTERVAL '1 day')
+       AND (upload_bytes_remaining > 0 OR download_bytes_remaining > 0)
+     ORDER BY expires_at ASC`,
+    [withinDays],
+  )
+  return result.rows.map(mapRow)
+}
+
+// ---------------------------------------------------------------------------
+// markExpiredCredits
+// Called by the credit expiry background job (to be added in a later PR).
+// Atomically marks all rows whose expires_at has passed and returns a summary
+// of bytes forfeited for logging and metrics.
+// ---------------------------------------------------------------------------
+
+export type ExpiredCreditsSummary = {
+  expiredCount: number
+  totalUploadBytesForfeited: bigint
+  totalDownloadBytesForfeited: bigint
+}
+
+const markExpiredCredits = async (): Promise<ExpiredCreditsSummary> => {
+  const db = await getDatabase()
+  const result = await db.query<{
+    count: string
+    upload_forfeited: string
+    download_forfeited: string
+  }>(
+    `WITH expired AS (
+       UPDATE purchased_credits
+       SET expired = TRUE, updated_at = NOW()
+       WHERE expired = FALSE
+         AND expires_at <= NOW()
+       RETURNING upload_bytes_remaining, download_bytes_remaining
+     )
+     SELECT
+       COUNT(*)                                     AS count,
+       COALESCE(SUM(upload_bytes_remaining),   0)  AS upload_forfeited,
+       COALESCE(SUM(download_bytes_remaining), 0)  AS download_forfeited
+     FROM expired`,
+  )
+
+  const row = result.rows[0]
+  return {
+    expiredCount: Number(row.count),
+    totalUploadBytesForfeited: BigInt(row.upload_forfeited),
+    totalDownloadBytesForfeited: BigInt(row.download_forfeited),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// getByAccountId
+// Full history including expired rows. Used by the credit history table.
+// ---------------------------------------------------------------------------
+
+const getByAccountId = async (
+  accountId: string,
+): Promise<PurchasedCredit[]> => {
+  const db = await getDatabase()
+  const result = await db.query<DBPurchasedCredit>(
+    `SELECT *
+     FROM purchased_credits
+     WHERE account_id = $1
+     ORDER BY purchased_at DESC`,
+    [accountId],
+  )
+  return result.rows.map(mapRow)
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export const purchasedCreditsRepository = {
+  createPurchasedCredit,
+  getActiveByAccountId,
+  consumeCredits,
+  getRemainingCredits,
+  getExpiringCredits,
+  markExpiredCredits,
+  getByAccountId,
+}

--- a/packages/models/src/users/index.ts
+++ b/packages/models/src/users/index.ts
@@ -5,3 +5,4 @@ export * from "./organization.js";
 export * from "./apiKey.js";
 export * from "./jwt.js";
 export * from "./intent.js";
+export * from "./purchasedCredit.js";

--- a/packages/models/src/users/purchasedCredit.ts
+++ b/packages/models/src/users/purchasedCredit.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+
+export const PurchasedCreditSchema = z.object({
+  id: z.string().uuid(),
+  accountId: z.string(),
+  intentId: z.string(),
+  uploadBytesOriginal: z.bigint(),
+  uploadBytesRemaining: z.bigint(),
+  downloadBytesOriginal: z.bigint(),
+  downloadBytesRemaining: z.bigint(),
+  purchasedAt: z.date(),
+  /** Every purchased credit row has a hard expiry date — never null. */
+  expiresAt: z.date(),
+  expired: z.boolean(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+
+export type PurchasedCredit = z.infer<typeof PurchasedCreditSchema>;
+
+/**
+ * Aggregate view of an account's remaining purchased credits across all
+ * active (non-expired) rows. Returned by getRemainingPurchasedCredits()
+ * and used by the per-user cap enforcement check.
+ */
+export type PurchasedCreditSummary = {
+  uploadBytesRemaining: bigint;
+  downloadBytesRemaining: bigint;
+  /** The soonest expires_at across active rows — used for expiry warnings. */
+  nextExpiryDate: Date | null;
+  activeRowCount: number;
+};
+
+/**
+ * Tracks whether an interaction was charged against purchased credits or
+ * against the account's free / one-off allocation.
+ *
+ * Stored in interactions.source. Required so the free-balance calculation
+ * (upload_limit - sum(interactions)) only counts free_tier rows and is not
+ * distorted by interactions that were already paid for by purchased credits.
+ */
+export enum InteractionSource {
+  FreeTier = "free_tier",
+  Purchased = "purchased",
+}


### PR DESCRIPTION
Introduces the data model foundation for Pay with AI3 economic protections.
Free/one-off allocation credits remain untouched on accounts.upload_limit /
accounts.download_limit. Purchased credits get their own table so the two
systems are completely independent — the upload path will check purchased
credits first and fall back to the existing allocation if none are available.

## What's added

**Migration 1 — purchased_credits table (20260302000000)**
- One row per purchase, each with an independent expires_at (never NULL).
- upload/download_bytes_original are immutable snapshots; _remaining columns
  are decremented by the FIFO consumption logic.
- Index on (account_id, expired, expires_at) covers every active-credits query.

**Migration 2 — interactions.source column (20260302000001)**
- Adds source VARCHAR(32) CHECK IN ('free_tier', 'purchased') to interactions.
- Default 'free_tier' backfills all existing rows correctly.
- Required so the free-balance calculation (upload_limit - sum(interactions))
  only counts free_tier rows and is not distorted by uploads charged against
  purchased credits.

**@auto-drive/models — new types**
- PurchasedCreditSchema / PurchasedCredit — typed row from purchased_credits.
- PurchasedCreditSummary — aggregate returned by getRemainingCredits().
- InteractionSource enum (free_tier | purchased) — matches the new DB column.

**purchasedCredits repository**
- createPurchasedCredit() — called by onConfirmedIntent() in the next PR.
- getActiveByAccountId() — FIFO-ordered (soonest-expiry first).
- consumeCredits() — transactional FIFO deduction with FOR UPDATE row lock
  to prevent concurrent uploads from double-spending. Returns neverthrow
  InsufficientPurchasedCreditsError so the caller can fall back gracefully.
- getRemainingCredits() — single-query aggregate for cap enforcement.
- getExpiringCredits(withinDays) — for expiry warning banners.
- markExpiredCredits() — atomic CTE UPDATE for the expiry background job.
- getByAccountId() — full history including expired rows.

**config.ts — credits block**
- CREDIT_EXPIRY_DAYS (default 90)
- MAX_CREDITS_PER_USER (default 100 GiB as BigInt)
- CREDIT_EXPIRY_CHECK_INTERVAL (default 3600000 ms)

## What is NOT changed

- accounts table, upload_limit, download_limit — untouched.
- interactions table data and all existing queries — untouched (column add only).
- All existing use-cases and controllers — untouched.
- buyCredits feature flag and its middleware — untouched.
- TypeScript: zero errors across packages/models and apps/backend.