### PR TITLE
fix: authenticated downloads fail due to credit enforcement and broken retry logic + disable download limiting

### DIFF
--- a/apps/backend/__tests__/unit/useCases/files.spec.ts
+++ b/apps/backend/__tests__/unit/useCases/files.spec.ts
@@ -2,10 +2,15 @@ import { jest } from '@jest/globals'
 import { ObjectUseCases } from '../../../src/core/objects/object.js'
 import { FilesUseCases } from '../../../src/core/objects/files/index.js'
 import { DownloadUseCase } from '../../../src/core/downloads/index.js'
+import { AccountsUseCases } from '../../../src/core/users/accounts.js'
 import { ByteRange } from '@autonomys/file-server'
 import { OffchainMetadata } from '@autonomys/auto-dag-data'
-import { NotAcceptableError } from '../../../src/errors/index.js'
+import {
+  NotAcceptableError,
+  ObjectNotFoundError,
+} from '../../../src/errors/index.js'
 import { err, ok } from 'neverthrow'
+import { createMockUser } from '../../utils/mocks.js'
 
 jest.unstable_mockModule('../../../src/core/objects/object.js', () => ({
   ObjectUseCases: {
@@ -75,6 +80,83 @@ describe('FilesUseCases', () => {
 
     expect(result.isErr()).toBe(true)
     expect(result._unsafeUnwrapErr()).toBeInstanceOf(NotAcceptableError)
+  })
+
+  describe('downloadObjectByUser', () => {
+    const user = createMockUser()
+
+    const metadata: OffchainMetadata = {
+      totalSize: 200n * 1024n * 1024n, // 200 MiB — above anonymous limit
+      type: 'file',
+      dataCid: 'user-test-cid',
+      totalChunks: 1,
+      chunks: [],
+    }
+
+    it('should allow download when metadata is found and access is authorized', async () => {
+      jest.spyOn(ObjectUseCases, 'getMetadata').mockResolvedValue(ok(metadata))
+      jest.spyOn(ObjectUseCases, 'authorizeDownload').mockResolvedValue(ok())
+
+      const result = await DownloadUseCase.downloadObjectByUser(
+        user,
+        metadata.dataCid,
+      )
+
+      expect(result.isOk()).toBe(true)
+      expect(result._unsafeUnwrap().metadata).toMatchObject({ type: 'file' })
+    })
+
+    it('should return ObjectNotFoundError when metadata lookup fails', async () => {
+      jest
+        .spyOn(ObjectUseCases, 'getMetadata')
+        .mockResolvedValue(err(new ObjectNotFoundError('not found')))
+
+      const result = await DownloadUseCase.downloadObjectByUser(
+        user,
+        'missing-cid',
+      )
+
+      expect(result.isErr()).toBe(true)
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(ObjectNotFoundError)
+    })
+
+    it('should return NotAcceptableError when file is blocked', async () => {
+      jest.spyOn(ObjectUseCases, 'getMetadata').mockResolvedValue(ok(metadata))
+      jest
+        .spyOn(ObjectUseCases, 'authorizeDownload')
+        .mockResolvedValue(err(new NotAcceptableError('blocked')))
+
+      const result = await DownloadUseCase.downloadObjectByUser(
+        user,
+        metadata.dataCid,
+        { blockingTags: ['insecure'] },
+      )
+
+      expect(result.isErr()).toBe(true)
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(NotAcceptableError)
+    })
+
+    it('should NOT check download credits — exhausted quota must not block authenticated users', async () => {
+      // Simulates a user whose free download quota is fully spent (pendingDownloadCredits < 0).
+      // The credit check is intentionally disabled until purchased download bytes
+      // are wired up; verifying getPendingCreditsByUserAndType is never called
+      // ensures the gate stays open.
+      const creditSpy = jest.spyOn(
+        AccountsUseCases,
+        'getPendingCreditsByUserAndType',
+      )
+
+      jest.spyOn(ObjectUseCases, 'getMetadata').mockResolvedValue(ok(metadata))
+      jest.spyOn(ObjectUseCases, 'authorizeDownload').mockResolvedValue(ok())
+
+      const result = await DownloadUseCase.downloadObjectByUser(
+        user,
+        metadata.dataCid,
+      )
+
+      expect(result.isOk()).toBe(true)
+      expect(creditSpy).not.toHaveBeenCalled()
+    })
   })
 
   describe('getNodesForPartialRetrieval', () => {

--- a/apps/backend/src/core/downloads/sync.ts
+++ b/apps/backend/src/core/downloads/sync.ts
@@ -53,11 +53,19 @@ const downloadObjectByUser = async (
   }
   const metadata = getResult.value
 
-  // Download credit enforcement is intentionally disabled — see accounts.ts.
-  // The infrastructure exists for future use but download limits are not
-  // enforced right now: purchased download bytes are not allocated on purchase
-  // and the quota tracking is not exposed in the UI. Blocking authenticated
-  // users here contradicts the stated design intent.
+  // NOTE: Download credit enforcement is intentionally disabled.
+  // The infrastructure exists for future use, but download limits are not
+  // enforced right now: purchased download bytes are not allocated on purchase,
+  // so users have no way to replenish a depleted download quota — making the
+  // block permanent. Re-enable once download credit purchasing is wired up.
+  //
+  // const pendingCredits = await AccountsUseCases.getPendingCreditsByUserAndType(
+  //   reader,
+  //   InteractionType.Download,
+  // )
+  // if (pendingCredits < metadata.totalSize) {
+  //   return err(new PaymentRequiredError('Not enough download credits'))
+  // }
 
   const authResult = await ObjectUseCases.authorizeDownload(
     cid,

--- a/apps/backend/src/core/downloads/sync.ts
+++ b/apps/backend/src/core/downloads/sync.ts
@@ -39,7 +39,7 @@ const downloadObjectByUser = async (
 ): Promise<
   Result<
     FileDownload,
-    ObjectNotFoundError | PaymentRequiredError | NotAcceptableError
+    ObjectNotFoundError | NotAcceptableError
   >
 > => {
   logger.debug(

--- a/apps/backend/src/core/downloads/sync.ts
+++ b/apps/backend/src/core/downloads/sync.ts
@@ -53,14 +53,11 @@ const downloadObjectByUser = async (
   }
   const metadata = getResult.value
 
-  const pendingCredits = await AccountsUseCases.getPendingCreditsByUserAndType(
-    reader,
-    InteractionType.Download,
-  )
-
-  if (pendingCredits < metadata.totalSize) {
-    return err(new PaymentRequiredError('Not enough download credits'))
-  }
+  // Download credit enforcement is intentionally disabled — see accounts.ts.
+  // The infrastructure exists for future use but download limits are not
+  // enforced right now: purchased download bytes are not allocated on purchase
+  // and the quota tracking is not exposed in the UI. Blocking authenticated
+  // users here contradicts the stated design intent.
 
   const authResult = await ObjectUseCases.authorizeDownload(
     cid,

--- a/apps/frontend/__tests__/unit/services/downloadObject.spec.ts
+++ b/apps/frontend/__tests__/unit/services/downloadObject.spec.ts
@@ -1,0 +1,327 @@
+/**
+ * Unit tests for `createApiService().downloadObject`
+ *
+ * These tests cover all four download scenarios:
+ *   1. Encrypted raw download (skipDecryption=true) — anonymous 402 path
+ *   2. Encrypted raw download (skipDecryption=true) — session success path
+ *   3. Decrypted download (skipDecryption=false) — anonymous, including the
+ *      HTTP/2 empty-statusText bug regression
+ *   4. Decrypted download (skipDecryption=false) — session
+ *
+ * External dependencies are fully mocked so no network or Next.js runtime is
+ * required.
+ */
+
+// ---------------------------------------------------------------------------
+// Module mocks — must be declared before any imports so Jest hoists them
+// ---------------------------------------------------------------------------
+
+jest.mock('@autonomys/auto-drive', () => ({
+  createAutoDriveApi: jest.fn(),
+}));
+
+jest.mock('utils/auth', () => ({
+  getAuthSession: jest.fn(),
+}));
+
+// uploadFileContent is imported by api.ts but never used in downloadObject.
+jest.mock('utils/file', () => ({
+  uploadFileContent: jest.fn(),
+}));
+
+// asyncFromStream is dynamically imported inside the skipDecryption=true path.
+jest.mock('@autonomys/asynchronous', () => ({
+  asyncFromStream: jest.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+
+import { createApiService } from '../../../src/services/api';
+import { createAutoDriveApi } from '@autonomys/auto-drive';
+import { getAuthSession } from 'utils/auth';
+import { asyncFromStream } from '@autonomys/asynchronous';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const TEST_CID = 'bafkr6itest000000000000000000000000000000000000000000000000';
+const API_BASE = 'http://localhost:3000';
+const DL_BASE = 'http://localhost:3001';
+
+const createApi = () =>
+  createApiService({ apiBaseUrl: API_BASE, downloadApiUrl: DL_BASE });
+
+/** Convenience — build a mock AutoDrive API with overrideable methods. */
+const mockAutoDriveApi = (overrides: {
+  sendDownloadRequest?: jest.Mock;
+  downloadFile?: jest.Mock;
+}) => {
+  const mock = {
+    sendDownloadRequest: overrides.sendDownloadRequest ?? jest.fn(),
+    downloadFile: overrides.downloadFile ?? jest.fn(),
+  };
+  (createAutoDriveApi as jest.Mock).mockReturnValue(mock);
+  return mock;
+};
+
+/** Session fixture for an authenticated Google user. */
+const SESSION_GOOGLE = { accessToken: 'tok-abc', authProvider: 'google' };
+
+// ---------------------------------------------------------------------------
+// Encrypted / raw download  (skipDecryption: true)
+// ---------------------------------------------------------------------------
+
+describe('downloadObject — encrypted raw download (skipDecryption: true)', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('anonymous — backend 402 throws the recognised "large file" login message', async () => {
+    (getAuthSession as jest.Mock).mockResolvedValue(null);
+
+    mockAutoDriveApi({
+      sendDownloadRequest: jest.fn().mockResolvedValue({
+        ok: false,
+        status: 402,
+        statusText: 'Payment Required',
+        body: null,
+      }),
+    });
+
+    const api = createApi();
+    await expect(
+      api.downloadObject(TEST_CID, { skipDecryption: true, authMode: 'anonymous' }),
+    ).rejects.toThrow(
+      'Downloading large files require authorization, please login via gauth, wallet, github or discord',
+    );
+  });
+
+  it('anonymous — backend 404 throws "File not found"', async () => {
+    (getAuthSession as jest.Mock).mockResolvedValue(null);
+
+    mockAutoDriveApi({
+      sendDownloadRequest: jest.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        body: null,
+      }),
+    });
+
+    const api = createApi();
+    await expect(
+      api.downloadObject(TEST_CID, { skipDecryption: true, authMode: 'anonymous' }),
+    ).rejects.toThrow('File not found');
+  });
+
+  it('session — 200 returns the async iterable produced by asyncFromStream', async () => {
+    (getAuthSession as jest.Mock).mockResolvedValue(SESSION_GOOGLE);
+
+    const fakeBody = {} as ReadableStream<Uint8Array>; // opaque stub
+    const fakeIterable: AsyncIterable<Buffer> = (async function* () {
+      yield Buffer.from('hello');
+    })();
+
+    mockAutoDriveApi({
+      sendDownloadRequest: jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        body: fakeBody,
+      }),
+    });
+    (asyncFromStream as jest.Mock).mockReturnValue(fakeIterable);
+
+    const api = createApi();
+    const result = await api.downloadObject(TEST_CID, {
+      skipDecryption: true,
+      authMode: 'session',
+    });
+
+    expect(asyncFromStream).toHaveBeenCalledWith(fakeBody);
+    expect(result).toBe(fakeIterable);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Decrypted download  (skipDecryption: false / default)
+// ---------------------------------------------------------------------------
+
+describe('downloadObject — decrypted download (skipDecryption: false)', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  // -------------------------------------------------------------------------
+  // Anonymous authMode
+  // -------------------------------------------------------------------------
+
+  describe('anonymous authMode', () => {
+    beforeEach(() => {
+      (getAuthSession as jest.Mock).mockResolvedValue(null);
+    });
+
+    /**
+     * BUG REGRESSION
+     *
+     * HTTP/2 always delivers an empty statusText.  The SDK's internal
+     * downloadObject therefore throws:
+     *
+     *   new Error('Failed to download file: ' + response.statusText)
+     *   // → "Failed to download file: "  (empty suffix)
+     *
+     * Before the fix, `isAnonymousTooLargeError` in download.ts did NOT match
+     * this message (it checks for "file too large", "payment required", etc.),
+     * so `fetchFromApi` never attempted the session-auth retry.
+     *
+     * The fix in api.ts wraps `downloadFile` in a try-catch and re-throws
+     * with the well-known login message whenever the error starts with
+     * "Failed to download file:" AND authMode is 'anonymous'.
+     */
+    it('[BUG REGRESSION] HTTP/2 empty-statusText SDK error is re-thrown as the recognised login message', async () => {
+      // Reproduce the exact error the SDK raises on HTTP/2 (statusText === "").
+      mockAutoDriveApi({
+        downloadFile: jest.fn().mockRejectedValue(
+          new Error('Failed to download file: '),
+        ),
+      });
+
+      const api = createApi();
+      await expect(
+        api.downloadObject(TEST_CID, { authMode: 'anonymous' }),
+      ).rejects.toThrow(
+        'Downloading large files require authorization, please login via gauth, wallet, github or discord',
+      );
+    });
+
+    it('SDK error with non-empty statusText starting with "Failed to download file:" is also re-thrown as the login message', async () => {
+      // HTTP/1.1 equivalent — statusText is populated but still represents a
+      // 402/other auth-related failure from the SDK.
+      mockAutoDriveApi({
+        downloadFile: jest.fn().mockRejectedValue(
+          new Error('Failed to download file: Payment Required'),
+        ),
+      });
+
+      const api = createApi();
+      await expect(
+        api.downloadObject(TEST_CID, { authMode: 'anonymous' }),
+      ).rejects.toThrow(
+        'Downloading large files require authorization, please login via gauth, wallet, github or discord',
+      );
+    });
+
+    it('unrelated SDK errors are propagated unchanged', async () => {
+      const originalError = new Error('Network connection reset');
+      mockAutoDriveApi({
+        downloadFile: jest.fn().mockRejectedValue(originalError),
+      });
+
+      const api = createApi();
+      await expect(
+        api.downloadObject(TEST_CID, { authMode: 'anonymous' }),
+      ).rejects.toThrow('Network connection reset');
+    });
+
+    it('non-Error rejections are propagated unchanged', async () => {
+      mockAutoDriveApi({
+        downloadFile: jest.fn().mockRejectedValue('string error'),
+      });
+
+      const api = createApi();
+      // rejects with the original non-Error value
+      await expect(
+        api.downloadObject(TEST_CID, { authMode: 'anonymous' }),
+      ).rejects.toBe('string error');
+    });
+
+    it('success path returns the iterable from downloadFile', async () => {
+      const fakeIterable: AsyncIterable<Buffer> = (async function* () {
+        yield Buffer.from('decrypted data');
+      })();
+      mockAutoDriveApi({
+        downloadFile: jest.fn().mockResolvedValue(fakeIterable),
+      });
+
+      const api = createApi();
+      const result = await api.downloadObject(TEST_CID, {
+        authMode: 'anonymous',
+      });
+
+      expect(result).toBe(fakeIterable);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Session authMode
+  // -------------------------------------------------------------------------
+
+  describe('session authMode', () => {
+    beforeEach(() => {
+      (getAuthSession as jest.Mock).mockResolvedValue(SESSION_GOOGLE);
+    });
+
+    it('success — returns the iterable from downloadFile', async () => {
+      const fakeIterable: AsyncIterable<Buffer> = (async function* () {
+        yield Buffer.from('hello session');
+      })();
+      mockAutoDriveApi({
+        downloadFile: jest.fn().mockResolvedValue(fakeIterable),
+      });
+
+      const api = createApi();
+      const result = await api.downloadObject(TEST_CID, {
+        authMode: 'session',
+      });
+
+      expect(result).toBe(fakeIterable);
+    });
+
+    it('"Failed to download file:" errors are NOT re-thrown — they propagate as-is in session mode', async () => {
+      // The re-throw guard is anonymous-only; session errors must bubble up
+      // unchanged so the caller gets the real error.
+      const sdkError = new Error('Failed to download file: ');
+      mockAutoDriveApi({
+        downloadFile: jest.fn().mockRejectedValue(sdkError),
+      });
+
+      const api = createApi();
+      await expect(
+        api.downloadObject(TEST_CID, { authMode: 'session' }),
+      ).rejects.toBe(sdkError);
+    });
+
+    it('passes the password to downloadFile when provided', async () => {
+      const fakeIterable: AsyncIterable<Buffer> = (async function* () {})();
+      const downloadFileMock = jest.fn().mockResolvedValue(fakeIterable);
+      mockAutoDriveApi({ downloadFile: downloadFileMock });
+
+      const api = createApi();
+      await api.downloadObject(TEST_CID, {
+        authMode: 'session',
+        password: 'hunter2',
+      });
+
+      expect(downloadFileMock).toHaveBeenCalledWith(TEST_CID, 'hunter2');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // session authMode with no session available
+  // -------------------------------------------------------------------------
+
+  describe('session authMode — no session available', () => {
+    it('throws the login message immediately without calling createAutoDriveApi', async () => {
+      (getAuthSession as jest.Mock).mockResolvedValue(null);
+
+      const api = createApi();
+      await expect(
+        api.downloadObject(TEST_CID, { authMode: 'session' }),
+      ).rejects.toThrow(
+        'Downloading large files require authorization, please login via gauth, wallet, github or discord',
+      );
+
+      // createAutoDriveApi should never be reached
+      expect(createAutoDriveApi).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/frontend/__tests__/unit/services/downloadObject.spec.ts
+++ b/apps/frontend/__tests__/unit/services/downloadObject.spec.ts
@@ -174,8 +174,10 @@ describe('downloadObject — decrypted download (skipDecryption: false)', () => 
      * so `fetchFromApi` never attempted the session-auth retry.
      *
      * The fix in api.ts wraps `downloadFile` in a try-catch and re-throws
-     * with the well-known login message whenever the error starts with
-     * "Failed to download file:" AND authMode is 'anonymous'.
+     * with the well-known login message only when the error is exactly
+     * "Failed to download file: " (empty suffix) AND authMode is 'anonymous'.
+     * Errors with a populated statusText propagate unchanged so
+     * isAnonymousTooLargeError in download.ts can discriminate properly.
      */
     it('[BUG REGRESSION] HTTP/2 empty-statusText SDK error is re-thrown as the recognised login message', async () => {
       // Reproduce the exact error the SDK raises on HTTP/2 (statusText === "").
@@ -193,21 +195,28 @@ describe('downloadObject — decrypted download (skipDecryption: false)', () => 
       );
     });
 
-    it('SDK error with non-empty statusText starting with "Failed to download file:" is also re-thrown as the login message', async () => {
-      // HTTP/1.1 equivalent — statusText is populated but still represents a
-      // 402/other auth-related failure from the SDK.
+    it('HTTP/1.1 SDK errors with a populated statusText propagate unchanged (handled by isAnonymousTooLargeError in download.ts)', async () => {
+      const sdkError = new Error('Failed to download file: Payment Required');
       mockAutoDriveApi({
-        downloadFile: jest.fn().mockRejectedValue(
-          new Error('Failed to download file: Payment Required'),
-        ),
+        downloadFile: jest.fn().mockRejectedValue(sdkError),
       });
 
       const api = createApi();
       await expect(
         api.downloadObject(TEST_CID, { authMode: 'anonymous' }),
-      ).rejects.toThrow(
-        'Downloading large files require authorization, please login via gauth, wallet, github or discord',
-      );
+      ).rejects.toBe(sdkError);
+    });
+
+    it('HTTP/1.1 SDK 404 errors propagate unchanged instead of becoming the login message', async () => {
+      const sdkError = new Error('Failed to download file: Not Found');
+      mockAutoDriveApi({
+        downloadFile: jest.fn().mockRejectedValue(sdkError),
+      });
+
+      const api = createApi();
+      await expect(
+        api.downloadObject(TEST_CID, { authMode: 'anonymous' }),
+      ).rejects.toBe(sdkError);
     });
 
     it('unrelated SDK errors are propagated unchanged', async () => {

--- a/apps/frontend/jest.config.ts
+++ b/apps/frontend/jest.config.ts
@@ -2,6 +2,16 @@ import type { Config } from 'jest'
 
 const config: Config = {
   testMatch: ['**/__tests__/**/*.spec.ts'],
+  // Resolve baseUrl ("./src") path aliases so Jest can find modules that the
+  // TypeScript compiler resolves through tsconfig's baseUrl/paths settings.
+  moduleNameMapper: {
+    // @/* → src/* (tsconfig paths alias)
+    '^@/(.+)$': '<rootDir>/src/$1',
+    // Bare non-scoped imports that go through baseUrl (e.g. "utils/auth",
+    // "services/api", "contexts/network", etc.) → src/<path>
+    '^(utils|services|contexts|globalStates|components|hooks|app)/(.+)$':
+      '<rootDir>/src/$1/$2',
+  },
   transform: {
     '^.+\\.tsx?$': [
       'ts-jest',

--- a/apps/frontend/src/services/api.ts
+++ b/apps/frontend/src/services/api.ts
@@ -487,7 +487,27 @@ export const createApiService = ({
       return asyncFromStream(response.body);
     }
 
-    return api.downloadFile(cid, password);
+    // The SDK's downloadFile calls its internal downloadObject which throws
+    // `"Failed to download file: ${response.statusText}"`. On HTTP/2 connections
+    // statusText is always empty, so the error message becomes
+    // "Failed to download file: " — which does NOT match any of the patterns
+    // in download.ts's isAnonymousTooLargeError, causing the session-auth
+    // retry to never fire for decrypted downloads.
+    // Re-throw with the known message so the retry logic kicks in correctly.
+    try {
+      return await api.downloadFile(cid, password);
+    } catch (e) {
+      if (
+        authMode === 'anonymous' &&
+        e instanceof Error &&
+        e.message.startsWith('Failed to download file:')
+      ) {
+        throw new Error(
+          'Downloading large files require authorization, please login via gauth, wallet, github or discord',
+        );
+      }
+      throw e;
+    }
   },
   // Banners
   getActiveBanners: async (): Promise<Banner[]> => {

--- a/apps/frontend/src/services/api.ts
+++ b/apps/frontend/src/services/api.ts
@@ -493,14 +493,15 @@ export const createApiService = ({
     // "Failed to download file: " — which does NOT match any of the patterns
     // in download.ts's isAnonymousTooLargeError, causing the session-auth
     // retry to never fire for decrypted downloads.
-    // Re-throw with the known message so the retry logic kicks in correctly.
+    // Only match the exact empty-suffix form so HTTP/1.1 errors (404, 500, etc.)
+    // with a populated statusText still propagate to isAnonymousTooLargeError.
     try {
       return await api.downloadFile(cid, password);
     } catch (e) {
       if (
         authMode === 'anonymous' &&
         e instanceof Error &&
-        e.message.startsWith('Failed to download file:')
+        e.message === 'Failed to download file: '
       ) {
         throw new Error(
           'Downloading large files require authorization, please login via gauth, wallet, github or discord',


### PR DESCRIPTION
## Problem

The backend code comment in `downloadObjectByUser` states:

> "Download credits are not enforced right now — infrastructure exists for future use but purchased download bytes are not allocated on purchase and are not counted here."

However, `downloadObjectByUser` was still checking `pendingCredits < metadata.totalSize` and returning a `402 PaymentRequiredError` when the user's free download quota was exhausted. Since purchased download bytes are never allocated on purchase, users have no way to replenish a depleted quota — making the block permanent.

Verified via browser: authenticated requests to `public.auto-drive.autonomys.xyz/api/downloads/{cid}` returned `{"error":"Not enough download credits"}` because `pendingDownloadCredits` was deeply negative, despite the design intent being that downloads are unrestricted for authenticated users.

A second independent bug prevented decrypted (password-protected) downloads from recovering even after the credit block was lifted: the session-auth retry in `fetchFromApi` never fired for the decrypted path. The SDK's `downloadFile` wraps all HTTP failures as `new Error('Failed to download file: ' + response.statusText)`. On HTTP/2, `statusText` is always `""`, producing `"Failed to download file: "` — a message that `isAnonymousTooLargeError` in `download.ts` does not match (it looks for "payment required", "file too large", etc.), so the anonymous→session retry was silently skipped.

## Changes

### Backend (`apps/backend`)
- **Commented out** the `pendingCredits` check in `downloadObjectByUser` so authenticated users are never blocked by download quota. The comment explains why enforcement is disabled and what must be wired up before re-enabling it. Download interactions are still registered via `registerInteraction` for future analytics/billing.
- **Removed `PaymentRequiredError`** from the `downloadObjectByUser` return type (it could no longer be returned after the check was disabled, flagged as a separate bugbot finding).

### Frontend (`apps/frontend`)
- **Fixed the session-auth retry** for decrypted downloads: `downloadObject` now wraps `api.downloadFile` in a try-catch and re-throws with the recognised login message when the error is exactly `"Failed to download file: "` (the HTTP/2 empty-statusText form) and `authMode` is `'anonymous'`. Errors with a populated `statusText` (HTTP/1.1 404, 500, etc.) propagate unchanged so `isAnonymousTooLargeError` in `download.ts` can still discriminate them correctly.
- **Added `moduleNameMapper`** to `jest.config.ts` so Jest resolves `tsconfig` `baseUrl` path aliases (`utils/*`, `services/*`, etc.).
- **Added 13 unit tests** for `createApiService().downloadObject` covering:
  - Encrypted raw download (`skipDecryption: true`): anonymous 402/404 error handling, session success
  - Decrypted download (`skipDecryption: false`): HTTP/2 empty-statusText bug regression, HTTP/1.1 populated-statusText errors propagate unchanged, unrelated errors propagate, session success, password forwarding, immediate guard when no session is available

## Test plan
- [ ] Download a file (encrypted) as an anonymous user — should work for small files, prompt login for large ones
- [ ] Download a file (decrypted, with password) as an anonymous user hitting a large file — should now prompt login instead of silently failing
- [ ] Download a file as an authenticated user whose free download quota is exhausted — should now succeed instead of returning 402
- [x] Run `yarn frontend test` — all 100 tests pass