### PR TITLE
fix(frontend): only disable close guard after successful clipboard copy

### DIFF
--- a/apps/frontend/src/components/molecules/ApiKeyCreationModal.tsx
+++ b/apps/frontend/src/components/molecules/ApiKeyCreationModal.tsx
@@ -139,10 +139,10 @@ export const ApiKeyCreationModal = ({
     if (apiKey) {
       try {
         await copyToClipboard(apiKey.secret);
+        setHasBeenCopied(true);
       } catch {
         toast.error('Failed to copy — please select and copy the key manually');
       }
-      setHasBeenCopied(true);
     }
   }, [apiKey, copyToClipboard]);
 


### PR DESCRIPTION
setHasBeenCopied(true) was placed after the try/catch in copyApiKey, so it ran even when navigator.clipboard.writeText threw. This disabled the dialog's close-prevention guard, letting the user dismiss the modal before successfully copying the secret — which is never shown again.