### PR TITLE
feat(frontend): surface complete object metadata on details page

### DIFF
--- a/apps/frontend/src/components/organisms/ObjectDetails/ObjectUploadDetails.tsx
+++ b/apps/frontend/src/components/organisms/ObjectDetails/ObjectUploadDetails.tsx
@@ -31,7 +31,6 @@ export const ObjectUploadDetails = ({
           {formatNumberWithCommas(minimumBlockDepth)}
         </a>
         {maximumBlockDepth != null &&
-          minimumBlockDepth != null &&
           maximumBlockDepth !== minimumBlockDepth && (
           <>
             <span className='text-gray-400'>→</span>

--- a/apps/frontend/src/components/organisms/ObjectDetails/ObjectUploadDetails.tsx
+++ b/apps/frontend/src/components/organisms/ObjectDetails/ObjectUploadDetails.tsx
@@ -6,6 +6,8 @@ import {
 } from '@heroicons/react/24/outline';
 import { getTypeFromMetadata } from '../../../utils/file';
 import { formatBytes, formatNumberWithCommas } from '../../../utils/number';
+import { formatDate } from '../../../utils/time';
+import { formatCid } from '../../../utils/table';
 import { EXTERNAL_ROUTES } from '@auto-drive/ui';
 
 export const ObjectUploadDetails = ({
@@ -15,6 +17,39 @@ export const ObjectUploadDetails = ({
   object: ObjectInformation;
   isOwner: boolean;
 }) => {
+  const { minimumBlockDepth, maximumBlockDepth } = object.uploadState;
+
+  const blockRangeDisplay =
+    minimumBlockDepth != null ? (
+      <span className='flex gap-1'>
+        <a
+          href={EXTERNAL_ROUTES.explorer.block(minimumBlockDepth)}
+          target='_blank'
+          rel='noopener noreferrer'
+          className='text-primary hover:text-primary/80 hover:underline'
+        >
+          {formatNumberWithCommas(minimumBlockDepth)}
+        </a>
+        {maximumBlockDepth != null &&
+          minimumBlockDepth != null &&
+          maximumBlockDepth !== minimumBlockDepth && (
+          <>
+            <span className='text-gray-400'>→</span>
+            <a
+              href={EXTERNAL_ROUTES.explorer.block(maximumBlockDepth)}
+              target='_blank'
+              rel='noopener noreferrer'
+              className='text-primary hover:text-primary/80 hover:underline'
+            >
+              {formatNumberWithCommas(maximumBlockDepth)}
+            </a>
+          </>
+        )}
+      </span>
+    ) : (
+      'N/A'
+    );
+
   return (
     <div className='grid grid-cols-1 gap-6 md:grid-cols-2'>
       <div className='rounded-lg border border-border bg-card p-6'>
@@ -52,6 +87,34 @@ export const ObjectUploadDetails = ({
               {formatBytes(Number(object.metadata.totalSize))}
             </span>
           </div>
+          {object.metadata.type === 'file' && (
+            <div className='flex justify-between'>
+              <span className='text-sm text-gray-500 dark:text-gray-400'>
+                Chunks:
+              </span>
+              <span className='text-sm font-medium'>
+                {object.metadata.totalChunks ?? 'N/A'}
+              </span>
+            </div>
+          )}
+          {object.metadata.type === 'folder' && (
+            <div className='flex justify-between'>
+              <span className='text-sm text-gray-500 dark:text-gray-400'>
+                Total Files:
+              </span>
+              <span className='text-sm font-medium'>
+                {object.metadata.totalFiles ?? 'N/A'}
+              </span>
+            </div>
+          )}
+          <div className='flex justify-between'>
+            <span className='text-sm text-gray-500 dark:text-gray-400'>
+              Uploaded:
+            </span>
+            <span className='text-sm font-medium'>
+              {object.createdAt ? formatDate(object.createdAt) : 'N/A'}
+            </span>
+          </div>
           <div className='flex justify-between'>
             <span className='text-sm text-gray-500 dark:text-gray-400'>
               Owner:
@@ -60,49 +123,19 @@ export const ObjectUploadDetails = ({
               {isOwner ? 'You' : 'Unknown'}
             </span>
           </div>
-          <div className='flex justify-between'>
-            <span className='text-sm text-gray-500 dark:text-gray-400'>
-              Uploaded Nodes:
-            </span>
-            <span className='text-sm font-medium'>
-              {object.uploadState.uploadedNodes ?? 'Processing'}
-            </span>
-          </div>
-          <div className='flex justify-between'>
-            <span className='text-sm text-gray-500 dark:text-gray-400'>
-              Total Nodes:
-            </span>
-            <span className='text-sm font-medium'>
-              {object.uploadState.totalNodes ?? 'Processing'}
-            </span>
-          </div>
-          <div className='flex justify-between'>
-            <span className='text-sm text-gray-500 dark:text-gray-400'>
-              Block range:
-            </span>
-            <span className='text-sm font-medium'>
-              {object.uploadState.minimumBlockDepth ? (
-                <a
-                  href={EXTERNAL_ROUTES.explorer.block(
-                    object.uploadState.minimumBlockDepth,
-                  )}
-                  target='_blank'
-                  rel='noopener noreferrer'
-                  className='text-primary hover:text-primary/80 hover:underline'
-                >
-                  {formatNumberWithCommas(object.uploadState.minimumBlockDepth)}
-                </a>
-              ) : (
-                'N/A'
-              )}
-            </span>
-          </div>
-          <div className='flex justify-between'>
-            <span className='text-sm text-gray-500 dark:text-gray-400'>
-              Archive blocks count:
-            </span>
-            <span className='text-sm font-medium'>0</span>
-          </div>
+          {object.publishedObjectId && (
+            <div className='flex justify-between'>
+              <span className='text-sm text-gray-500 dark:text-gray-400'>
+                Published ID:
+              </span>
+              <span
+                className='text-sm font-medium font-mono'
+                title={object.publishedObjectId}
+              >
+                {formatCid(object.publishedObjectId)}
+              </span>
+            </div>
+          )}
         </div>
       </div>
       <div className='rounded-lg border border-border bg-card p-6'>
@@ -119,7 +152,7 @@ export const ObjectUploadDetails = ({
               Total Nodes:
             </span>
             <span className='text-sm font-medium'>
-              {object.uploadState.totalNodes}
+              {object.uploadState.totalNodes ?? 'N/A'}
             </span>
           </div>
           <div className='flex justify-between'>
@@ -127,35 +160,22 @@ export const ObjectUploadDetails = ({
               Uploaded Nodes:
             </span>
             <span className='text-sm font-medium'>
-              {object.uploadState.uploadedNodes}
+              {object.uploadState.uploadedNodes ?? 'N/A'}
+            </span>
+          </div>
+          <div className='flex justify-between'>
+            <span className='text-sm text-gray-500 dark:text-gray-400'>
+              Archived Nodes:
+            </span>
+            <span className='text-sm font-medium'>
+              {object.uploadState.archivedNodes ?? 'N/A'}
             </span>
           </div>
           <div className='flex justify-between'>
             <span className='text-sm text-gray-500 dark:text-gray-400'>
               Block range:
             </span>
-            <span className='text-sm font-medium'>
-              {object.uploadState.minimumBlockDepth ? (
-                <a
-                  href={EXTERNAL_ROUTES.explorer.block(
-                    object.uploadState.minimumBlockDepth,
-                  )}
-                  target='_blank'
-                  rel='noopener noreferrer'
-                  className='text-primary hover:text-primary/80 hover:underline'
-                >
-                  {formatNumberWithCommas(object.uploadState.minimumBlockDepth)}
-                </a>
-              ) : (
-                'N/A'
-              )}
-            </span>
-          </div>
-          <div className='flex justify-between'>
-            <span className='text-sm text-gray-500 dark:text-gray-400'>
-              Archive blocks count:
-            </span>
-            <span className='text-sm font-medium'>0</span>
+            <span className='text-sm font-medium'>{blockRangeDisplay}</span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
This PR fixes some incorrect, or hardcoded values on the file display page. 

- Show upload timestamp (createdAt) in Metadata card
- Show chunk count for files, total file count for folders
- Show publishedObjectId (truncated, full on hover) when available
- Replace hardcoded 'Archive blocks count: 0' with real archivedNodes
- Expand block range to show both min and max as explorer links
- Add null/undefined guards on every field so older or incomplete records never render broken output (fall back to 'N/A')
- Remove duplicate Uploaded/Total Nodes rows from Metadata card (they belong in Upload Status only)