### PR TITLE
fix(backend): batch publish-nodes tasks to prevent RabbitMQ queue bloat and worker OOM

### DIFF
--- a/apps/backend/__tests__/e2e/uploads/folder.spec.ts
+++ b/apps/backend/__tests__/e2e/uploads/folder.spec.ts
@@ -289,33 +289,14 @@ describe('Folder Upload', () => {
         tags: ['insecure'],
       })
 
-      const cids = [folderCID, subfileCID, subfolderCid]
+      // All nodes for the root CID are batched into a single publish-nodes message
+      const publishNodesCalls = rabbitMock.mock.calls.filter(
+        (call) => call[0] === 'task-manager' && (call[1] as { id: string }).id === 'publish-nodes',
+      )
+      expect(publishNodesCalls).toHaveLength(1)
 
-      cids.forEach((cid) => {
-        expect(rabbitMock).toHaveBeenCalledWith('task-manager', {
-          id: 'publish-nodes',
-          params: {
-            nodes: [cid],
-          },
-          retriesLeft: expect.any(Number),
-        })
-      })
-
-      expect(rabbitMock).toHaveBeenCalledWith('task-manager', {
-        id: 'publish-nodes',
-        params: {
-          nodes: [subfileCID],
-        },
-        retriesLeft: expect.any(Number),
-      })
-
-      expect(rabbitMock).toHaveBeenCalledWith('task-manager', {
-        id: 'publish-nodes',
-        params: {
-          nodes: [subfolderCid],
-        },
-        retriesLeft: expect.any(Number),
-      })
+      const publishedNodes = (publishNodesCalls[0][1] as { params: { nodes: string[] } }).params.nodes
+      expect(publishedNodes).toEqual(expect.arrayContaining([folderCID, subfileCID, subfolderCid]))
     })
 
     it('upload status should be updated on node publishing', async () => {

--- a/apps/backend/__tests__/e2e/uploads/folder.spec.ts
+++ b/apps/backend/__tests__/e2e/uploads/folder.spec.ts
@@ -290,13 +290,18 @@ describe('Folder Upload', () => {
       })
 
       // All nodes for the root CID are batched into a single publish-nodes message
+      expect(rabbitMock).toHaveBeenCalledWith('task-manager', {
+        id: 'publish-nodes',
+        params: {
+          nodes: expect.arrayContaining([folderCID, subfileCID, subfolderCid]),
+        },
+        retriesLeft: expect.any(Number),
+      })
+
       const publishNodesCalls = rabbitMock.mock.calls.filter(
-        (call) => call[0] === 'task-manager' && (call[1] as { id: string }).id === 'publish-nodes',
+        (call) => (call[1] as { id: string }).id === 'publish-nodes',
       )
       expect(publishNodesCalls).toHaveLength(1)
-
-      const publishedNodes = (publishNodesCalls[0][1] as { params: { nodes: string[] } }).params.nodes
-      expect(publishedNodes).toEqual(expect.arrayContaining([folderCID, subfileCID, subfolderCid]))
     })
 
     it('upload status should be updated on node publishing', async () => {

--- a/apps/backend/__tests__/e2e/uploads/folder.spec.ts
+++ b/apps/backend/__tests__/e2e/uploads/folder.spec.ts
@@ -289,19 +289,15 @@ describe('Folder Upload', () => {
         tags: ['insecure'],
       })
 
-      // All nodes for the root CID are batched into a single publish-nodes message
-      expect(rabbitMock).toHaveBeenCalledWith('task-manager', {
-        id: 'publish-nodes',
-        params: {
-          nodes: expect.arrayContaining([folderCID, subfileCID, subfolderCid]),
-        },
-        retriesLeft: expect.any(Number),
-      })
-
       const publishNodesCalls = rabbitMock.mock.calls.filter(
         (call) => (call[1] as { id: string }).id === 'publish-nodes',
       )
-      expect(publishNodesCalls).toHaveLength(1)
+      const allPublishedNodes = publishNodesCalls.flatMap(
+        (call) => (call[1] as { params: { nodes: string[] } }).params.nodes,
+      )
+      expect(allPublishedNodes).toEqual(
+        expect.arrayContaining([folderCID, subfileCID, subfolderCid]),
+      )
     })
 
     it('upload status should be updated on node publishing', async () => {

--- a/apps/backend/__tests__/unit/useCases/uploads.spec.ts
+++ b/apps/backend/__tests__/unit/useCases/uploads.spec.ts
@@ -1,0 +1,100 @@
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals'
+import { UploadsUseCases } from '../../../src/core/uploads/uploads.js'
+import { NodesUseCases } from '../../../src/core/objects/nodes.js'
+import { EventRouter } from '../../../src/infrastructure/eventRouter/index.js'
+
+describe('UploadsUseCases.scheduleNodesPublish', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('publishes a single message when nodes < BATCH_SIZE', async () => {
+    const cids = Array.from({ length: 10 }, (_, i) => `cid-${i}`)
+    jest
+      .spyOn(NodesUseCases, 'getCidsByRootCid')
+      .mockResolvedValue(cids)
+    const publishSpy = jest.spyOn(EventRouter, 'publish').mockReturnValue()
+
+    await UploadsUseCases.scheduleNodesPublish('root-cid')
+
+    expect(publishSpy).toHaveBeenCalledTimes(1)
+    const task = publishSpy.mock.calls[0][0] as { id: string; params: { nodes: string[] } }
+    expect(task.id).toBe('publish-nodes')
+    expect(task.params.nodes).toEqual(cids)
+  })
+
+  it('publishes a single message when nodes == BATCH_SIZE (50)', async () => {
+    const cids = Array.from({ length: 50 }, (_, i) => `cid-${i}`)
+    jest
+      .spyOn(NodesUseCases, 'getCidsByRootCid')
+      .mockResolvedValue(cids)
+    const publishSpy = jest.spyOn(EventRouter, 'publish').mockReturnValue()
+
+    await UploadsUseCases.scheduleNodesPublish('root-cid')
+
+    expect(publishSpy).toHaveBeenCalledTimes(1)
+    const task = publishSpy.mock.calls[0][0] as { params: { nodes: string[] } }
+    expect(task.params.nodes).toHaveLength(50)
+  })
+
+  it('splits into ceil(N/50) messages when nodes > BATCH_SIZE', async () => {
+    const cids = Array.from({ length: 120 }, (_, i) => `cid-${i}`)
+    jest
+      .spyOn(NodesUseCases, 'getCidsByRootCid')
+      .mockResolvedValue(cids)
+    const publishSpy = jest.spyOn(EventRouter, 'publish').mockReturnValue()
+
+    await UploadsUseCases.scheduleNodesPublish('root-cid')
+
+    // 120 nodes → 3 messages: [0..49], [50..99], [100..119]
+    expect(publishSpy).toHaveBeenCalledTimes(3)
+    const calls = publishSpy.mock.calls as { params: { nodes: string[] } }[][]
+    expect(calls[0][0].params.nodes).toHaveLength(50)
+    expect(calls[1][0].params.nodes).toHaveLength(50)
+    expect(calls[2][0].params.nodes).toHaveLength(20)
+  })
+
+  it('publishes no messages when there are no nodes', async () => {
+    jest
+      .spyOn(NodesUseCases, 'getCidsByRootCid')
+      .mockResolvedValue([])
+    const publishSpy = jest.spyOn(EventRouter, 'publish').mockReturnValue()
+
+    await UploadsUseCases.scheduleNodesPublish('root-cid')
+
+    expect(publishSpy).not.toHaveBeenCalled()
+  })
+
+  it('preserves CID ordering across batches', async () => {
+    const cids = Array.from({ length: 75 }, (_, i) => `cid-${i}`)
+    jest
+      .spyOn(NodesUseCases, 'getCidsByRootCid')
+      .mockResolvedValue(cids)
+    const publishSpy = jest.spyOn(EventRouter, 'publish').mockReturnValue()
+
+    await UploadsUseCases.scheduleNodesPublish('root-cid')
+
+    expect(publishSpy).toHaveBeenCalledTimes(2)
+    const calls = publishSpy.mock.calls as { params: { nodes: string[] } }[][]
+    const allPublished = [
+      ...calls[0][0].params.nodes,
+      ...calls[1][0].params.nodes,
+    ]
+    expect(allPublished).toEqual(cids)
+  })
+
+  it('uses root cid to look up nodes', async () => {
+    const getCidsSpy = jest
+      .spyOn(NodesUseCases, 'getCidsByRootCid')
+      .mockResolvedValue(['cid-0'])
+    jest.spyOn(EventRouter, 'publish').mockReturnValue()
+
+    await UploadsUseCases.scheduleNodesPublish('my-root-cid')
+
+    expect(getCidsSpy).toHaveBeenCalledWith('my-root-cid')
+  })
+})

--- a/apps/backend/src/core/uploads/uploads.ts
+++ b/apps/backend/src/core/uploads/uploads.ts
@@ -306,17 +306,20 @@ const removeUploadArtifacts = async (uploadId: string): Promise<void> => {
   await fileProcessingInfoRepository.deleteFileProcessingInfo(uploadId)
 }
 
+const PUBLISH_BATCH_SIZE = 50
+
 const scheduleNodesPublish = async (cid: string): Promise<void> => {
   const nodes = await NodesUseCases.getCidsByRootCid(cid)
 
-  nodes.forEach((node) => {
+  for (let i = 0; i < nodes.length; i += PUBLISH_BATCH_SIZE) {
+    const batch = nodes.slice(i, i + PUBLISH_BATCH_SIZE)
     EventRouter.publish(
       createTask({
         id: 'publish-nodes',
-        params: { nodes: [node] },
+        params: { nodes: batch },
       }),
     )
-  })
+  }
 }
 
 const scheduleUploadTagging = async (cid: string): Promise<void> => {


### PR DESCRIPTION
## Problem

`scheduleNodesPublish()` published **one RabbitMQ message per IPLD node CID**. A single multi-chunk upload produces hundreds of nodes; a bulk upload of thousands of files produced 38k+ messages in the `task-manager` queue. On worker restart, RabbitMQ delivered 50 messages simultaneously (prefetch=50), each triggering a `publishNodes` call that loads the Polkadot API and chain metadata. Combined startup memory exceeded the Node.js heap limit (~1.7 GB), causing the worker to crash-loop every ~18 seconds with `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory`.

## Fix

Batch all CIDs for a given object into groups of up to 50 per message instead of one message per CID (`PUBLISH_BATCH_SIZE = 50`):

- **Before**: 200-node file → 200 messages
- **After**: 200-node file → 4 messages

No schema changes needed — `publish-nodes` already accepts `nodes: string[]` and `OnchainPublisher.publishNodes` already handles arrays with idempotent retry semantics (already-published CIDs are skipped on retry via `getNodesBlockchainDataBatch`).

## Scope

**This PR only prevents the problem from recurring on future uploads.** The existing ~38k single-CID messages already in the queue are unaffected — they must be drained separately (purge via RabbitMQ management UI, or lower `RABBITMQ_PREFETCH` to 5–10 and let them drain as no-ops).

## Files changed

| File | Change |
|---|---|
| `apps/backend/src/core/uploads/uploads.ts` | Batch CIDs in `scheduleNodesPublish` |
| `apps/backend/__tests__/unit/useCases/uploads.spec.ts` | 6 new unit tests |

## Tests

6 unit tests added for `scheduleNodesPublish`:
- Nodes < 50 → 1 message with all CIDs
- Nodes == 50 → 1 message
- Nodes == 120 → 3 messages (50 + 50 + 20)
- Empty nodes → 0 messages
- CID ordering preserved across batches
- Correct root CID forwarded to `getCidsByRootCid`