### PR TITLE
fix(frontend): invalidate account and creditSummary after upload

### DIFF
--- a/apps/frontend/src/components/molecules/UploadingFileModal.tsx
+++ b/apps/frontend/src/components/molecules/UploadingFileModal.tsx
@@ -4,6 +4,7 @@ import { Button } from '@auto-drive/ui';
 import { useEncryptionStore } from 'globalStates/encryption';
 import { useNetwork } from 'contexts/network';
 import { useFileTableState } from '@/components/organisms/FileTable/state';
+import { useQueryClient } from '@tanstack/react-query';
 
 type FileProgress = {
   progress: number;
@@ -38,6 +39,7 @@ export const UploadingFileModal = ({
   const uploadStartedRef = useRef(false);
   const network = useNetwork();
   const refetch = useFileTableState((v) => v.fetch);
+  const queryClient = useQueryClient();
 
   const totalFiles = files?.length || 0;
 
@@ -178,6 +180,8 @@ export const UploadingFileModal = ({
       const success = await manageUpload(password || undefined);
       if (success) {
         refetch();
+        queryClient.invalidateQueries({ queryKey: ['account'] });
+        queryClient.invalidateQueries({ queryKey: ['creditSummary'] });
         setTimeout(() => {
           handleClose();
         }, 1000);

--- a/apps/frontend/src/components/molecules/UploadingFolderModal.tsx
+++ b/apps/frontend/src/components/molecules/UploadingFolderModal.tsx
@@ -6,6 +6,7 @@ import { useEncryptionStore } from 'globalStates/encryption';
 import { useNetwork } from 'contexts/network';
 import { useFileTableState } from '@/components/organisms/FileTable/state';
 import { useUserStore } from 'globalStates/user';
+import { useQueryClient } from '@tanstack/react-query';
 import { AccountModel } from '@auto-drive/models';
 import { BuyMoreCreditsButton } from 'components/atoms/BuyMoreCreditsButton';
 import { formatBytes } from 'utils/number';
@@ -28,6 +29,7 @@ export const UploadingFolderModal = ({
   const progressPercentage = Math.round(progress);
 
   const refetch = useFileTableState((v) => v.fetch);
+  const queryClient = useQueryClient();
 
   const resetUploadState = useCallback(() => {
     setPassword(undefined);
@@ -72,6 +74,8 @@ export const UploadingFolderModal = ({
       const success = await handleUpload();
       if (success) {
         refetch();
+        queryClient.invalidateQueries({ queryKey: ['account'] });
+        queryClient.invalidateQueries({ queryKey: ['creditSummary'] });
         handleClose();
       }
     };


### PR DESCRIPTION
The sidebar storage display used the formula:
  freeRemaining = account.pendingUploadCredits - purchasedBytesRemaining

When creditSummary refetched (30s interval) after an upload that consumed purchased credits, purchasedBytesRemaining updated but account.pendingUploadCredits stayed stale, making the free storage appear to decrease by the upload size.

Fix: invalidate both ['account'] and ['creditSummary'] queries immediately after a successful upload so both values update atomically.