### PR TITLE
fix(backend): enable API key auth for credit purchase intents

### DIFF
--- a/apps/auth/src/services/authManager/providers/apikey.ts
+++ b/apps/auth/src/services/authManager/providers/apikey.ts
@@ -1,12 +1,24 @@
 import { OAuthUser } from '@auto-drive/models'
 import { ApiKeysUseCases } from '../../../useCases/apikeys.js'
+import { usersRepository } from '../../../repositories/users.js'
 
 const getUserFromApiKey = async (secret: string): Promise<OAuthUser> => {
   const apiKey = await ApiKeysUseCases.getApiKeyFromSecret(secret)
 
+  // Look up the full user row so that oauthUsername and oauthAvatarUrl are
+  // available downstream.  Without this, feature flag checks that inspect
+  // oauthUsername (e.g. staff domain / allowlist checks for buyCredits)
+  // fail because the username is undefined.
+  const dbUser = await usersRepository.getUserByOAuthInformation(
+    apiKey.oauthProvider,
+    apiKey.oauthUserId,
+  )
+
   return {
     provider: apiKey.oauthProvider,
     id: apiKey.oauthUserId,
+    username: dbUser?.oauth_username ?? undefined,
+    avatarUrl: dbUser?.oauth_avatar_url ?? undefined,
   }
 }
 

