### PR TITLE
Feat/pay with ai3/step 10 payment robustness

### DIFF
--- a/apps/backend/.env.sample
+++ b/apps/backend/.env.sample
@@ -4,5 +4,60 @@ FILES_GATEWAY_URL=http://changeme.com # change to your own (or it'll fail when f
 FILES_GATEWAY_TOKEN=changeme # change to your own (or it'll fail when fetching archived files)
 AUTH_SERVICE_API_KEY=1234567890 # change to your own if updated in auth
 RABBITMQ_URL=amqp://guest:guest@localhost:5672
-EVM_CHAIN_ENDPOINT=http://localhost:8545 # update it you want to simulate/test buy credits feature
-EVM_CHAIN_CONTRACT_ADDRESS=0x0000000000000000000000000000000000000000 # update it you want to simulate/test buy credits feature
+
+# ---------------------------------------------------------------------------
+# Pay-with-AI3 / purchased credits feature
+# ---------------------------------------------------------------------------
+
+# Feature flags — set BUY_CREDITS_ACTIVE=true to enable the purchase flow.
+# BUY_CREDITS_STAFF_ONLY=true restricts it to admin/staff accounts only,
+# useful for a staged rollout before opening to all users.
+BUY_CREDITS_ACTIVE=false
+BUY_CREDITS_STAFF_ONLY=false
+
+# EVM endpoint for the AutoDriveCreditsReceiver contract.
+# Point this at the Auto-EVM RPC for the target network (mainnet or Taurus
+# testnet).  The payment manager watches this chain for deposit events.
+EVM_CHAIN_ENDPOINT=http://localhost:8545
+
+# Address of the deployed AutoDriveCreditsReceiver contract.
+# Must match the chain pointed to by EVM_CHAIN_ENDPOINT.
+EVM_CHAIN_CONTRACT_ADDRESS=0x0000000000000000000000000000000000000000
+
+# Number of block confirmations to wait before treating a payment as final.
+# Higher values reduce the risk of processing a payment that is later
+# reversed by a chain reorganisation. Default: 6.
+EVM_CHAIN_CONFIRMATIONS=6
+
+# How often (in milliseconds) the payment manager polls for CONFIRMED intents
+# that have not yet had credits applied. This is a fallback for cases where
+# the event watcher misses a log. Default: 30000 (30 seconds).
+EVM_CHAIN_CHECK_INTERVAL=30000
+
+# Price multiplier applied on top of the raw Autonomys consensus fee to
+# determine the AI3 cost per byte. A value of 5.0 means users pay 5× the
+# current on-chain transaction byte fee. Default: 5.00.
+CREDITS_PRICE_MULTIPLIER=5.00
+
+# ---------------------------------------------------------------------------
+# Credit lifecycle
+# ---------------------------------------------------------------------------
+
+# Number of days after purchase before a credit batch expires.
+# Users see this value on the purchase confirmation screen and in their credit
+# history. Default: 90.
+CREDIT_EXPIRY_DAYS=90
+
+# Maximum total purchased upload bytes allowed per user across all active
+# (non-expired) credit rows. Attempts to purchase beyond this cap result in
+# an OVER_CAP intent requiring admin review. Default: 107374182400 (100 GiB).
+MAX_CREDITS_PER_USER=107374182400
+
+# How often (in milliseconds) the background job runs to mark expired credit
+# rows and clean up stale PENDING intents. Default: 3600000 (1 hour).
+CREDIT_EXPIRY_CHECK_INTERVAL=3600000
+
+# How many minutes a PENDING intent remains valid before it is treated as
+# expired. Users must submit their on-chain transaction within this window
+# after creating an intent. Default: 10.
+INTENT_EXPIRY_MINUTES=10

--- a/apps/backend/src/app/controllers/credits.ts
+++ b/apps/backend/src/app/controllers/credits.ts
@@ -118,6 +118,44 @@ creditsController.get(
 )
 
 // ---------------------------------------------------------------------------
+// GET /credits/batches/all
+// Admin-only: all credit batches across every user, newest-first.
+// Each row includes the owner's userPublicId for easy cross-referencing
+// with the admin user table.  Returns 403 for non-admin callers.
+//
+// NOTE: registered BEFORE GET /credits/batches so Express does not attempt
+// to match the literal string "all" against the existing /batches route
+// (they are separate paths and Express won't confuse them, but ordering
+// here keeps the admin routes grouped together).
+// ---------------------------------------------------------------------------
+
+creditsController.get(
+  '/batches/all',
+  asyncSafeHandler(async (req, res) => {
+    const user = await handleAuth(req, res)
+    if (!user) {
+      return
+    }
+
+    const result = await handleInternalErrorResult(
+      CreditsUseCases.getAllBatches(user),
+      'Failed to get all credit batches',
+    )
+    if (result.isErr()) {
+      handleError(result.error, res)
+      return
+    }
+
+    res.status(200).json(
+      result.value.map((batch) => ({
+        ...serializeCredit(batch),
+        userPublicId: batch.userPublicId,
+      })),
+    )
+  }),
+)
+
+// ---------------------------------------------------------------------------
 // GET /credits/economics
 // Admin-only: system-wide credit stats (expiring totals, byte volumes).
 // Returns 403 for non-admin users.

--- a/apps/backend/src/core/users/credits.ts
+++ b/apps/backend/src/core/users/credits.ts
@@ -1,5 +1,8 @@
 import { PurchasedCredit, User, UserRole, UserWithOrganization } from '@auto-drive/models'
-import { purchasedCreditsRepository } from '../../infrastructure/repositories/users/purchasedCredits.js'
+import {
+  AdminCreditBatchRow,
+  purchasedCreditsRepository,
+} from '../../infrastructure/repositories/users/purchasedCredits.js'
 import { AccountsUseCases } from './accounts.js'
 import { config } from '../../config.js'
 import { ForbiddenError } from '../../errors/index.js'
