### PR TITLE
feat(backend): expose contract info via GET /intents/contract

### DIFF
--- a/apps/backend/.env.sample
+++ b/apps/backend/.env.sample
@@ -24,6 +24,10 @@ EVM_CHAIN_ENDPOINT=http://localhost:8545
 # Must match the chain pointed to by EVM_CHAIN_ENDPOINT.
 EVM_CHAIN_CONTRACT_ADDRESS=0x0000000000000000000000000000000000000000
 
+# EVM chain ID for the network where the contract is deployed.
+# Mainnet Auto-EVM = 870, Chronos Testnet = 8700.
+EVM_CHAIN_ID=870
+
 # Number of block confirmations to wait before treating a payment as final.
 # Higher values reduce the risk of processing a payment that is later
 # reversed by a chain reorganisation. Default: 6.

--- a/apps/backend/src/app/apis/frontend.ts
+++ b/apps/backend/src/app/apis/frontend.ts
@@ -75,6 +75,21 @@ const createServer = async () => {
       res.status(200).json(result.value)
     }),
   )
+  app.get('/intents/contract', (_req, res) => {
+    res.status(200).json({
+      chainId: config.paymentManager.chainId,
+      contractAddress: config.paymentManager.contractAddress,
+      payIntentAbi: [
+        {
+          inputs: [{ name: 'intentId', type: 'bytes32' }],
+          name: 'payIntent',
+          outputs: [],
+          stateMutability: 'payable',
+          type: 'function',
+        },
+      ],
+    })
+  })
   app.use('/intents', featureFlagMiddleware('buyCredits'), intentsController)
   app.use('/credits', featureFlagMiddleware('buyCredits'), creditsController)
   app.use('/banners', bannersController)