--- a/apps/backend/__tests__/unit/useCases/featureFlags.spec.ts
+++ b/apps/backend/__tests__/unit/useCases/featureFlags.spec.ts
@@ -47,6 +47,10 @@ describe('hasGoogleAuth', () => {
 // verify that such a user passes the Google-auth gate, enabling third-party
 // apps to create intents server-side with an API key from a Google-registered
 // account.
+//
+// The fix in apps/auth/src/services/authManager/providers/apikey.ts ensures
+// that oauthUsername is resolved from the DB, so staff-only checks that
+// depend on oauthUsername (domain / allowlist) also work for API key auth.
 
 describe('hasGoogleAuth — API key inherits oauthProvider', () => {
   it('returns true when API key owner registered via Google', () => {
@@ -64,9 +68,13 @@ describe('hasGoogleAuth — API key inherits oauthProvider', () => {
 
 describe('FeatureFlagsUseCases.get — buyCredits via API key', () => {
   const originalFlags = config.featureFlags.flags
+  const originalDomains = config.featureFlags.staffDomains
+  const originalAllowlist = config.featureFlags.allowlistedUsernames
 
   afterEach(() => {
     config.featureFlags.flags = originalFlags
+    config.featureFlags.staffDomains = originalDomains
+    config.featureFlags.allowlistedUsernames = originalAllowlist
   })
 
   it('active=true: grants buyCredits for API key from Google-registered account', () => {
@@ -85,6 +93,47 @@ describe('FeatureFlagsUseCases.get — buyCredits via API key', () => {
       buyCredits: { active: true, staffOnly: false },
     }
     const user = makeUser({ oauthProvider: 'github' })
+    expect(FeatureFlagsUseCases.get(user).buyCredits).toBe(false)
+  })
+
+  it('staffOnly=true: grants buyCredits when API key user has oauthUsername on staff domain', () => {
+    config.featureFlags.flags = {
+      ...originalFlags,
+      buyCredits: { active: false, staffOnly: true },
+    }
+    config.featureFlags.staffDomains = ['subspace.network']
+    // Simulates a fully resolved API key user (with oauthUsername from DB)
+    const user = makeUser({
+      oauthProvider: 'google',
+      oauthUsername: 'dev@subspace.network',
+    })
+    expect(FeatureFlagsUseCases.get(user).buyCredits).toBe(true)
+  })
+
+  it('staffOnly=true: grants buyCredits when API key user is in allowlist', () => {
+    config.featureFlags.flags = {
+      ...originalFlags,
+      buyCredits: { active: false, staffOnly: true },
+    }
+    config.featureFlags.allowlistedUsernames = ['admin@example.com']
+    const user = makeUser({
+      oauthProvider: 'google',
+      oauthUsername: 'admin@example.com',
+    })
+    expect(FeatureFlagsUseCases.get(user).buyCredits).toBe(true)
+  })
+
+  it('staffOnly=true: blocks API key user when oauthUsername is undefined (pre-fix behaviour)', () => {
+    config.featureFlags.flags = {
+      ...originalFlags,
+      buyCredits: { active: false, staffOnly: true },
+    }
+    config.featureFlags.staffDomains = ['subspace.network']
+    // Before the fix, API key auth returned no username — this must fail
+    const user = makeUser({
+      oauthProvider: 'google',
+      oauthUsername: undefined,
+    })
     expect(FeatureFlagsUseCases.get(user).buyCredits).toBe(false)
   })
 })

--- a/apps/backend/__tests__/unit/useCases/featureFlags.spec.ts
+++ b/apps/backend/__tests__/unit/useCases/featureFlags.spec.ts
@@ -40,6 +40,55 @@ describe('hasGoogleAuth', () => {
   })
 })
 
+// ── API key scenario ──────────────────────────────────────────────────────
+// When a request arrives with `x-auth-provider: apikey`, the auth service
+// resolves the API key to the owning user.  The returned User object carries
+// the *original* oauthProvider of the account (e.g. 'google').  These tests
+// verify that such a user passes the Google-auth gate, enabling third-party
+// apps to create intents server-side with an API key from a Google-registered
+// account.
+
+describe('hasGoogleAuth — API key inherits oauthProvider', () => {
+  it('returns true when API key owner registered via Google', () => {
+    // The auth service returns a user whose oauthProvider is 'google'
+    // regardless of whether the current request used OAuth or an API key.
+    const apiKeyUser = makeUser({ oauthProvider: 'google' })
+    expect(hasGoogleAuth(apiKeyUser)).toBe(true)
+  })
+
+  it('returns false when API key owner registered via GitHub', () => {
+    const apiKeyUser = makeUser({ oauthProvider: 'github' })
+    expect(hasGoogleAuth(apiKeyUser)).toBe(false)
+  })
+})
+
+describe('FeatureFlagsUseCases.get — buyCredits via API key', () => {
+  const originalFlags = config.featureFlags.flags
+
+  afterEach(() => {
+    config.featureFlags.flags = originalFlags
+  })
+
+  it('active=true: grants buyCredits for API key from Google-registered account', () => {
+    config.featureFlags.flags = {
+      ...originalFlags,
+      buyCredits: { active: true, staffOnly: false },
+    }
+    // Simulates the resolved user from an API key whose owner signed up with Google
+    const user = makeUser({ oauthProvider: 'google' })
+    expect(FeatureFlagsUseCases.get(user).buyCredits).toBe(true)
+  })
+
+  it('active=true: blocks API key from non-Google account', () => {
+    config.featureFlags.flags = {
+      ...originalFlags,
+      buyCredits: { active: true, staffOnly: false },
+    }
+    const user = makeUser({ oauthProvider: 'github' })
+    expect(FeatureFlagsUseCases.get(user).buyCredits).toBe(false)
+  })
+})
+
 describe('FeatureFlagsUseCases.get — buyCredits gating', () => {
   const originalFlags = config.featureFlags.flags
   const originalDomains = config.featureFlags.staffDomains

--- a/apps/backend/src/app/controllers/intents.ts
+++ b/apps/backend/src/app/controllers/intents.ts
@@ -26,15 +26,19 @@ intentsController.post(
     }
 
     // Defense-in-depth: when the feature is publicly active, intent creation
-    // requires Google authentication.  The featureFlagMiddleware already blocks
-    // non-Google users from reaching this route (buyCredits returns false for
-    // them), but we check explicitly here to return a clear error code rather
-    // than a silent 404 in case of any middleware bypass.
+    // requires a Google-verified account.  The featureFlagMiddleware already
+    // blocks non-Google users from reaching this route (buyCredits returns
+    // false for them), but we check explicitly here to return a clear error
+    // code rather than a silent 404 in case of any middleware bypass.
+    //
+    // Note: API keys inherit the oauthProvider of the account that created
+    // them, so an API key from a Google-registered account satisfies this
+    // check.  This enables third-party apps to create intents server-side.
     if (config.featureFlags.flags.buyCredits.active && !hasGoogleAuth(user)) {
       res.status(403).json({
-        error: 'GOOGLE_AUTH_REQUIRED',
+        error: 'GOOGLE_ACCOUNT_REQUIRED',
         message:
-          'Google authentication is required to purchase storage credits.',
+          'A Google-verified account is required to purchase storage credits. You can authenticate via Google OAuth or use an API key from a Google-registered account.',
       })
       return
     }

--- a/apps/backend/src/core/featureFlags/express.ts
+++ b/apps/backend/src/core/featureFlags/express.ts
@@ -18,31 +18,38 @@ export type FeatureFlagKey = keyof typeof config.featureFlags.flags
 export const featureFlagMiddleware =
   (key: FeatureFlagKey) =>
   async (req: Request, res: Response, next: NextFunction) => {
-    // Authenticate the user if credentials are present.  Let auth errors
-    // propagate — the caller (asyncSafeHandler / Express error handler)
-    // will return a proper error instead of a misleading 404.
-    let user = null
-    if (req.headers.authorization) {
-      user = await handleAuth(req, res)
-      if (!user) {
-        // handleAuth already sent a 401 response
-        return
+    try {
+      // Authenticate the user if credentials are present.
+      let user = null
+      if (req.headers.authorization) {
+        user = await handleAuth(req, res)
+        if (!user) {
+          // handleAuth already sent a 401 response
+          return
+        }
       }
-    }
 
-    const featureFlags = FeatureFlagsUseCases.get(user)
+      const featureFlags = FeatureFlagsUseCases.get(user)
 
-    if (featureFlags[key]) {
-      next()
-    } else {
-      if (user) {
-        logger.debug(
-          'Feature flag %s is not active for user (oauthProvider=%s)',
-          key,
-          user.oauthProvider,
-        )
+      if (featureFlags[key]) {
+        next()
+      } else {
+        if (user) {
+          logger.debug(
+            'Feature flag %s is not active for user (oauthProvider=%s)',
+            key,
+            user.oauthProvider,
+          )
+        }
+        res.sendStatus(404)
       }
-      res.sendStatus(404)
+    } catch (error) {
+      // Log and return 500 rather than letting the rejection go unhandled,
+      // which would crash the process in Express 4.
+      logger.error(error, 'featureFlagMiddleware: unexpected error')
+      if (!res.headersSent) {
+        res.status(500).json({ error: 'Internal server error' })
+      }
     }
   }
 

--- a/apps/backend/src/core/featureFlags/express.ts
+++ b/apps/backend/src/core/featureFlags/express.ts
@@ -2,24 +2,53 @@ import { NextFunction, Request, Response } from 'express'
 import { handleAuth } from '../../infrastructure/services/auth/express.js'
 import { FeatureFlagsUseCases } from './index.js'
 import { config } from '../../config.js'
+import { createLogger } from '../../infrastructure/drivers/logger.js'
+
+const logger = createLogger('core:featureFlags:express')
 
 export type FeatureFlagKey = keyof typeof config.featureFlags.flags
 
+// Middleware that gates a route behind a feature flag.
+//
+// Unlike `getFeatureFlags` (used by the public /features endpoint), this
+// middleware does NOT silently fall back to unauthenticated flags on auth
+// failure.  If the request includes credentials but auth fails (e.g. the
+// auth service is unreachable, or the API key is invalid), the middleware
+// lets the auth error surface rather than hiding the route behind a 404.
 export const featureFlagMiddleware =
   (key: FeatureFlagKey) =>
   async (req: Request, res: Response, next: NextFunction) => {
-    const featureFlags = await getFeatureFlags(req, res)
-    if (!featureFlags) {
-      return
+    // Authenticate the user if credentials are present.  Let auth errors
+    // propagate — the caller (asyncSafeHandler / Express error handler)
+    // will return a proper error instead of a misleading 404.
+    let user = null
+    if (req.headers.authorization) {
+      user = await handleAuth(req, res)
+      if (!user) {
+        // handleAuth already sent a 401 response
+        return
+      }
     }
+
+    const featureFlags = FeatureFlagsUseCases.get(user)
 
     if (featureFlags[key]) {
       next()
     } else {
+      if (user) {
+        logger.debug(
+          'Feature flag %s is not active for user (oauthProvider=%s)',
+          key,
+          user.oauthProvider,
+        )
+      }
       res.sendStatus(404)
     }
   }
 
+// Returns feature flags for the current request.  Used by the public
+// /features endpoint.  On auth failure it falls back to unauthenticated
+// flags so the endpoint always returns a result.
 export const getFeatureFlags = async (req: Request, res: Response) => {
   // If is authenticated, get the user from the request
   if (req.headers.authorization) {
@@ -30,7 +59,8 @@ export const getFeatureFlags = async (req: Request, res: Response) => {
       }
 
       return FeatureFlagsUseCases.get(user)
-    } catch {
+    } catch (error) {
+      logger.warn(error, 'Auth failed in getFeatureFlags, falling back to unauthenticated flags')
       // Auth failure — fall through to unauthenticated flags
       return FeatureFlagsUseCases.get(null)
     }

--- a/apps/backend/src/core/featureFlags/index.ts
+++ b/apps/backend/src/core/featureFlags/index.ts
@@ -17,14 +17,20 @@ const get = (user: User | null) => {
   )
 }
 
-// Returns true if the user authenticated via Google OAuth.
-// Used as the purchase gate when the feature is publicly active.
+// Returns true if the user's account was registered via Google OAuth.
+// Used as the purchase gate when buyCredits is publicly active.
+//
+// This checks the user's *registration* provider (oauthProvider), not the
+// current auth method.  When a request uses an API key, the auth service
+// resolves the key to its owner and returns the owner's original oauthProvider.
+// This means an API key from a Google-registered account satisfies this check,
+// enabling third-party apps to create intents server-side.
 export const hasGoogleAuth = (user: User | null): boolean => {
   return Boolean(user && user.oauthProvider === 'google')
 }
 
 const isActive = (key: string, value: FeatureFlag, user: User | null) => {
-  // buyCredits requires Google auth when publicly active (Sybil protection).
+  // buyCredits requires Google auth when publicly active.
   if (key === 'buyCredits' && value.active) {
     return hasGoogleAuth(user)
   }

--- a/apps/backend/src/docs/reference/index.ts
+++ b/apps/backend/src/docs/reference/index.ts
@@ -3,6 +3,7 @@ import { downloads } from './downloads.js'
 import { objects } from './objects.js'
 import { accounts } from './accounts.js'
 import { uploads } from './uploads.js'
+import { intents } from './intents.js'
 
 export const swagger = {
   openapi: '3.0.0',
@@ -31,6 +32,20 @@ X-Auth-Provider: apikey
 
 API keys should be kept secure and not shared with unauthorized parties.
 
+## Purchasing Storage Credits (Pay with AI3)
+
+Third-party applications can purchase storage credits programmatically using the Intents API. The flow is:
+
+1. **Create an account** — Register at [ai3.storage](https://ai3.storage) via Google OAuth
+2. **Generate an API key** — From the dashboard, create an API key
+3. **Create an intent** — \`POST /intents\` with your API key returns an \`intentId\` with a locked price
+4. **Pay on-chain** — Call \`payIntent(intentId)\` on the \`AutoDriveCreditsReceiver\` contract, sending AI3 tokens
+5. **Submit tx hash** — \`POST /intents/:id/watch\` with the transaction hash
+6. **Poll for completion** — \`GET /intents/:id\` until status is \`completed\`
+7. **Upload content** — Use the Auto Drive SDK with the same API key (credits are now on the account)
+
+**Note:** A Google-verified account is currently required to purchase credits. API keys inherit the auth provider of the account that created them, so an API key from a Google-registered account satisfies this requirement.
+
 ## Auto-Drive Services
 
 Auto-Drive consists of two main services:
@@ -42,6 +57,7 @@ The Storage Service handles all file operations including uploads, downloads, an
 - Object metadata management
 - Access control and permissions
 - Account management
+- Credit purchases (Pay with AI3)
 
 ### 2. Auto-Drive Download Gateway
 
@@ -54,6 +70,7 @@ The Auto-Drive Download Gateway is a service that allows you to download files f
     ...uploads.paths,
     ...objects.paths,
     ...downloads.paths,
+    ...intents.paths,
   },
   security: [
     {
@@ -68,6 +85,7 @@ The Auto-Drive Download Gateway is a service that allows you to download files f
       ...common.components.schemas,
       ...accounts.components.schemas,
       ...downloads.components.schemas,
+      ...intents.components.schemas,
     },
     securitySchemes: {
       apiKey: {

--- a/apps/backend/src/docs/reference/intents.ts
+++ b/apps/backend/src/docs/reference/intents.ts
@@ -1,0 +1,224 @@
+import { autoDriveServers } from './servers.js'
+
+export const intents = {
+  paths: {
+    '/intents/price': {
+      get: {
+        summary: 'Intents - Get current storage price',
+        description:
+          'Returns the current price per byte (in shannons) and price per GB (in AI3). This endpoint does not require authentication.',
+        tags: ['Auto Drive API'],
+        servers: autoDriveServers,
+        responses: {
+          '200': {
+            description: 'Current price information',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    price: {
+                      type: 'number',
+                      description: 'Price per byte in shannons',
+                    },
+                    pricePerGB: {
+                      type: 'number',
+                      description: 'Price per GB in AI3 tokens',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/intents': {
+      post: {
+        summary: 'Intents - Create a purchase intent',
+        description: `Creates a PENDING intent with the current price locked in. The intent has a time-limited price-lock window (default 10 minutes) during which the price is guaranteed.
+
+**Authentication:** Currently requires a Google-verified account. You can authenticate via:
+- Google OAuth session
+- API key from a Google-registered account (set \`X-Auth-Provider: apikey\`)
+
+**Third-party integration pattern:**
+1. Create an Auto Drive account via Google OAuth at https://ai3.storage
+2. Generate an API key from the dashboard
+3. Call \`POST /intents\` with the API key to get an \`intentId\` and locked price
+4. Have the end user call \`payIntent(intentId)\` on the \`AutoDriveCreditsReceiver\` contract, sending AI3 tokens
+5. Call \`POST /intents/:id/watch\` with the transaction hash
+6. Poll \`GET /intents/:id\` until status is \`completed\`
+7. Upload content via the Auto Drive SDK using the same API key`,
+        tags: ['Auto Drive API'],
+        servers: autoDriveServers,
+        responses: {
+          '200': {
+            description: 'Intent created successfully',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/Intent',
+                },
+              },
+            },
+          },
+          '401': {
+            description: 'Unauthorized — missing or invalid credentials',
+          },
+          '403': {
+            description:
+              'Google-verified account required — the authenticated account was not registered via Google OAuth',
+          },
+          '404': {
+            description:
+              'Feature not available — the buyCredits feature flag is not active for this user',
+          },
+        },
+      },
+    },
+    '/intents/{id}': {
+      get: {
+        summary: 'Intents - Get intent status',
+        description:
+          'Returns the current status of a purchase intent. Use this to poll for completion after calling `/intents/:id/watch`.',
+        tags: ['Auto Drive API'],
+        servers: autoDriveServers,
+        parameters: [
+          {
+            name: 'id',
+            in: 'path',
+            required: true,
+            schema: { type: 'string' },
+            description: 'The intent ID returned by POST /intents',
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'Intent details',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/Intent',
+                },
+              },
+            },
+          },
+          '401': {
+            description: 'Unauthorized',
+          },
+          '403': {
+            description:
+              'Forbidden — the intent belongs to a different user',
+          },
+          '404': {
+            description: 'Intent not found',
+          },
+          '410': {
+            description: 'Intent has expired (price-lock window elapsed)',
+          },
+        },
+      },
+    },
+    '/intents/{id}/watch': {
+      post: {
+        summary: 'Intents - Submit transaction hash for watching',
+        description:
+          'Attaches a transaction hash to a pending intent and queues on-chain confirmation watching. Call this after the user has submitted the `payIntent` transaction on-chain.',
+        tags: ['Auto Drive API'],
+        servers: autoDriveServers,
+        parameters: [
+          {
+            name: 'id',
+            in: 'path',
+            required: true,
+            schema: { type: 'string' },
+            description: 'The intent ID',
+          },
+        ],
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  txHash: {
+                    type: 'string',
+                    description:
+                      'The transaction hash from the on-chain payIntent call',
+                  },
+                },
+                required: ['txHash'],
+              },
+            },
+          },
+        },
+        responses: {
+          '204': {
+            description: 'Transaction hash accepted — watching started',
+          },
+          '400': {
+            description: 'Missing or invalid txHash',
+          },
+          '401': {
+            description: 'Unauthorized',
+          },
+          '403': {
+            description: 'Forbidden — the intent belongs to a different user',
+          },
+          '410': {
+            description: 'Intent has expired',
+          },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {
+      Intent: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+            description: 'Unique intent identifier (hex string)',
+          },
+          userPublicId: {
+            type: 'string',
+            description: 'Public ID of the intent owner',
+          },
+          status: {
+            type: 'string',
+            enum: [
+              'pending',
+              'confirmed',
+              'completed',
+              'failed',
+              'expired',
+              'over_cap',
+            ],
+            description: 'Current intent status',
+          },
+          txHash: {
+            type: 'string',
+            description: 'On-chain transaction hash (set after /watch)',
+          },
+          paymentAmount: {
+            type: 'string',
+            description: 'Payment amount in shannons (bigint as string)',
+          },
+          shannonsPerByte: {
+            type: 'string',
+            description:
+              'Locked price per byte in shannons (bigint as string)',
+          },
+          expiresAt: {
+            type: 'string',
+            format: 'date-time',
+            description: 'Price-lock expiry timestamp',
+          },
+        },
+      },
+    },
+  },
+}


### PR DESCRIPTION
## Summary

**Root cause fix:** API key auth didn't resolve `oauthUsername` from the database, causing staff-only feature flag checks to fail.

**Additional fix:** `featureFlagMiddleware` silently swallowed auth errors via a catch-all, masking the real issue as a 404.

## Root cause

When `BUY_CREDITS_STAFF_ONLY=true`, the `featureFlagMiddleware('buyCredits')` calls `isStaff(user)`, which checks `user.oauthUsername` against staff domains and allowlisted usernames. This works for direct OAuth auth (Google, GitHub, Discord) because those providers return `{ provider, id, username, avatarUrl }`. But the API key provider in `apps/auth/src/services/authManager/providers/apikey.ts` only returned `{ provider, id }` — no `username`.

This `OAuthUser` flows into `getUserByOAuthUser()` which sets `oauthUsername: user.username` on the resolved user object. Since `user.username` was `undefined` from the API key provider, `isStaffDomain()` and `isStaffUsername()` both returned `false`, so `buyCredits` evaluated to `false`, and the middleware returned 404.

## Changes

### 1. Fix API key auth to resolve full user info (root cause)
**`apps/auth/src/services/authManager/providers/apikey.ts`**

The API key provider now looks up the full user row from the DB via `usersRepository.getUserByOAuthInformation()` to populate `username` and `avatarUrl`, matching the behaviour of all other auth providers.

### 2. Fix `featureFlagMiddleware` error handling
**`apps/backend/src/core/featureFlags/express.ts`**

The middleware delegated to `getFeatureFlags()` which wraps `handleAuth` in a try/catch that silently falls back to unauthenticated flags on any error. This meant auth failures surfaced as a misleading 404 instead of the actual error. The middleware now calls `handleAuth` directly and lets auth errors propagate. Added debug logging of `oauthProvider` when a flag evaluates to false.

### 3. Improve error messages
**`apps/backend/src/app/controllers/intents.ts`**

`GOOGLE_AUTH_REQUIRED` → `GOOGLE_ACCOUNT_REQUIRED` with message clarifying that API keys from Google-registered accounts are also accepted.

### 4. Add OpenAPI docs for intent endpoints
**`apps/backend/src/docs/reference/intents.ts`** (new) + **`apps/backend/src/docs/reference/index.ts`**

Documents `POST /intents`, `GET /intents/:id`, `POST /intents/:id/watch`, `GET /intents/price` with a third-party integration guide describing the full Pay with AI3 flow via API key.

### 5. Add tests
**`apps/backend/__tests__/unit/useCases/featureFlags.spec.ts`**

Tests covering API key auth through feature flags, including:
- `hasGoogleAuth` with API key-resolved users
- `buyCredits` active mode with API key auth
- `buyCredits` staff-only mode with API key user that has `oauthUsername` (the fixed path)
- `buyCredits` staff-only mode with undefined `oauthUsername` (the pre-fix broken path)

## Test plan

- [x] `yarn backend lint` passes
- [x] `yarn auth lint` passes
- [x] All 31 feature flag tests pass (including 7 new)
- [x] All 41 intent tests pass
- [ ] Deploy and verify `POST /intents` works with API key auth from a Google-registered staff account
- [ ] Verify `GET /api/features` returns `{"buyCredits": true}` for the same API key

🤖 Generated with [Claude Code](https://claude.com/claude-code)