### PR TITLE
fix(frontend): pass explicit gasPrice to fix MetaMask fee estimation …

### DIFF
--- a/apps/frontend/src/components/views/PurchaseCredits/steps/Step3_TransferTokens.tsx
+++ b/apps/frontend/src/components/views/PurchaseCredits/steps/Step3_TransferTokens.tsx
@@ -3,9 +3,9 @@
 import { Button } from '@auto-drive/ui';
 import { InfoRow } from '../atoms/InfoRow';
 import { Section } from '../atoms/Section';
-import { useAccount, useWriteContract } from 'wagmi';
+import { useAccount, usePublicClient, useWriteContract } from 'wagmi';
 import { useConnectModal } from '@rainbow-me/rainbowkit';
-import { type Hash } from 'viem';
+import { parseGwei, type Hash } from 'viem';
 import { useCallback, useEffect, useState } from 'react';
 import { usePaymentIntent } from '../../../../hooks/usePaymentIntent';
 import { useNetwork } from '../../../../contexts/network';
@@ -24,6 +24,7 @@ export const PurchaseStep3TransferTokens = ({
   void onBack;
   const { address, isConnected } = useAccount();
   const { openConnectModal } = useConnectModal();
+  const publicClient = usePublicClient();
   const { formatCreditsInMbAsValue, formatCreditsInMbAsAi3 } = usePrices();
   const [intentId, setIntentId] = useState<string | undefined>(undefined);
 
@@ -67,8 +68,17 @@ export const PurchaseStep3TransferTokens = ({
       const depositTransaction = await paymentIntent(
         formatCreditsInMbAsValue(Number(context.sizeMB)),
       );
+      // Auto EVM is a Substrate-based network that does not support EIP-1559
+      // fee history. Fetch the current gas price via eth_gasPrice and add a
+      // 1 GWEI buffer so MetaMask can display the fee correctly and the tx
+      // is reliably included without the user having to manually adjust gas.
+      const baseGasPrice = publicClient
+        ? await publicClient.getGasPrice()
+        : BigInt(0);
+      const gasPrice = baseGasPrice + parseGwei('1');
       const hash = await writeContractAsync({
         ...depositTransaction,
+        gasPrice,
       });
       setIntentId(depositTransaction.intentId);
       setTxHash(hash);
@@ -80,6 +90,7 @@ export const PurchaseStep3TransferTokens = ({
     paymentIntent,
     formatCreditsInMbAsValue,
     context.sizeMB,
+    publicClient,
     writeContractAsync,
   ]);
 

--- a/apps/frontend/src/components/views/PurchaseCredits/steps/Step3_TransferTokens.tsx
+++ b/apps/frontend/src/components/views/PurchaseCredits/steps/Step3_TransferTokens.tsx
@@ -72,13 +72,14 @@ export const PurchaseStep3TransferTokens = ({
       // fee history. Fetch the current gas price via eth_gasPrice and add a
       // 1 GWEI buffer so MetaMask can display the fee correctly and the tx
       // is reliably included without the user having to manually adjust gas.
-      const baseGasPrice = publicClient
-        ? await publicClient.getGasPrice()
-        : BigInt(0);
-      const gasPrice = baseGasPrice + parseGwei('1');
+      // When publicClient is unavailable, omit gasPrice entirely so the
+      // wallet falls back to its own fee estimation.
+      const gasPrice = publicClient
+        ? (await publicClient.getGasPrice()) + parseGwei('1')
+        : undefined;
       const hash = await writeContractAsync({
         ...depositTransaction,
-        gasPrice,
+        ...(gasPrice != null && { gasPrice }),
       });
       setIntentId(depositTransaction.intentId);
       setTxHash(hash);


### PR DESCRIPTION
…on Auto EVM

Auto EVM is a Substrate-based network that does not implement EIP-1559 fee history (eth_feeHistory). MetaMask falls back to its own estimation which fails on custom networks, showing "Network fee: Unavailable" and blocking confirmation.

Fix: fetch the current gas price via eth_gasPrice (which the network does support) and add a 1 GWEI buffer before passing it explicitly to writeContractAsync. Supplying gasPrice forces a legacy (type-0) transaction, bypassing EIP-1559 estimation entirely — MetaMask receives a concrete fee it can display, and the tx is reliably included without the user having to manually adjust gas.