### PR TITLE
feat(frontend): admin-only Cached/Not cached tag on file detail page

### DIFF
--- a/apps/frontend/src/components/organisms/ObjectDetails/ObjectDetailsActions.tsx
+++ b/apps/frontend/src/components/organisms/ObjectDetails/ObjectDetailsActions.tsx
@@ -1,4 +1,4 @@
-import { DownloadStatus, ObjectInformation, ObjectTag } from '@auto-drive/models';
+import { ObjectInformation, ObjectTag } from '@auto-drive/models';
 import { Button } from '@auto-drive/ui';
 import { cn } from '@/utils/cn';
 import {
@@ -8,7 +8,7 @@ import {
   ExclamationTriangleIcon,
   CloudArrowDownIcon,
 } from '@heroicons/react/24/outline';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useUserStore } from 'globalStates/user';
 import toast from 'react-hot-toast';
 import { useNetwork } from '../../../contexts/network';
@@ -19,9 +19,11 @@ import { ObjectDeleteModal } from '../../molecules/ObjectDeleteModal';
 export const ObjectDetailsActions = ({
   object,
   isOwner,
+  isCached,
 }: {
   object: ObjectInformation;
   isOwner: boolean;
+  isCached: boolean | null;
 }) => {
   const { user } = useUserStore();
   const { api } = useNetwork();
@@ -29,16 +31,7 @@ export const ObjectDetailsActions = ({
   const [shareModalCid, setShareModalCid] = useState<string | null>(null);
   const [deleteModalCid, setDeleteModalCid] = useState<string | null>(null);
   const [isReporting, setIsReporting] = useState(false);
-  const [isCached, setIsCached] = useState<boolean | null>(null);
   const [isBringingToCache, setIsBringingToCache] = useState(false);
-
-  useEffect(() => {
-    if (!object?.metadata.dataCid) return;
-    
-    api.checkDownloadStatus(object.metadata.dataCid)
-      .then((status) => setIsCached(status === DownloadStatus.Cached))
-      .catch(() => setIsCached(false));
-  }, [api, object?.metadata.dataCid]);
 
   const hasFileOwnership = object?.owners.some(
     (o) =>

--- a/apps/frontend/src/components/organisms/ObjectDetails/ObjectDetailsTags.tsx
+++ b/apps/frontend/src/components/organisms/ObjectDetails/ObjectDetailsTags.tsx
@@ -1,13 +1,16 @@
-import { ObjectInformation, ObjectTag } from '@auto-drive/models';
+import { ObjectInformation, ObjectTag, UserRole } from '@auto-drive/models';
 import { ConditionalRender } from '../../atoms/ConditionalRender';
+import { RoleProtected } from '../../atoms/RoleProtected';
 import { Badge } from '@/components/atoms/Badge';
 import { getTypeFromMetadata } from 'utils/file';
 import { formatBytes } from '../../../utils/number';
 
 export const ObjectDetailsTags = ({
   object,
+  isCached,
 }: {
   object: ObjectInformation;
+  isCached: boolean | null;
 }) => {
   return (
     <div>
@@ -38,6 +41,18 @@ export const ObjectDetailsTags = ({
             Banned
           </span>
         </ConditionalRender>
+        {isCached !== null && (
+          <RoleProtected roles={[UserRole.Admin]}>
+            <span
+              className={`ml-2 rounded-lg p-1 text-xs font-semibold text-white ${
+                isCached ? 'bg-green-600' : 'bg-gray-500'
+              }`}
+              title='Visible to admins only'
+            >
+              {isCached ? 'Cached' : 'Not cached'}
+            </span>
+          </RoleProtected>
+        )}
       </p>
     </div>
   );

--- a/apps/frontend/src/components/organisms/ObjectDetails/index.tsx
+++ b/apps/frontend/src/components/organisms/ObjectDetails/index.tsx
@@ -8,6 +8,7 @@ import { Loader } from 'lucide-react';
 import { FilePreview } from '@/components/molecules/FilePreview';
 import { IconByFileType } from '@/components/atoms/IconByFileType';
 import { GoBackButton } from '@/components/atoms/GoBackButton';
+import { useFileInCache } from 'hooks/useFileInCache';
 import { ObjectDetailsTags } from './ObjectDetailsTags';
 import { ObjectDetailsActions } from './ObjectDetailsActions';
 import { ObjectUploadDetails } from './ObjectUploadDetails';
@@ -30,6 +31,8 @@ export const ObjectDetails = ({
       o.oauthUserId === user?.oauthUserId &&
       o.role === OwnerRole.ADMIN,
   );
+
+  const isCached = useFileInCache(object?.metadata.dataCid ?? '');
 
   const isLoading = object === null;
   if (isLoading) {
@@ -54,9 +57,9 @@ export const ObjectDetails = ({
               fileType={getTypeFromMetadata(object.metadata) ?? ''}
             />
           </div>
-          <ObjectDetailsTags object={object} />
+          <ObjectDetailsTags object={object} isCached={isCached} />
         </div>
-        <ObjectDetailsActions isOwner={isOwner} object={object} />
+        <ObjectDetailsActions isOwner={isOwner} object={object} isCached={isCached} />
       </div>
       <ObjectUploadDetails object={object} isOwner={isOwner} />
       <ObjectUploadOptions object={object} />

--- a/apps/frontend/src/hooks/useFileInCache.ts
+++ b/apps/frontend/src/hooks/useFileInCache.ts
@@ -3,13 +3,13 @@ import { useNetwork } from 'contexts/network';
 import { DownloadStatus } from '@auto-drive/models';
 
 /**
- * Hook to check if a file is available in the cache
- * @param cid Content identifier of the file
- * @returns boolean indicating if the file is cached
+ * Hook to check if a file is available in the cache.
+ * @param cid Content identifier of the file.
+ * @returns `true` if cached, `false` if not cached, `null` while the check is in flight.
  */
-export const useFileInCache = (cid: string): boolean => {
+export const useFileInCache = (cid: string): boolean | null => {
   const { api } = useNetwork();
-  const [isCached, setIsCached] = useState<boolean>(false);
+  const [isCached, setIsCached] = useState<boolean | null>(null);
 
   useEffect(() => {
     let mounted = true;
@@ -17,16 +17,9 @@ export const useFileInCache = (cid: string): boolean => {
     const checkCache = async () => {
       if (!cid) return;
 
-      try {
-        const status = await api.checkDownloadStatus(cid).catch(() => false);
-        if (mounted) {
-          setIsCached(status === DownloadStatus.Cached);
-        }
-      } catch (error) {
-        console.error('Error checking file cache status:', error);
-        if (mounted) {
-          setIsCached(false);
-        }
+      const status = await api.checkDownloadStatus(cid).catch(() => false);
+      if (mounted) {
+        setIsCached(status === DownloadStatus.Cached);
       }
     };
 


### PR DESCRIPTION
## Summary

Adds an admin-only cache status indicator on the file detail page so admins can see at a glance whether a file is currently in the download cache.

- Show a green "Cached" or gray "Not cached" pill next to the existing file tags (Insecure / On review / Banned), visible only to admins via `RoleProtected`
- Lift `useFileInCache` into the parent `ObjectDetails` component so both the tag and the "Bring to Cache" button share a single API call instead of making two
- Widen `useFileInCache` return type from `boolean` to `boolean | null` (`null` = loading), which prevents the "Bring to Cache" button from flashing on initial render
- Clean up dead code: removed an unreachable outer `try/catch` in the hook (the `.catch(() => false)` on the promise already handles errors)

### What didn't change

- The "Bring to Cache" button behavior is unchanged — it already renders for any authenticated user when `isCached === false`, and the backend endpoint (`POST /downloads/async/:cid`) has no ownership restriction
- No backend changes
