### PR TITLE
fix: add archival reconciliation to resolve stuck objects (#674)

### DIFF
--- a/apps/backend/src/app/servers/frontendWorker.ts
+++ b/apps/backend/src/app/servers/frontendWorker.ts
@@ -70,10 +70,17 @@
   const shutdown = async () => {
     logger.info('Shutting down frontend worker...')
     objectMappingArchiver.stop()
-    const { reconciliationJob } = await import(
-      '../../infrastructure/services/reconciliationJob.js'
-    )
-    reconciliationJob.stop()
+    // reconciliationJob.stop() is safe even if never started (no-op),
+    // but we only import it when it was actually activated.
+    if (
+      config.featureFlags.flags.objectMappingArchiver.active &&
+      config.featureFlags.flags.taskManager.active
+    ) {
+      const { reconciliationJob } = await import(
+        '../../infrastructure/services/reconciliationJob.js'
+      )
+      reconciliationJob.stop()
+    }
     paymentManager.stop()
     const { creditExpiryJob } = await import(
       '../../infrastructure/services/creditExpiryJob.js'

--- a/apps/backend/src/app/servers/frontendWorker.ts
+++ b/apps/backend/src/app/servers/frontendWorker.ts
@@ -31,6 +31,16 @@
   }
   if (config.featureFlags.flags.objectMappingArchiver.active) {
     objectMappingArchiver.start()
+
+    // Start periodic reconciliation to resolve stuck nodes.
+    // Requires task manager to be active (task-manager queue consumer).
+    if (config.featureFlags.flags.taskManager.active) {
+      const { reconciliationJob } = await import(
+        '../../infrastructure/services/reconciliationJob.js'
+      )
+      reconciliationJob.start()
+    }
+
     somethingActive = true
   }
   if (
@@ -60,6 +70,10 @@
   const shutdown = async () => {
     logger.info('Shutting down frontend worker...')
     objectMappingArchiver.stop()
+    const { reconciliationJob } = await import(
+      '../../infrastructure/services/reconciliationJob.js'
+    )
+    reconciliationJob.stop()
     paymentManager.stop()
     const { creditExpiryJob } = await import(
       '../../infrastructure/services/creditExpiryJob.js'

--- a/apps/backend/src/config.ts
+++ b/apps/backend/src/config.ts
@@ -35,6 +35,9 @@ export const config = {
     url: env('OBJECT_MAPPING_ARCHIVER_URL'),
     step: Number(env('OBJECT_MAPPING_ARCHIVER_STEP', '1000')),
   },
+  reconciliation: {
+    intervalMs: Number(env('RECONCILIATION_INTERVAL_MS', '300000')), // 5 minutes
+  },
   filesGateway: {
     url: env('FILES_GATEWAY_URL'),
     token: env('FILES_GATEWAY_TOKEN'),

--- a/apps/backend/src/core/objects/object.ts
+++ b/apps/backend/src/core/objects/object.ts
@@ -573,6 +573,36 @@ const checkObjectsArchivalStatus = async () => {
   )
 }
 
+/**
+ * Like checkObjectsArchivalStatus but scoped to a specific set of head_cids.
+ * Uses a single aggregate query instead of N+1, making it safe for large
+ * batches during reconciliation.
+ */
+const checkArchivalStatusForObjects = async (
+  headCids: string[],
+): Promise<void> => {
+  if (headCids.length === 0) return
+
+  const fullyArchived =
+    await nodesRepository.getFullyArchivedHeadCids(headCids)
+
+  logger.info(
+    'Targeted archival check: %d/%d objects fully archived',
+    fullyArchived.length,
+    headCids.length,
+  )
+
+  for (const cid of fullyArchived) {
+    logger.debug('Publishing archival task for object (cid=%s)', cid)
+    EventRouter.publish(
+      createTask({
+        id: 'object-archived',
+        params: { cid },
+      }),
+    )
+  }
+}
+
 const addTag = async (cid: string, tag: string) => {
   const tags = await metadataRepository.getMetadata(cid)
   if (!tags) {
@@ -709,6 +739,7 @@ export const ObjectUseCases = {
   downloadPublishedObject,
   unpublishObject,
   checkObjectsArchivalStatus,
+  checkArchivalStatusForObjects,
   populateCaches,
   addTag,
   banObject,

--- a/apps/backend/src/core/objects/reconciliation.ts
+++ b/apps/backend/src/core/objects/reconciliation.ts
@@ -13,6 +13,16 @@ const logger = createLogger('useCases:objects:reconciliation')
 
 const BATCH_SIZE = 500
 
+// Track consecutive zero-progress runs to detect permanently unresolvable
+// nodes (the indexer also missed them and can't provide their data).
+let consecutiveZeroProgressRuns = 0
+const ZERO_PROGRESS_WARN_THRESHOLD = 3
+
+// Concurrency guard — if a reconciliation is already in flight, skip.
+// Prevents duplicate work when the setInterval tick overlaps with a
+// self-rescheduled drain or when RabbitMQ prefetch delivers two tasks.
+let isRunning = false
+
 /**
  * Reconciles stuck nodes that have been published on-chain but are missing
  * piece_index/piece_offset from the indexer.
@@ -22,7 +32,7 @@ const BATCH_SIZE = 500
  *   uploaded objects are prioritized over legacy backlog
  * - Extracts blake3 hashes from CIDs and batch-queries the indexer
  * - Applies archival data for any nodes the indexer can resolve
- * - Triggers archival status check for affected objects
+ * - Triggers archival status check for affected objects (targeted, not N+1)
  * - If backlog remains AND progress was made: self-reschedules via
  *   RabbitMQ immediately (yields to other tasks in the queue between
  *   batches)
@@ -31,12 +41,27 @@ const BATCH_SIZE = 500
  *   the next run.
  */
 const processReconciliation = async (): Promise<void> => {
+  if (isRunning) {
+    logger.debug('Reconciliation already in progress, skipping')
+    return
+  }
+
+  isRunning = true
+  try {
+    await runReconciliationBatch()
+  } finally {
+    isRunning = false
+  }
+}
+
+const runReconciliationBatch = async (): Promise<void> => {
   const unreconciledNodes = await nodesRepository.getUnreconciledNodes(
     BATCH_SIZE,
   )
 
   if (unreconciledNodes.length === 0) {
     logger.debug('No unreconciled nodes found, skipping')
+    consecutiveZeroProgressRuns = 0
     return
   }
 
@@ -128,9 +153,27 @@ const processReconciliation = async (): Promise<void> => {
     affectedHeadCids.size,
   )
 
-  // Check if any objects are now fully archived
-  if (resolvedCount > 0) {
-    await ObjectUseCases.checkObjectsArchivalStatus()
+  // Check if any objects are now fully archived (targeted, single query)
+  if (affectedHeadCids.size > 0) {
+    await ObjectUseCases.checkArchivalStatusForObjects(
+      Array.from(affectedHeadCids),
+    )
+  }
+
+  // Track zero-progress runs to surface permanently unresolvable nodes
+  if (resolvedCount === 0) {
+    consecutiveZeroProgressRuns++
+    if (consecutiveZeroProgressRuns >= ZERO_PROGRESS_WARN_THRESHOLD) {
+      logger.error(
+        'Reconciliation made no progress for %d consecutive runs. ' +
+          '%d unreconciled nodes may be permanently unresolvable ' +
+          '(indexer also missing their data). Consider indexer-side backfill.',
+        consecutiveZeroProgressRuns,
+        unreconciledNodes.length,
+      )
+    }
+  } else {
+    consecutiveZeroProgressRuns = 0
   }
 
   // Only reschedule immediately when the batch made progress. If zero

--- a/apps/backend/src/core/objects/reconciliation.ts
+++ b/apps/backend/src/core/objects/reconciliation.ts
@@ -23,10 +23,12 @@ const BATCH_SIZE = 500
  * - Extracts blake3 hashes from CIDs and batch-queries the indexer
  * - Applies archival data for any nodes the indexer can resolve
  * - Triggers archival status check for affected objects
- * - If backlog remains: self-reschedules via RabbitMQ immediately
- *   (yields to other tasks in the queue between batches)
- * - If backlog is clear: returns without rescheduling. The periodic
- *   interval in the worker will enqueue the next run.
+ * - If backlog remains AND progress was made: self-reschedules via
+ *   RabbitMQ immediately (yields to other tasks in the queue between
+ *   batches)
+ * - If no progress was made or backlog is clear: returns without
+ *   rescheduling. The periodic interval in the worker will enqueue
+ *   the next run.
  */
 const processReconciliation = async (): Promise<void> => {
   const unreconciledNodes = await nodesRepository.getUnreconciledNodes(
@@ -131,21 +133,24 @@ const processReconciliation = async (): Promise<void> => {
     await ObjectUseCases.checkObjectsArchivalStatus()
   }
 
-  // If more stuck nodes remain, enqueue another batch immediately.
-  // The task goes to the back of the RabbitMQ queue, so it naturally
-  // yields to any pending uploads/publishes/archives.
-  const remainingCount = await nodesRepository.getUnreconciledNodesCount()
-  if (remainingCount > 0) {
-    logger.info(
-      'Rescheduling reconciliation, %d unreconciled nodes remaining',
-      remainingCount,
-    )
-    EventRouter.publish(
-      createTask({
-        id: 'reconcile-archival',
-        params: {},
-      }),
-    )
+  // Only reschedule immediately when the batch made progress. If zero
+  // nodes were resolved the indexer is likely down or hasn't caught up,
+  // and hammering it in a tight loop is wasteful. The periodic 5-minute
+  // interval will restart the drain once the indexer recovers.
+  if (resolvedCount > 0) {
+    const remainingCount = await nodesRepository.getUnreconciledNodesCount()
+    if (remainingCount > 0) {
+      logger.info(
+        'Rescheduling reconciliation, %d unreconciled nodes remaining',
+        remainingCount,
+      )
+      EventRouter.publish(
+        createTask({
+          id: 'reconcile-archival',
+          params: {},
+        }),
+      )
+    }
   }
 }
 

--- a/apps/backend/src/core/objects/reconciliation.ts
+++ b/apps/backend/src/core/objects/reconciliation.ts
@@ -1,0 +1,154 @@
+import {
+  blake3HashFromCid,
+  stringToCid,
+} from '@autonomys/auto-dag-data'
+import { nodesRepository } from '../../infrastructure/repositories/index.js'
+import { objectMappingIndexerClient } from '../../infrastructure/services/dsn/objectMappingIndexerClient/index.js'
+import { ObjectUseCases } from './object.js'
+import { createLogger } from '../../infrastructure/drivers/logger.js'
+import { EventRouter } from '../../infrastructure/eventRouter/index.js'
+import { createTask } from '../../infrastructure/eventRouter/tasks.js'
+
+const logger = createLogger('useCases:objects:reconciliation')
+
+const BATCH_SIZE = 500
+
+/**
+ * Reconciles stuck nodes that have been published on-chain but are missing
+ * piece_index/piece_offset from the indexer.
+ *
+ * Strategy:
+ * - Fetches a batch of unreconciled nodes, ordered newest-first so newly
+ *   uploaded objects are prioritized over legacy backlog
+ * - Extracts blake3 hashes from CIDs and batch-queries the indexer
+ * - Applies archival data for any nodes the indexer can resolve
+ * - Triggers archival status check for affected objects
+ * - If backlog remains: self-reschedules via RabbitMQ immediately
+ *   (yields to other tasks in the queue between batches)
+ * - If backlog is clear: returns without rescheduling. The periodic
+ *   interval in the worker will enqueue the next run.
+ */
+const processReconciliation = async (): Promise<void> => {
+  const unreconciledNodes = await nodesRepository.getUnreconciledNodes(
+    BATCH_SIZE,
+  )
+
+  if (unreconciledNodes.length === 0) {
+    logger.debug('No unreconciled nodes found, skipping')
+    return
+  }
+
+  logger.info(
+    'Processing reconciliation batch of %d nodes',
+    unreconciledNodes.length,
+  )
+
+  // Build CID → hash mapping
+  const cidHashMap = new Map<string, string>()
+  for (const node of unreconciledNodes) {
+    try {
+      const hash = Buffer.from(
+        blake3HashFromCid(stringToCid(node.cid)),
+      ).toString('hex')
+      cidHashMap.set(node.cid, hash)
+    } catch (error) {
+      logger.warn(
+        'Failed to extract blake3 hash from CID %s: %s',
+        node.cid,
+        error instanceof Error ? error.message : String(error),
+      )
+    }
+  }
+
+  if (cidHashMap.size === 0) {
+    logger.warn('No valid hashes extracted from batch, skipping')
+    return
+  }
+
+  // Build reverse map: hash → CID for matching results back
+  const hashCidMap = new Map<string, string>()
+  for (const [cid, hash] of cidHashMap) {
+    hashCidMap.set(hash, cid)
+  }
+
+  // Build CID → head_cid map for tracking affected objects
+  const cidHeadCidMap = new Map<string, string>(
+    unreconciledNodes.map((n) => [n.cid, n.head_cid]),
+  )
+
+  const hashes = Array.from(cidHashMap.values())
+
+  // Query indexer in sub-batches to avoid overwhelming it
+  const SUB_BATCH_SIZE = 100
+  let resolvedCount = 0
+  const affectedHeadCids = new Set<string>()
+
+  for (let i = 0; i < hashes.length; i += SUB_BATCH_SIZE) {
+    const hashBatch = hashes.slice(i, i + SUB_BATCH_SIZE)
+
+    const mappings =
+      await objectMappingIndexerClient.getObjectMappings(hashBatch)
+
+    // Apply resolved mappings
+    for (const [hash, pieceIndex, pieceOffset] of mappings) {
+      const cid = hashCidMap.get(hash)
+      if (!cid) {
+        continue
+      }
+
+      try {
+        await nodesRepository.setNodeArchivingData({
+          cid,
+          pieceIndex,
+          pieceOffset,
+        })
+        resolvedCount++
+
+        // Track affected objects for archival status check
+        const headCid = cidHeadCidMap.get(cid)
+        if (headCid) {
+          affectedHeadCids.add(headCid)
+        }
+      } catch (error) {
+        logger.warn(
+          'Failed to set archival data for node %s: %s',
+          cid,
+          error instanceof Error ? error.message : String(error),
+        )
+      }
+    }
+  }
+
+  logger.info(
+    'Reconciliation batch complete: resolved %d/%d nodes, %d objects affected',
+    resolvedCount,
+    unreconciledNodes.length,
+    affectedHeadCids.size,
+  )
+
+  // Check if any objects are now fully archived
+  if (resolvedCount > 0) {
+    await ObjectUseCases.checkObjectsArchivalStatus()
+  }
+
+  // If more stuck nodes remain, enqueue another batch immediately.
+  // The task goes to the back of the RabbitMQ queue, so it naturally
+  // yields to any pending uploads/publishes/archives.
+  const remainingCount = await nodesRepository.getUnreconciledNodesCount()
+  if (remainingCount > 0) {
+    logger.info(
+      'Rescheduling reconciliation, %d unreconciled nodes remaining',
+      remainingCount,
+    )
+    EventRouter.publish(
+      createTask({
+        id: 'reconcile-archival',
+        params: {},
+      }),
+    )
+  }
+}
+
+export const ReconciliationUseCases = {
+  processReconciliation,
+}

--- a/apps/backend/src/infrastructure/eventRouter/processors/frontend.ts
+++ b/apps/backend/src/infrastructure/eventRouter/processors/frontend.ts
@@ -1,5 +1,6 @@
 import { OnchainPublisher } from '../../services/upload/onchainPublisher/index.js'
 import { NodesUseCases } from '../../../core/objects/nodes.js'
+import { ReconciliationUseCases } from '../../../core/objects/reconciliation.js'
 import { UploadsUseCases } from '../../../core/uploads/uploads.js'
 import { Task } from '../tasks.js'
 import { createHandlerWithRetries } from '../utils.js'
@@ -21,6 +22,8 @@ export const processFrontendTask = createHandlerWithRetries(
       return NodesUseCases.ensureObjectPublished(params.cid)
     } else if (id === 'watch-intent-tx') {
       return paymentManager.watchTransaction(params.txHash)
+    } else if (id === 'reconcile-archival') {
+      return ReconciliationUseCases.processReconciliation()
     } else {
       throw new Error(`Received task ${id} but no handler found.`)
     }

--- a/apps/backend/src/infrastructure/eventRouter/tasks.ts
+++ b/apps/backend/src/infrastructure/eventRouter/tasks.ts
@@ -69,6 +69,11 @@ export const TaskSchema = z.discriminatedUnion('id', [
       cid: z.string(),
     }),
   }),
+  z.object({
+    id: z.literal('reconcile-archival'),
+    retriesLeft: z.number().default(MAX_RETRIES),
+    params: z.object({}),
+  }),
 ])
 
 export type MigrateUploadTask = z.infer<typeof TaskSchema>
@@ -129,6 +134,10 @@ type TaskCreateParams =
         cid: string
       }
     }
+  | {
+      id: 'reconcile-archival'
+      params: Record<string, never>
+    }
 
 export const createTask = (task: TaskCreateParams): Task => {
   switch (task.id) {
@@ -181,6 +190,12 @@ export const createTask = (task: TaskCreateParams): Task => {
         retriesLeft: MAX_RETRIES,
       }
     case 'populate-cache':
+      return {
+        id: task.id,
+        params: task.params,
+        retriesLeft: MAX_RETRIES,
+      }
+    case 'reconcile-archival':
       return {
         id: task.id,
         params: task.params,

--- a/apps/backend/src/infrastructure/repositories/objects/nodes.ts
+++ b/apps/backend/src/infrastructure/repositories/objects/nodes.ts
@@ -238,6 +238,42 @@ const getLastArchivedPieceNode = async () => {
     .then((e) => e.rows.at(0))
 }
 
+const getUnreconciledNodes = async (limit: number) => {
+  const db = await getDatabase()
+
+  return db
+    .query<Pick<Node, 'cid' | 'head_cid'>>({
+      text: `
+        SELECT n.cid, n.head_cid
+        FROM nodes n
+        JOIN metadata m ON n.head_cid = m.head_cid
+        WHERE n.block_published_on IS NOT NULL
+          AND n.piece_index IS NULL
+          AND n.piece_offset IS NULL
+        ORDER BY m.created_at DESC
+        LIMIT $1
+      `,
+      values: [limit],
+    })
+    .then((e) => e.rows)
+}
+
+const getUnreconciledNodesCount = async () => {
+  const db = await getDatabase()
+
+  return db
+    .query<{ count: string }>({
+      text: `
+        SELECT COUNT(*) as count
+        FROM nodes
+        WHERE block_published_on IS NOT NULL
+          AND piece_index IS NULL
+          AND piece_offset IS NULL
+      `,
+    })
+    .then((e) => Number(e.rows[0].count))
+}
+
 const getNodesCountWithoutDataByRootCid = async (rootCid: string) => {
   const db = await getDatabase()
   return db.query<{ count: number }>({
@@ -372,4 +408,6 @@ export const nodesRepository = {
   updateNodeBlockchainData,
   updateNodesBlockchainDataBatch,
   hasEncodedNode,
+  getUnreconciledNodes,
+  getUnreconciledNodesCount,
 }

--- a/apps/backend/src/infrastructure/repositories/objects/nodes.ts
+++ b/apps/backend/src/infrastructure/repositories/objects/nodes.ts
@@ -265,10 +265,11 @@ const getUnreconciledNodesCount = async () => {
     .query<{ count: string }>({
       text: `
         SELECT COUNT(*) as count
-        FROM nodes
-        WHERE block_published_on IS NOT NULL
-          AND piece_index IS NULL
-          AND piece_offset IS NULL
+        FROM nodes n
+        JOIN metadata m ON n.head_cid = m.head_cid
+        WHERE n.block_published_on IS NOT NULL
+          AND n.piece_index IS NULL
+          AND n.piece_offset IS NULL
       `,
     })
     .then((e) => Number(e.rows[0].count))

--- a/apps/backend/src/infrastructure/repositories/objects/nodes.ts
+++ b/apps/backend/src/infrastructure/repositories/objects/nodes.ts
@@ -388,6 +388,31 @@ const hasEncodedNode = async (cid: string) => {
     .then((e) => e.rows[0].exists)
 }
 
+/**
+ * Given a set of head_cids, returns those where ALL nodes have
+ * piece_index set (i.e. fully archived). Single query instead of N+1.
+ */
+const getFullyArchivedHeadCids = async (
+  headCids: string[],
+): Promise<string[]> => {
+  if (headCids.length === 0) return []
+
+  const db = await getDatabase()
+
+  return db
+    .query<{ head_cid: string }>({
+      text: `
+        SELECT head_cid
+        FROM nodes
+        WHERE head_cid = ANY($1)
+        GROUP BY head_cid
+        HAVING COUNT(*) = COUNT(piece_index)
+      `,
+      values: [headCids],
+    })
+    .then((e) => e.rows.map((r) => r.head_cid))
+}
+
 export const nodesRepository = {
   getNode,
   getNodeCount,
@@ -411,4 +436,5 @@ export const nodesRepository = {
   hasEncodedNode,
   getUnreconciledNodes,
   getUnreconciledNodesCount,
+  getFullyArchivedHeadCids,
 }

--- a/apps/backend/src/infrastructure/services/dsn/objectMappingIndexerClient/index.ts
+++ b/apps/backend/src/infrastructure/services/dsn/objectMappingIndexerClient/index.ts
@@ -1,0 +1,73 @@
+import { ObjectMappingIndexerRPCApi } from '@auto-files/rpc-apis'
+import { config } from '../../../../config.js'
+import { createLogger } from '../../../drivers/logger.js'
+
+const logger = createLogger('dsn:objectMappingIndexerClient')
+
+const getHttpUrl = (url: string) => {
+  if (url.startsWith('http://') || url.startsWith('https://')) {
+    return url
+  }
+  return url.replace(/^ws(s)?:\/\//, 'http$1://')
+}
+
+const httpClient = ObjectMappingIndexerRPCApi.createHttpClient(
+  getHttpUrl(config.objectMappingArchiver.url),
+)
+
+// If more than this many consecutive individual lookups fail,
+// assume the indexer is down and stop wasting round-trips.
+const MAX_CONSECUTIVE_FAILURES = 10
+
+/**
+ * Batch-queries the indexer for object mappings by hash.
+ *
+ * The indexer's get_object_mappings throws if ANY hash in the batch is missing.
+ * When that happens, we fall back to querying hashes individually so we can
+ * still resolve the ones the indexer does have. A circuit breaker aborts if
+ * the indexer appears to be unreachable.
+ */
+const getObjectMappings = async (
+  hashes: string[],
+): Promise<Array<[string, number, number]>> => {
+  try {
+    return await httpClient.get_object_mappings({ hashes })
+  } catch {
+    // Batch failed — likely some hashes missing from indexer.
+    // Fall back to individual queries to salvage what we can.
+    logger.debug(
+      'Batch lookup failed for %d hashes, falling back to individual queries',
+      hashes.length,
+    )
+    const results: Array<[string, number, number]> = []
+    let consecutiveFailures = 0
+
+    for (const hash of hashes) {
+      try {
+        const [mapping] = await httpClient.get_object_mappings({
+          hashes: [hash],
+        })
+        if (mapping) {
+          results.push(mapping)
+        }
+        consecutiveFailures = 0
+      } catch {
+        consecutiveFailures++
+        if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+          logger.warn(
+            'Aborting individual lookups after %d consecutive failures (%d/%d resolved so far)',
+            MAX_CONSECUTIVE_FAILURES,
+            results.length,
+            hashes.length,
+          )
+          break
+        }
+      }
+    }
+    return results
+  }
+}
+
+export const objectMappingIndexerClient = {
+  getObjectMappings,
+}

--- a/apps/backend/src/infrastructure/services/dsn/objectMappingIndexerClient/index.ts
+++ b/apps/backend/src/infrastructure/services/dsn/objectMappingIndexerClient/index.ts
@@ -51,14 +51,15 @@ const getObjectMappings = async (
           results.push(mapping)
         }
         consecutiveFailures = 0
-      } catch {
+      } catch (error) {
         consecutiveFailures++
         if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
           logger.warn(
-            'Aborting individual lookups after %d consecutive failures (%d/%d resolved so far)',
+            'Aborting individual lookups after %d consecutive failures (%d/%d resolved so far). Last error: %s',
             MAX_CONSECUTIVE_FAILURES,
             results.length,
             hashes.length,
+            error instanceof Error ? error.message : String(error),
           )
           break
         }

--- a/apps/backend/src/infrastructure/services/reconciliationJob.ts
+++ b/apps/backend/src/infrastructure/services/reconciliationJob.ts
@@ -1,0 +1,47 @@
+import { config } from '../../config.js'
+import { createLogger } from '../drivers/logger.js'
+import { EventRouter } from '../eventRouter/index.js'
+import { createTask } from '../eventRouter/tasks.js'
+import { safeCallback } from '../../shared/utils/safe.js'
+
+const logger = createLogger('ReconciliationJob')
+
+let reconciliationInterval: NodeJS.Timeout | null = null
+
+const enqueueReconciliation = () => {
+  logger.debug('Enqueuing reconcile-archival task')
+  EventRouter.publish(
+    createTask({ id: 'reconcile-archival', params: {} }),
+  )
+}
+
+const start = (): void => {
+  logger.info('Starting reconciliation job', {
+    intervalMs: config.reconciliation.intervalMs,
+  })
+
+  // Enqueue immediately on start to drain any existing backlog
+  enqueueReconciliation()
+
+  // Then periodically enqueue as a safety net for future disconnections.
+  // If the backlog is empty, processReconciliation returns quickly.
+  // If there's a backlog, it self-reschedules via RabbitMQ for fast
+  // draining; this interval just ensures the loop restarts if it stops.
+  reconciliationInterval = setInterval(
+    safeCallback(enqueueReconciliation),
+    config.reconciliation.intervalMs,
+  )
+}
+
+const stop = (): void => {
+  logger.info('Stopping reconciliation job')
+  if (reconciliationInterval) {
+    clearInterval(reconciliationInterval)
+    reconciliationInterval = null
+  }
+}
+
+export const reconciliationJob = {
+  start,
+  stop,
+}


### PR DESCRIPTION
Objects with all nodes published on-chain but missing piece_index/piece_offset from the indexer remain permanently stuck in 'Archiving' status (~14K nodes, ~9K objects on mainnet). The root cause is the object-mapping-indexer missing chain events during WebSocket disconnections, with no backfill mechanism.

This adds a backend-side reconciliation system that:

- Periodically queries nodes stuck in archiving (published but no piece data)
- Batch-resolves their blake3 hashes against the indexer HTTP API
- Applies archival data and triggers object status checks
- Prioritizes newest objects first (ORDER BY metadata.created_at DESC)
- Processes in batches of 500, self-rescheduling via RabbitMQ when backlog exists, with a periodic 5-min interval as safety net

New files:
- core/objects/reconciliation.ts — core reconciliation logic
- services/dsn/objectMappingIndexerClient/index.ts — indexer HTTP client with batch fallback and circuit breaker
- services/reconciliationJob.ts — setInterval service (creditExpiryJob pattern)

Modified files:
- repositories/objects/nodes.ts — getUnreconciledNodes(), getUnreconciledNodesCount()
- eventRouter/tasks.ts — reconcile-archival task type
- eventRouter/processors/frontend.ts — task handler
- config.ts — reconciliation.intervalMs (RECONCILIATION_INTERVAL_MS env var)
- servers/frontendWorker.ts — job startup and shutdown

Addresses https://github.com/autonomys/auto-drive/issues/674