--- a/apps/backend/src/config.ts
+++ b/apps/backend/src/config.ts
@@ -65,6 +65,7 @@ export const config = {
   paymentManager: {
     url: env('EVM_CHAIN_ENDPOINT'),
     contractAddress: getAddress(env('EVM_CHAIN_CONTRACT_ADDRESS')),
+    chainId: Number(env('EVM_CHAIN_ID', '870')),
     confirmations: Number(env('EVM_CHAIN_CONFIRMATIONS', '6')),
     checkInterval: Number(env('EVM_CHAIN_CHECK_INTERVAL', '30000')),
     priceMultiplier: Number(env('CREDITS_PRICE_MULTIPLIER', '5.00')),

--- a/apps/backend/src/docs/reference/index.ts
+++ b/apps/backend/src/docs/reference/index.ts
@@ -39,11 +39,12 @@ Third-party applications can purchase storage credits programmatically using the
 1. **Create an account** — Register at [ai3.storage](https://ai3.storage) via Google OAuth
 2. **Generate an API key** — From the dashboard, create an API key
 3. **Get contract info** — \`GET /intents/contract\` returns the contract address, chain ID, and ABI
-4. **Create an intent** — \`POST /intents\` with your API key returns an \`intentId\` with a locked price
-5. **Pay on-chain** — Call \`payIntent(intentId)\` on the contract, sending AI3 as native value
-6. **Submit tx hash** — \`POST /intents/:id/watch\` with the transaction hash
-7. **Poll for completion** — \`GET /intents/:id\` until status is \`completed\`
-8. **Upload content** — Use the Auto Drive SDK with the same API key (credits are now on the account)
+4. **Check current price** — \`GET /intents/price\` returns the current price per byte and per GB to display to the user
+5. **Create an intent** — \`POST /intents\` with your API key returns an \`intentId\` with the price locked in
+6. **Pay on-chain** — Call \`payIntent(intentId)\` on the contract, sending AI3 as native value
+7. **Submit tx hash** — \`POST /intents/:id/watch\` with the transaction hash
+8. **Poll for completion** — \`GET /intents/:id\` until status is \`completed\`
+9. **Upload content** — Use the Auto Drive SDK with the same API key (credits are now on the account)
 
 **Note:** A Google-verified account is currently required to purchase credits. API keys inherit the auth provider of the account that created them, so an API key from a Google-registered account satisfies this requirement.
 

--- a/apps/backend/src/docs/reference/index.ts
+++ b/apps/backend/src/docs/reference/index.ts
@@ -38,11 +38,12 @@ Third-party applications can purchase storage credits programmatically using the
 
 1. **Create an account** — Register at [ai3.storage](https://ai3.storage) via Google OAuth
 2. **Generate an API key** — From the dashboard, create an API key
-3. **Create an intent** — \`POST /intents\` with your API key returns an \`intentId\` with a locked price
-4. **Pay on-chain** — Call \`payIntent(intentId)\` on the \`AutoDriveCreditsReceiver\` contract, sending AI3 tokens
-5. **Submit tx hash** — \`POST /intents/:id/watch\` with the transaction hash
-6. **Poll for completion** — \`GET /intents/:id\` until status is \`completed\`
-7. **Upload content** — Use the Auto Drive SDK with the same API key (credits are now on the account)
+3. **Get contract info** — \`GET /intents/contract\` returns the contract address, chain ID, and ABI
+4. **Create an intent** — \`POST /intents\` with your API key returns an \`intentId\` with a locked price
+5. **Pay on-chain** — Call \`payIntent(intentId)\` on the contract, sending AI3 as native value
+6. **Submit tx hash** — \`POST /intents/:id/watch\` with the transaction hash
+7. **Poll for completion** — \`GET /intents/:id\` until status is \`completed\`
+8. **Upload content** — Use the Auto Drive SDK with the same API key (credits are now on the account)
 
 **Note:** A Google-verified account is currently required to purchase credits. API keys inherit the auth provider of the account that created them, so an API key from a Google-registered account satisfies this requirement.
 

--- a/apps/backend/src/docs/reference/intents.ts
+++ b/apps/backend/src/docs/reference/intents.ts
@@ -69,11 +69,12 @@ export const intents = {
 1. Create an Auto Drive account via Google OAuth at https://ai3.storage
 2. Generate an API key from the dashboard
 3. Call \`GET /intents/contract\` to get the contract address, chain ID, and ABI
-4. Call \`POST /intents\` with the API key to get an \`intentId\` and locked price
-5. Have the end user call \`payIntent(intentId)\` on the contract, sending AI3 as native value
-6. Call \`POST /intents/:id/watch\` with the transaction hash
-7. Poll \`GET /intents/:id\` until status is \`completed\`
-8. Upload content via the Auto Drive SDK using the same API key`,
+4. Call \`GET /intents/price\` to get the current price per byte and per GB
+5. Call \`POST /intents\` with the API key to get an \`intentId\` with the price locked in
+6. Have the end user call \`payIntent(intentId)\` on the contract, sending AI3 as native value
+7. Call \`POST /intents/:id/watch\` with the transaction hash
+8. Poll \`GET /intents/:id\` until status is \`completed\`
+9. Upload content via the Auto Drive SDK using the same API key`,
         tags: ['Auto Drive API'],
         servers: autoDriveServers,
         responses: {

--- a/apps/backend/src/docs/reference/intents.ts
+++ b/apps/backend/src/docs/reference/intents.ts
@@ -9,6 +9,7 @@ export const intents = {
           'Returns the current price per byte (in shannons) and price per GB (in AI3). This endpoint does not require authentication.',
         tags: ['Auto Drive API'],
         servers: autoDriveServers,
+        security: [],
         responses: {
           '200': {
             description: 'Current price information',
@@ -33,6 +34,28 @@ export const intents = {
         },
       },
     },
+    '/intents/contract': {
+      get: {
+        summary: 'Intents - Get smart contract info',
+        description:
+          'Returns the on-chain contract address, EVM chain ID, and the minimal ABI needed to call `payIntent`. This endpoint does not require authentication. Use this to build the on-chain transaction for step 4 of the integration flow.',
+        tags: ['Auto Drive API'],
+        servers: autoDriveServers,
+        security: [],
+        responses: {
+          '200': {
+            description: 'Contract information',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/ContractInfo',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
     '/intents': {
       post: {
         summary: 'Intents - Create a purchase intent',
@@ -45,11 +68,12 @@ export const intents = {
 **Third-party integration pattern:**
 1. Create an Auto Drive account via Google OAuth at https://ai3.storage
 2. Generate an API key from the dashboard
-3. Call \`POST /intents\` with the API key to get an \`intentId\` and locked price
-4. Have the end user call \`payIntent(intentId)\` on the \`AutoDriveCreditsReceiver\` contract, sending AI3 tokens
-5. Call \`POST /intents/:id/watch\` with the transaction hash
-6. Poll \`GET /intents/:id\` until status is \`completed\`
-7. Upload content via the Auto Drive SDK using the same API key`,
+3. Call \`GET /intents/contract\` to get the contract address, chain ID, and ABI
+4. Call \`POST /intents\` with the API key to get an \`intentId\` and locked price
+5. Have the end user call \`payIntent(intentId)\` on the contract, sending AI3 as native value
+6. Call \`POST /intents/:id/watch\` with the transaction hash
+7. Poll \`GET /intents/:id\` until status is \`completed\`
+8. Upload content via the Auto Drive SDK using the same API key`,
         tags: ['Auto Drive API'],
         servers: autoDriveServers,
         responses: {
@@ -176,6 +200,28 @@ export const intents = {
   },
   components: {
     schemas: {
+      ContractInfo: {
+        type: 'object',
+        required: ['chainId', 'contractAddress', 'payIntentAbi'],
+        properties: {
+          chainId: {
+            type: 'integer',
+            description:
+              'EVM chain ID where the contract is deployed (e.g. 870 for Auto-EVM Mainnet)',
+          },
+          contractAddress: {
+            type: 'string',
+            description:
+              'Address of the AutoDriveCreditsReceiver contract (checksummed)',
+          },
+          payIntentAbi: {
+            type: 'array',
+            description:
+              'Minimal ABI for the payIntent function — pass directly to viem/ethers/web3.js',
+            items: { type: 'object' },
+          },
+        },
+      },
       Intent: {
         type: 'object',
         properties: {


### PR DESCRIPTION
Third-party integrators need the contract address, chain ID, and ABI to construct the on-chain payIntent transaction. This was previously only available in frontend source code.