@@ -140,9 +143,30 @@ const getEconomics = async (
   })
 }
 
+// ---------------------------------------------------------------------------
+// getAllBatches
+// Admin-only: full purchase history across all users with their publicId.
+// Returns 403 for non-admin callers.
+// ---------------------------------------------------------------------------
+
+const getAllBatches = async (
+  executor: User,
+): Promise<Result<AdminCreditBatchRow[], ForbiddenError>> => {
+  if (executor.role !== UserRole.Admin) {
+    logger.warn('Non-admin user attempted to access all credit batches', {
+      publicId: executor.publicId,
+    })
+    return err(new ForbiddenError('Admin access required'))
+  }
+
+  const rows = await purchasedCreditsRepository.getAllWithUserPublicId()
+  return ok(rows)
+}
+
 export const CreditsUseCases = {
   getSummary,
   getBatches,
   getExpiringBatches,
   getEconomics,
+  getAllBatches,
 }

--- a/apps/backend/src/core/users/intents.ts
+++ b/apps/backend/src/core/users/intents.ts
@@ -166,7 +166,9 @@ const markIntentAsConfirmed = async ({
   if (
     intent.status === IntentStatus.CONFIRMED ||
     intent.status === IntentStatus.COMPLETED ||
-    intent.status === IntentStatus.OVER_CAP
+    intent.status === IntentStatus.OVER_CAP ||
+    intent.status === IntentStatus.FAILED ||
+    intent.status === IntentStatus.EXPIRED
   ) {
     logger.info('markIntentAsConfirmed: intent already processed — skipping', {
       intentId,

--- a/apps/backend/src/core/users/intents.ts
+++ b/apps/backend/src/core/users/intents.ts
@@ -371,6 +371,13 @@ const getPrice = async (): Promise<{ price: number; pricePerGB: number }> => {
   }
 }
 
+// Returns PENDING intents that already have a tx_hash — used by the payment
+// manager startup sweep to re-watch transactions that were submitted but never
+// confirmed due to a service restart or RPC outage.
+const getPendingWithTxHash = async (): Promise<Intent[]> => {
+  return intentsRepository.getPendingWithTxHash()
+}
+
 export const IntentsUseCases = {
   createIntent,
   getIntent,
@@ -380,6 +387,7 @@ export const IntentsUseCases = {
   markIntentAsConfirmed,
   getConfirmedIntents,
   getOverCapIntents,
+  getPendingWithTxHash,
   reprocessOverCapIntent,
   getIntentCredits,
   getPrice,

--- a/apps/backend/src/core/users/intents.ts
+++ b/apps/backend/src/core/users/intents.ts
@@ -155,8 +155,28 @@ const markIntentAsConfirmed = async ({
     return err(new ObjectNotFoundError('Intent not found'))
   }
 
+  // Idempotency guard — do not overwrite an intent that is already in a
+  // post-PENDING state.  Duplicate calls arise from:
+  //   • chain reorgs causing the same event to be re-emitted
+  //   • the payment manager reconnecting and re-processing already-seen logs
+  //   • watchTransaction and the _checkConfirmedIntents polling loop racing
+  //
+  // We return ok() rather than an error so the caller does not treat a
+  // duplicate as a failure and does not retry indefinitely.
+  if (
+    intent.status === IntentStatus.CONFIRMED ||
+    intent.status === IntentStatus.COMPLETED ||
+    intent.status === IntentStatus.OVER_CAP
+  ) {
+    logger.info('markIntentAsConfirmed: intent already processed — skipping', {
+      intentId,
+      currentStatus: intent.status,
+    })
+    return ok(intent)
+  }
+
   return ok(
-    intentsRepository.updateIntent({
+    await intentsRepository.updateIntent({
       ...intent,
       status: IntentStatus.CONFIRMED,
       paymentAmount,

--- a/apps/backend/src/core/users/intents.ts
+++ b/apps/backend/src/core/users/intents.ts
@@ -209,9 +209,34 @@ const onConfirmedIntent = async (intentId: string) => {
     return err(new Error('Intent has no deposit amount'))
   }
 
+  // Guard: reject payments whose value is too small to purchase even a single
+  // byte of storage.  getIntentCredits divides paymentAmount by shannonsPerByte
+  // using BigInt integer division, so a dust payment (paymentAmount <
+  // shannonsPerByte) yields 0 credits.  Granting 0 credits would mark the
+  // intent COMPLETED while giving the user nothing — a misleading outcome that
+  // wastes a DB row and silently discards the payment.
+  //
+  // Instead we log a warning and return an error so the polling loop retries
+  // (in case of a transient pricing mismatch) and operators are alerted.
+  // In practice this should never happen because the frontend enforces a
+  // minimum package size, but the guard defends against buggy clients or
+  // future contract changes.
+  const creditBytes = IntentsUseCases.getIntentCredits(intent)
+  if (creditBytes === BigInt(0)) {
+    logger.warn(
+      'onConfirmedIntent: payment too small to yield any credits — skipping',
+      {
+        intentId,
+        paymentAmount: intent.paymentAmount.toString(),
+        shannonsPerByte: intent.shannonsPerByte.toString(),
+      },
+    )
+    return err(new Error('Payment amount yields zero credits'))
+  }
+
   const addResult = await AccountsUseCases.addCreditsToAccount(
     intent.userPublicId,
-    IntentsUseCases.getIntentCredits(intent),
+    creditBytes,
     intentId,
   )
 

--- a/apps/backend/src/core/users/intents.ts
+++ b/apps/backend/src/core/users/intents.ts
@@ -216,22 +216,25 @@ const onConfirmedIntent = async (intentId: string) => {
   // intent COMPLETED while giving the user nothing — a misleading outcome that
   // wastes a DB row and silently discards the payment.
   //
-  // Instead we log a warning and return an error so the polling loop retries
-  // (in case of a transient pricing mismatch) and operators are alerted.
-  // In practice this should never happen because the frontend enforces a
-  // minimum package size, but the guard defends against buggy clients or
-  // future contract changes.
+  // Both paymentAmount and shannonsPerByte are immutable on a confirmed intent,
+  // so this condition is permanent.  We mark the intent FAILED (terminal) so
+  // the polling loop stops retrying.  The on-chain payment is irreversible;
+  // resolution requires admin review (similar to OVER_CAP handling).
   const creditBytes = IntentsUseCases.getIntentCredits(intent)
   if (creditBytes === BigInt(0)) {
     logger.warn(
-      'onConfirmedIntent: payment too small to yield any credits — skipping',
+      'onConfirmedIntent: payment too small to yield any credits — marking FAILED',
       {
         intentId,
         paymentAmount: intent.paymentAmount.toString(),
         shannonsPerByte: intent.shannonsPerByte.toString(),
       },
     )
-    return err(new Error('Payment amount yields zero credits'))
+    await intentsRepository.updateIntent({
+      ...intent,
+      status: IntentStatus.FAILED,
+    })
+    return ok()
   }
 
   const addResult = await AccountsUseCases.addCreditsToAccount(

--- a/apps/backend/src/infrastructure/repositories/users/intents.ts
+++ b/apps/backend/src/infrastructure/repositories/users/intents.ts
@@ -117,6 +117,23 @@ const expireIntentIfPending = async (intentId: string): Promise<boolean> => {
   return (result.rowCount ?? 0) > 0
 }
 
+// Returns PENDING intents that already have an on-chain tx_hash.
+// These are intents where the user submitted a transaction but the payment
+// manager did not process the confirmation event — typically because the
+// service was restarted or the EVM RPC was temporarily unavailable.
+// Used by the startup recovery sweep so that no paid transaction is silently
+// abandoned across a service restart.
+const getPendingWithTxHash = async (): Promise<Intent[]> => {
+  const db = await getDatabase()
+  const result = await db.query<DBIntent>(
+    `SELECT * FROM intents
+     WHERE status = $1
+       AND tx_hash IS NOT NULL`,
+    [IntentStatus.PENDING],
+  )
+  return mapRows(result.rows)
+}
+
 // Returns all intents that were blocked by the per-user cap.
 // These are terminal — the polling loop skips them — and require admin review.
 const getOverCapIntents = async (): Promise<Intent[]> => {
@@ -136,4 +153,5 @@ export const intentsRepository = {
   getExpiredPendingIntents,
   expireIntentIfPending,
   getOverCapIntents,
+  getPendingWithTxHash,
 }

--- a/apps/backend/src/infrastructure/repositories/users/purchasedCredits.ts
+++ b/apps/backend/src/infrastructure/repositories/users/purchasedCredits.ts
@@ -549,6 +549,30 @@ const createPurchasedCreditWithCapCheck = async (
 }
 
 // ---------------------------------------------------------------------------
+// getAllWithUserPublicId
+// Admin view: every credit batch across all users, joined with the
+// user_public_id from the originating intent row. Ordered newest-first.
+// ---------------------------------------------------------------------------
+
+export type AdminCreditBatchRow = PurchasedCredit & {
+  userPublicId: string
+}
+
+const getAllWithUserPublicId = async (): Promise<AdminCreditBatchRow[]> => {
+  const db = await getDatabase()
+  const result = await db.query<DBPurchasedCredit & { user_public_id: string }>(
+    `SELECT pc.*, i.user_public_id
+     FROM purchased_credits pc
+     JOIN intents i ON i.id = pc.intent_id
+     ORDER BY pc.purchased_at DESC`,
+  )
+  return result.rows.map((row) => ({
+    ...mapRow(row),
+    userPublicId: row.user_public_id,
+  }))
+}
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
@@ -564,4 +588,5 @@ export const purchasedCreditsRepository = {
   createPurchasedCreditWithCapCheck,
   markExpiredCredits,
   getByAccountId,
+  getAllWithUserPublicId,
 }

--- a/apps/backend/src/infrastructure/services/paymentManager/index.ts
+++ b/apps/backend/src/infrastructure/services/paymentManager/index.ts
@@ -122,8 +122,56 @@ const parseEventLogs = <
 let checkInterval: NodeJS.Timeout | null = null
 let unwatchContractEvent: (() => void) | null = null
 
+// On startup, re-watch any PENDING intents that already have a tx_hash.
+// These represent transactions submitted by users before the last service
+// restart or during an EVM RPC outage.  The cleanup job explicitly skips
+// PENDING+txHash rows (they are not abandoned — they are actively watched),
+// so without this sweep they would sit in limbo indefinitely: the user paid
+// on-chain but receives no credits.
+//
+// Re-calling watchTransaction for each orphan is safe:
+//   • waitForTransactionReceipt returns immediately for already-mined txs
+//   • markIntentAsConfirmed is idempotent — a duplicate CONFIRMED write is a
+//     no-op if the intent was already processed before the restart
+const _recoverOrphanedTransactions = async () => {
+  const pending = await IntentsUseCases.getPendingWithTxHash()
+  if (pending.length === 0) {
+    logger.info('Startup recovery: no orphaned transactions found')
+    return
+  }
+
+  logger.info('Startup recovery: re-watching orphaned transactions', {
+    count: pending.length,
+    intentIds: pending.map((i) => i.id),
+  })
+
+  await Promise.allSettled(
+    pending.map(async (intent) => {
+      if (!intent.txHash) return
+      try {
+        await paymentManager.watchTransaction(intent.txHash)
+        logger.info('Startup recovery: transaction recovered', {
+          intentId: intent.id,
+          txHash: intent.txHash,
+        })
+      } catch (err) {
+        logger.error('Startup recovery: failed to recover transaction', {
+          intentId: intent.id,
+          txHash: intent.txHash,
+          err,
+        })
+      }
+    }),
+  )
+}
+
 const start = () => {
   logger.info('Starting payment manager')
+
+  // Run the recovery sweep asynchronously so it does not block startup.
+  // Errors inside the sweep are caught per-intent and logged individually.
+  safeCallback(paymentManager._recoverOrphanedTransactions)()
+
   checkInterval = setInterval(
     safeCallback(paymentManager._checkConfirmedIntents),
     config.paymentManager.checkInterval,
@@ -154,6 +202,7 @@ export const paymentManager = {
   stop,
   _onLogs: onLogs,
   _checkConfirmedIntents: _checkConfirmedIntents,
+  _recoverOrphanedTransactions: _recoverOrphanedTransactions,
   _viemClient: viemClient,
   _parseEventLogs: parseEventLogs,
 }

--- a/apps/frontend/__tests__/unit/utils/credits.spec.ts
+++ b/apps/frontend/__tests__/unit/utils/credits.spec.ts
@@ -1,4 +1,4 @@
-import { isPackageOverCap, daysUntilExpiry, sumExpiringUploadBytes } from '../../../src/utils/credits'
+import { isPackageOverCap, daysUntilExpiry, sumExpiringUploadBytes, getBatchStatus } from '../../../src/utils/credits'
 
 // ---------------------------------------------------------------------------
 // isPackageOverCap
@@ -126,5 +126,56 @@ describe('sumExpiringUploadBytes', () => {
       { uploadBytesRemaining: oneMiB.toString() },
     ]
     expect(sumExpiringUploadBytes(batches)).toBe(oneMiB * 3n)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getBatchStatus
+// ---------------------------------------------------------------------------
+
+describe('getBatchStatus', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date('2026-06-01T00:00:00Z'))
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  const makeBatch = (overrides: Partial<{ expired: boolean; uploadBytesRemaining: string; expiresAt: string }> = {}) => ({
+    expired: false,
+    uploadBytesRemaining: '1048576',
+    expiresAt: '2026-12-01T00:00:00Z',
+    ...overrides,
+  })
+
+  it('returns "expired" when batch.expired is true', () => {
+    expect(getBatchStatus(makeBatch({ expired: true }))).toBe('expired')
+  })
+
+  it('returns "depleted" when uploadBytesRemaining is zero', () => {
+    expect(getBatchStatus(makeBatch({ uploadBytesRemaining: '0' }))).toBe('depleted')
+  })
+
+  it('returns "expiring" when the batch expires within 30 days', () => {
+    // 15 days from "now" (2026-06-01)
+    expect(getBatchStatus(makeBatch({ expiresAt: '2026-06-16T00:00:00Z' }))).toBe('expiring')
+  })
+
+  it('returns "expiring" when the batch expires in exactly 30 days', () => {
+    expect(getBatchStatus(makeBatch({ expiresAt: '2026-07-01T00:00:00Z' }))).toBe('expiring')
+  })
+
+  it('returns "active" when the batch expires in more than 30 days', () => {
+    expect(getBatchStatus(makeBatch({ expiresAt: '2026-07-02T00:00:00Z' }))).toBe('active')
+  })
+
+  it('prioritises "expired" over "depleted"', () => {
+    expect(getBatchStatus(makeBatch({ expired: true, uploadBytesRemaining: '0' }))).toBe('expired')
+  })
+
+  it('prioritises "depleted" over "expiring"', () => {
+    expect(getBatchStatus(makeBatch({ uploadBytesRemaining: '0', expiresAt: '2026-06-10T00:00:00Z' }))).toBe('depleted')
   })
 })

--- a/apps/frontend/src/components/views/AdminPanel/AdminCredits.tsx
+++ b/apps/frontend/src/components/views/AdminPanel/AdminCredits.tsx
@@ -6,42 +6,12 @@ import { formatBytes } from '../../../utils/number';
 import { formatDate } from '../../../utils/time';
 import { RefreshCw, AlertTriangle, RotateCcw } from 'lucide-react';
 import { Button } from '@auto-drive/ui';
+import { getBatchStatus, STATUS_CLASSES, STATUS_LABEL } from '../../../utils/credits';
 import type {
   AdminCreditBatch,
   CreditEconomicsResponse,
   OverCapIntent,
 } from '../../../services/api';
-
-// ---------------------------------------------------------------------------
-// Batch status helpers (mirrors CreditHistory)
-// ---------------------------------------------------------------------------
-
-type BatchStatus = 'active' | 'expiring' | 'depleted' | 'expired';
-
-const getBatchStatus = (batch: AdminCreditBatch): BatchStatus => {
-  if (batch.expired) return 'expired';
-  if (BigInt(batch.uploadBytesRemaining) === BigInt(0)) return 'depleted';
-  const msLeft =
-    new Date(batch.expiresAt).getTime() - Date.now();
-  const daysLeft = Math.ceil(msLeft / (1000 * 60 * 60 * 24));
-  if (daysLeft <= 30) return 'expiring';
-  return 'active';
-};
-
-const STATUS_CLASSES: Record<BatchStatus, string> = {
-  active: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
-  expiring:
-    'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400',
-  depleted: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400',
-  expired: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
-};
-
-const STATUS_LABEL: Record<BatchStatus, string> = {
-  active: 'Active',
-  expiring: 'Expiring soon',
-  depleted: 'Depleted',
-  expired: 'Expired',
-};
 
 // ---------------------------------------------------------------------------
 // Economics summary card

--- a/apps/frontend/src/components/views/AdminPanel/AdminCredits.tsx
+++ b/apps/frontend/src/components/views/AdminPanel/AdminCredits.tsx
@@ -1,0 +1,345 @@
+'use client';
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useNetwork } from '../../../contexts/network';
+import { formatBytes } from '../../../utils/number';
+import { formatDate } from '../../../utils/time';
+import { RefreshCw, AlertTriangle, RotateCcw } from 'lucide-react';
+import { Button } from '@auto-drive/ui';
+import type {
+  AdminCreditBatch,
+  CreditEconomicsResponse,
+  OverCapIntent,
+} from '../../../services/api';
+
+// ---------------------------------------------------------------------------
+// Batch status helpers (mirrors CreditHistory)
+// ---------------------------------------------------------------------------
+
+type BatchStatus = 'active' | 'expiring' | 'depleted' | 'expired';
+
+const getBatchStatus = (batch: AdminCreditBatch): BatchStatus => {
+  if (batch.expired) return 'expired';
+  if (BigInt(batch.uploadBytesRemaining) === BigInt(0)) return 'depleted';
+  const msLeft =
+    new Date(batch.expiresAt).getTime() - Date.now();
+  const daysLeft = Math.ceil(msLeft / (1000 * 60 * 60 * 24));
+  if (daysLeft <= 30) return 'expiring';
+  return 'active';
+};
+
+const STATUS_CLASSES: Record<BatchStatus, string> = {
+  active: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+  expiring:
+    'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400',
+  depleted: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400',
+  expired: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
+};
+
+const STATUS_LABEL: Record<BatchStatus, string> = {
+  active: 'Active',
+  expiring: 'Expiring soon',
+  depleted: 'Depleted',
+  expired: 'Expired',
+};
+
+// ---------------------------------------------------------------------------
+// Economics summary card
+// ---------------------------------------------------------------------------
+
+const EconomicsCard = ({
+  economics,
+}: {
+  economics: CreditEconomicsResponse;
+}) => (
+  <div className='grid grid-cols-1 gap-4 sm:grid-cols-3'>
+    <div className='rounded-lg border border-border bg-card p-4'>
+      <p className='text-xs text-muted-foreground'>Batches expiring ≤ 30 d</p>
+      <p className='mt-1 text-2xl font-semibold text-foreground'>
+        {economics.totalExpiringWithin30Days}
+      </p>
+    </div>
+    <div className='rounded-lg border border-border bg-card p-4'>
+      <p className='text-xs text-muted-foreground'>Upload bytes expiring</p>
+      <p className='mt-1 text-2xl font-semibold text-foreground'>
+        {formatBytes(Number(BigInt(economics.totalExpiringUploadBytes)), 1)}
+      </p>
+    </div>
+    <div className='rounded-lg border border-border bg-card p-4'>
+      <p className='text-xs text-muted-foreground'>Download bytes expiring</p>
+      <p className='mt-1 text-2xl font-semibold text-foreground'>
+        {formatBytes(Number(BigInt(economics.totalExpiringDownloadBytes)), 1)}
+      </p>
+    </div>
+  </div>
+);
+
+// ---------------------------------------------------------------------------
+// OVER_CAP intents panel
+// ---------------------------------------------------------------------------
+
+const OverCapPanel = ({
+  intents,
+  onReprocess,
+  reprocessingId,
+}: {
+  intents: OverCapIntent[];
+  onReprocess: (id: string) => void;
+  reprocessingId: string | null;
+}) => {
+  if (intents.length === 0) {
+    return (
+      <p className='text-sm text-muted-foreground'>
+        No over-cap intents — all payments resolved.
+      </p>
+    );
+  }
+
+  return (
+    <div className='overflow-x-auto'>
+      <table className='w-full text-sm'>
+        <thead>
+          <tr className='border-b border-border text-left text-xs text-muted-foreground'>
+            <th className='pb-2 pr-4 font-medium'>Intent ID</th>
+            <th className='pb-2 pr-4 font-medium'>User</th>
+            <th className='pb-2 pr-4 font-medium'>Paid (AI3 shannons)</th>
+            <th className='pb-2 pr-4 font-medium'>Tx hash</th>
+            <th className='pb-2 font-medium'>Action</th>
+          </tr>
+        </thead>
+        <tbody>
+          {intents.map((intent) => (
+            <tr
+              key={intent.id}
+              className='border-b border-border last:border-0'
+            >
+              <td className='py-2 pr-4 font-mono text-xs'>
+                {intent.id.slice(0, 12)}…
+              </td>
+              <td className='py-2 pr-4 font-mono text-xs'>
+                {intent.userPublicId.slice(0, 12)}…
+              </td>
+              <td className='py-2 pr-4'>
+                {intent.paymentAmount ?? '—'}
+              </td>
+              <td className='py-2 pr-4 font-mono text-xs'>
+                {intent.txHash
+                  ? `${intent.txHash.slice(0, 10)}…`
+                  : '—'}
+              </td>
+              <td className='py-2'>
+                <Button
+                  variant='outline'
+                  disabled={reprocessingId === intent.id}
+                  onClick={() => onReprocess(intent.id)}
+                  className='flex items-center gap-1 text-xs'
+                >
+                  <RotateCcw className='h-3 w-3' />
+                  {reprocessingId === intent.id ? 'Reprocessing…' : 'Reprocess'}
+                </Button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// All credit batches table
+// ---------------------------------------------------------------------------
+
+const AllBatchesTable = ({ batches }: { batches: AdminCreditBatch[] }) => {
+  if (batches.length === 0) {
+    return (
+      <p className='text-sm text-muted-foreground'>
+        No credit batches have been purchased yet.
+      </p>
+    );
+  }
+
+  return (
+    <div className='overflow-x-auto'>
+      <table className='w-full text-sm'>
+        <thead>
+          <tr className='border-b border-border text-left text-xs text-muted-foreground'>
+            <th className='pb-2 pr-4 font-medium'>User</th>
+            <th className='pb-2 pr-4 font-medium'>Status</th>
+            <th className='pb-2 pr-4 font-medium'>Purchased</th>
+            <th className='pb-2 pr-4 font-medium'>Original</th>
+            <th className='pb-2 pr-4 font-medium'>Remaining</th>
+            <th className='pb-2 pr-4 font-medium'>Used %</th>
+            <th className='pb-2 font-medium'>Expires</th>
+          </tr>
+        </thead>
+        <tbody>
+          {batches.map((batch) => {
+            const status = getBatchStatus(batch);
+            const original = Number(BigInt(batch.uploadBytesOriginal));
+            const remaining = Number(BigInt(batch.uploadBytesRemaining));
+            const usedPct =
+              original > 0
+                ? Math.round(((original - remaining) / original) * 100)
+                : 0;
+
+            return (
+              <tr
+                key={batch.id}
+                className='border-b border-border last:border-0'
+              >
+                <td className='py-2 pr-4 font-mono text-xs'>
+                  {batch.userPublicId.slice(0, 14)}…
+                </td>
+                <td className='py-2 pr-4'>
+                  <span
+                    className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_CLASSES[status]}`}
+                  >
+                    {STATUS_LABEL[status]}
+                  </span>
+                </td>
+                <td className='py-2 pr-4 text-xs'>
+                  {formatDate(batch.purchasedAt)}
+                </td>
+                <td className='py-2 pr-4 text-xs'>
+                  {formatBytes(original, 1)}
+                </td>
+                <td className='py-2 pr-4 text-xs'>
+                  {formatBytes(remaining, 1)}
+                </td>
+                <td className='py-2 pr-4'>
+                  <div className='flex items-center gap-2'>
+                    <div className='h-1.5 w-16 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700'>
+                      <div
+                        className='h-full rounded-full bg-blue-500'
+                        style={{ width: `${usedPct}%` }}
+                      />
+                    </div>
+                    <span className='text-xs text-muted-foreground'>
+                      {usedPct}%
+                    </span>
+                  </div>
+                </td>
+                <td className='py-2 text-xs'>
+                  {batch.expired ? (
+                    <span className='text-red-500'>
+                      Expired {formatDate(batch.expiresAt)}
+                    </span>
+                  ) : (
+                    formatDate(batch.expiresAt)
+                  )}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export const AdminCredits = () => {
+  const { api } = useNetwork();
+  const queryClient = useQueryClient();
+
+  const { data: economics, isLoading: economicsLoading } =
+    useQuery<CreditEconomicsResponse>({
+      queryKey: ['adminCreditEconomics'],
+      queryFn: () => api.getCreditEconomics(),
+      staleTime: 60_000,
+    });
+
+  const { data: batches = [], isLoading: batchesLoading } = useQuery<
+    AdminCreditBatch[]
+  >({
+    queryKey: ['adminCreditBatches'],
+    queryFn: () => api.getAdminCreditBatches(),
+    staleTime: 60_000,
+  });
+
+  const { data: overCapIntents = [], isLoading: overCapLoading } = useQuery<
+    OverCapIntent[]
+  >({
+    queryKey: ['adminOverCapIntents'],
+    queryFn: () => api.getOverCapIntents(),
+    staleTime: 30_000,
+  });
+
+  const { mutate: reprocess, variables: reprocessingId } = useMutation<
+    void,
+    Error,
+    string
+  >({
+    mutationFn: (intentId: string) => api.reprocessIntent(intentId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['adminOverCapIntents'] });
+      void queryClient.invalidateQueries({ queryKey: ['adminCreditBatches'] });
+    },
+  });
+
+  const isLoading = economicsLoading || batchesLoading || overCapLoading;
+
+  return (
+    <div className='space-y-8'>
+      <div className='flex items-center gap-2'>
+        <h2 className='text-xl font-semibold'>Purchased Credits</h2>
+        {isLoading && (
+          <RefreshCw className='h-4 w-4 animate-spin text-muted-foreground' />
+        )}
+      </div>
+
+      {/* Economics summary */}
+      <div>
+        <h3 className='mb-3 text-sm font-medium text-muted-foreground uppercase tracking-wide'>
+          System Economics (expiring ≤ 30 days)
+        </h3>
+        {economics ? (
+          <EconomicsCard economics={economics} />
+        ) : (
+          !economicsLoading && (
+            <p className='text-sm text-muted-foreground'>
+              No economics data available.
+            </p>
+          )
+        )}
+      </div>
+
+      {/* OVER_CAP intents */}
+      <div>
+        <div className='mb-3 flex items-center gap-2'>
+          <h3 className='text-sm font-medium text-muted-foreground uppercase tracking-wide'>
+            Over-Cap Intents
+          </h3>
+          {overCapIntents.length > 0 && (
+            <span className='inline-flex items-center gap-1 rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700 dark:bg-red-900/30 dark:text-red-400'>
+              <AlertTriangle className='h-3 w-3' />
+              {overCapIntents.length} need review
+            </span>
+          )}
+        </div>
+        <p className='mb-3 text-xs text-muted-foreground'>
+          Payments confirmed on-chain that could not be converted to credits
+          because the user hit the per-user cap. Raise the cap via the account
+          editor, then click Reprocess to retry.
+        </p>
+        <OverCapPanel
+          intents={overCapIntents}
+          onReprocess={(id) => reprocess(id)}
+          reprocessingId={reprocessingId ?? null}
+        />
+      </div>
+
+      {/* All batches table */}
+      <div>
+        <h3 className='mb-3 text-sm font-medium text-muted-foreground uppercase tracking-wide'>
+          All Purchase Batches ({batches.length})
+        </h3>
+        <AllBatchesTable batches={batches} />
+      </div>
+    </div>
+  );
+};

--- a/apps/frontend/src/components/views/AdminPanel/AdminCredits.tsx
+++ b/apps/frontend/src/components/views/AdminPanel/AdminCredits.tsx
@@ -82,10 +82,12 @@ const OverCapPanel = ({
   intents,
   onReprocess,
   reprocessingId,
+  isPending,
 }: {
   intents: OverCapIntent[];
   onReprocess: (id: string) => void;
   reprocessingId: string | null;
+  isPending: boolean;
 }) => {
   if (intents.length === 0) {
     return (
@@ -130,12 +132,12 @@ const OverCapPanel = ({
               <td className='py-2'>
                 <Button
                   variant='outline'
-                  disabled={reprocessingId === intent.id}
+                  disabled={isPending && reprocessingId === intent.id}
                   onClick={() => onReprocess(intent.id)}
                   className='flex items-center gap-1 text-xs'
                 >
                   <RotateCcw className='h-3 w-3' />
-                  {reprocessingId === intent.id ? 'Reprocessing…' : 'Reprocess'}
+                  {isPending && reprocessingId === intent.id ? 'Reprocessing…' : 'Reprocess'}
                 </Button>
               </td>
             </tr>
@@ -269,7 +271,7 @@ export const AdminCredits = () => {
     staleTime: 30_000,
   });
 
-  const { mutate: reprocess, variables: reprocessingId } = useMutation<
+  const { mutate: reprocess, variables: reprocessingId, isPending: isReprocessing } = useMutation<
     void,
     Error,
     string
@@ -330,6 +332,7 @@ export const AdminCredits = () => {
           intents={overCapIntents}
           onReprocess={(id) => reprocess(id)}
           reprocessingId={reprocessingId ?? null}
+          isPending={isReprocessing}
         />
       </div>
 

--- a/apps/frontend/src/components/views/AdminPanel/index.tsx
+++ b/apps/frontend/src/components/views/AdminPanel/index.tsx
@@ -11,6 +11,7 @@ import {
 import { useNetwork } from 'contexts/network';
 import { Button } from '@auto-drive/ui';
 import { AdminStats } from './AdminStats';
+import { AdminCredits } from './AdminCredits';
 
 export const AdminPanel = () => {
   const [accountsWithUsers, setAccountsWithUsers] = useState<
@@ -133,6 +134,11 @@ export const AdminPanel = () => {
 
       {/* Analytics Section */}
       <AdminStats />
+
+      {/* Purchased Credits Section */}
+      <div className='rounded-lg border border-gray-200 bg-background p-6'>
+        <AdminCredits />
+      </div>
 
       {/* Users Section */}
       <div className='rounded-lg border border-gray-200 bg-background p-6'>

--- a/apps/frontend/src/components/views/CreditHistory/index.tsx
+++ b/apps/frontend/src/components/views/CreditHistory/index.tsx
@@ -6,41 +6,17 @@ import { useUserStore } from '../../../globalStates/user';
 import { AccountModel } from '@auto-drive/models';
 import { formatBytes } from '../../../utils/number';
 import { formatDate } from '../../../utils/time';
-import { daysUntilExpiry } from '../../../utils/credits';
+import {
+  daysUntilExpiry,
+  getBatchStatus,
+  STATUS_CLASSES,
+  STATUS_LABEL,
+} from '../../../utils/credits';
 import Link from 'next/link';
 import { Button } from '@auto-drive/ui';
 import { ShoppingCart, RefreshCw } from 'lucide-react';
 import { useMemo } from 'react';
 import type { ExpiringCreditBatch } from '../../../services/api';
-
-// ---------------------------------------------------------------------------
-// Batch status helpers
-// ---------------------------------------------------------------------------
-
-type BatchStatus = 'active' | 'expiring' | 'depleted' | 'expired';
-
-const getBatchStatus = (batch: ExpiringCreditBatch): BatchStatus => {
-  if (batch.expired) return 'expired';
-  if (BigInt(batch.uploadBytesRemaining) === BigInt(0)) return 'depleted';
-  const days = daysUntilExpiry(new Date(batch.expiresAt));
-  if (days !== null && days <= 30) return 'expiring';
-  return 'active';
-};
-
-const STATUS_LABEL: Record<BatchStatus, string> = {
-  active: 'Active',
-  expiring: 'Expiring soon',
-  depleted: 'Depleted',
-  expired: 'Expired',
-};
-
-const STATUS_CLASSES: Record<BatchStatus, string> = {
-  active: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
-  expiring:
-    'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400',
-  depleted: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400',
-  expired: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
-};
 
 // ---------------------------------------------------------------------------
 // Consumption progress bar

--- a/apps/frontend/src/services/api.ts
+++ b/apps/frontend/src/services/api.ts
@@ -35,6 +35,30 @@ export type ExpiringCreditBatch = {
   createdAt: string;
   updatedAt: string;
 };
+
+// Wire-format of rows from GET /credits/batches/all (admin endpoint).
+// Extends ExpiringCreditBatch with the owner's userPublicId.
+export type AdminCreditBatch = ExpiringCreditBatch & {
+  userPublicId: string;
+};
+
+// Wire-format of GET /credits/economics (admin)
+export type CreditEconomicsResponse = {
+  totalExpiringWithin30Days: number;
+  totalExpiringUploadBytes: string;
+  totalExpiringDownloadBytes: string;
+};
+
+// Wire-format of rows from GET /intents/over-cap (admin)
+export type OverCapIntent = {
+  id: string;
+  userPublicId: string;
+  status: string;
+  txHash?: string;
+  paymentAmount?: string;
+  shannonsPerByte: string;
+  expiresAt?: string;
+};
 import { getAuthSession } from 'utils/auth';
 import { uploadFileContent } from 'utils/file';
 
@@ -552,5 +576,103 @@ export const createApiService = ({
     }
 
     return response.json();
+  },
+
+  // -------------------------------------------------------------------------
+  // Admin: all credit batches across all users
+  // -------------------------------------------------------------------------
+
+  getAdminCreditBatches: async (): Promise<AdminCreditBatch[]> => {
+    const session = await getAuthSession();
+    if (!session?.authProvider || !session.accessToken) {
+      throw new Error('No session');
+    }
+
+    const response = await fetch(`${apiBaseUrl}/credits/batches/all`, {
+      headers: {
+        Authorization: `Bearer ${session.accessToken}`,
+        'X-Auth-Provider': session.authProvider,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Network response was not ok: ${response.statusText}`);
+    }
+
+    return response.json() as Promise<AdminCreditBatch[]>;
+  },
+
+  // -------------------------------------------------------------------------
+  // Admin: system-wide credit economics summary
+  // -------------------------------------------------------------------------
+
+  getCreditEconomics: async (): Promise<CreditEconomicsResponse> => {
+    const session = await getAuthSession();
+    if (!session?.authProvider || !session.accessToken) {
+      throw new Error('No session');
+    }
+
+    const response = await fetch(`${apiBaseUrl}/credits/economics`, {
+      headers: {
+        Authorization: `Bearer ${session.accessToken}`,
+        'X-Auth-Provider': session.authProvider,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Network response was not ok: ${response.statusText}`);
+    }
+
+    return response.json() as Promise<CreditEconomicsResponse>;
+  },
+
+  // -------------------------------------------------------------------------
+  // Admin: list OVER_CAP intents
+  // -------------------------------------------------------------------------
+
+  getOverCapIntents: async (): Promise<OverCapIntent[]> => {
+    const session = await getAuthSession();
+    if (!session?.authProvider || !session.accessToken) {
+      throw new Error('No session');
+    }
+
+    const response = await fetch(`${apiBaseUrl}/intents/over-cap`, {
+      headers: {
+        Authorization: `Bearer ${session.accessToken}`,
+        'X-Auth-Provider': session.authProvider,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Network response was not ok: ${response.statusText}`);
+    }
+
+    return response.json() as Promise<OverCapIntent[]>;
+  },
+
+  // -------------------------------------------------------------------------
+  // Admin: reprocess a single OVER_CAP intent
+  // -------------------------------------------------------------------------
+
+  reprocessIntent: async (intentId: string): Promise<void> => {
+    const session = await getAuthSession();
+    if (!session?.authProvider || !session.accessToken) {
+      throw new Error('No session');
+    }
+
+    const response = await fetch(
+      `${apiBaseUrl}/intents/${intentId}/reprocess`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${session.accessToken}`,
+          'X-Auth-Provider': session.authProvider,
+        },
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error(`Network response was not ok: ${response.statusText}`);
+    }
   },
 });

--- a/apps/frontend/src/utils/credits.ts
+++ b/apps/frontend/src/utils/credits.ts
@@ -38,3 +38,39 @@ export const sumExpiringUploadBytes = (
   batches: { uploadBytesRemaining: string }[],
 ): bigint =>
   batches.reduce((acc, b) => acc + BigInt(b.uploadBytesRemaining), BigInt(0));
+
+// ---------------------------------------------------------------------------
+// Batch status classification — shared by CreditHistory and AdminCredits
+// ---------------------------------------------------------------------------
+
+export type BatchStatus = 'active' | 'expiring' | 'depleted' | 'expired';
+
+export interface BatchStatusFields {
+  expired: boolean;
+  uploadBytesRemaining: string;
+  expiresAt: string;
+}
+
+export const getBatchStatus = (batch: BatchStatusFields): BatchStatus => {
+  if (batch.expired) return 'expired';
+  if (BigInt(batch.uploadBytesRemaining) === BigInt(0)) return 'depleted';
+  const days = daysUntilExpiry(new Date(batch.expiresAt));
+  if (days !== null && days <= 30) return 'expiring';
+  return 'active';
+};
+
+export const STATUS_CLASSES: Record<BatchStatus, string> = {
+  active:
+    'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+  expiring:
+    'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400',
+  depleted: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400',
+  expired: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
+};
+
+export const STATUS_LABEL: Record<BatchStatus, string> = {
+  active: 'Active',
+  expiring: 'Expiring soon',
+  depleted: 'Depleted',
+  expired: 'Expired',
+};


### PR DESCRIPTION
## Summary

Production-hardening for pay-with-AI3: idempotency, edge-case payment fixes, orphaned transaction recovery, env var documentation, and an admin credits panel.

- **Idempotency on payment confirmation** — `markIntentAsConfirmed` now skips re-processing if the intent is already `CONFIRMED`, `COMPLETED`, or `OVER_CAP`, preventing double credit grants from duplicate on-chain events.
- **Dust payment guard** — `onConfirmedIntent` now rejects payments where `paymentAmount / shannonsPerByte` rounds to zero, rather than silently marking the intent `COMPLETED` with 0 bytes granted.
- **Orphaned transaction recovery** — on startup, the payment manager sweeps for `PENDING` intents with a `tx_hash` (submitted while the manager was down) and resumes watching each one via `Promise.allSettled`.
- **`.env.sample` updated** — all 11 pay-with-AI3 env vars documented with descriptions and defaults.
- **Admin credits panel** — new section in the admin dashboard showing: system-wide credit economics (expiring totals), all `OVER_CAP` intents with a Reprocess button, and a full purchase history table across all users (user, status, original/remaining bytes, usage bar, expiry date). Backed by a new `GET /credits/batches/all` admin endpoint.

