### PR TITLE
feat(s3): return 403 Forbidden for DeleteObject requests

### DIFF
--- a/apps/backend/__tests__/integration/s3-sdk/index.spec.ts
+++ b/apps/backend/__tests__/integration/s3-sdk/index.spec.ts
@@ -2,6 +2,7 @@ import { dbMigration } from '../../utils/dbMigrate.js'
 import {
   CompleteMultipartUploadCommand,
   CreateMultipartUploadCommand,
+  DeleteObjectCommand,
   GetObjectCommand,
   HeadObjectCommand,
   PutObjectCommand,
@@ -170,6 +171,20 @@ describe('AWS S3 - SDK', () => {
     expect(Buffer.from(await result.Body!.transformToByteArray())).toEqual(
       SecondBody,
     )
+  })
+
+  describe('DeleteObject', () => {
+    it('should return 403 AccessDenied - storage is immutable', async () => {
+      const command = new DeleteObjectCommand({
+        Bucket,
+        Key,
+      })
+
+      await expect(s3Client.send(command)).rejects.toMatchObject({
+        $metadata: { httpStatusCode: 403 },
+        Code: 'AccessDenied',
+      })
+    })
   })
 
   describe('Metadata handled correctly', () => {

--- a/apps/backend/src/app/controllers/s3/http.ts
+++ b/apps/backend/src/app/controllers/s3/http.ts
@@ -5,6 +5,7 @@ import { createLogger } from '../../../infrastructure/drivers/logger.js'
 import {
   completeMultipartUploadHandler,
   createMultipartUploadHandler,
+  deleteObjectHandler,
   getObjectHandler,
   headObjectHandler,
   putObjectHandler,
@@ -26,6 +27,7 @@ const S3HandlerConfig: S3HandlerConfig = {
   CreateMultipartUpload: createMultipartUploadHandler,
   UploadPart: uploadPartHandler,
   CompleteMultipartUpload: completeMultipartUploadHandler,
+  DeleteObject: deleteObjectHandler,
 }
 
 const getS3Method = (req: Request) => {
@@ -42,6 +44,9 @@ const getS3Method = (req: Request) => {
     }
     if (req.method === 'HEAD') {
       return 'HeadObject'
+    }
+    if (req.method === 'DELETE') {
+      return 'DeleteObject'
     }
   }
   return s3Method

--- a/apps/backend/src/app/controllers/s3/s3.ts
+++ b/apps/backend/src/app/controllers/s3/s3.ts
@@ -194,6 +194,14 @@ export const completeMultipartUploadHandler = async (
   sendXML(res, 'CompleteMultipartUploadResult', downloadResult.value)
 }
 
+export const deleteObjectHandler = async (_req: Request, res: Response) => {
+  sendXML(res.status(403), 'Error', {
+    Code: 'AccessDenied',
+    Message:
+      'Auto Drive storage is immutable. Objects cannot be deleted from the Autonomys DSN.',
+  })
+}
+
 export const putObjectHandler = async (req: Request, res: Response) => {
   const user = await handleS3Auth(req, res)
   if (!user) return


### PR DESCRIPTION
## Summary

Auto Drive storage is immutable - objects on the Autonomys DSN cannot be deleted. Previously, DELETE requests fell through `getS3Method()` returning `undefined`, hit the generic `if (!handler)` branch, and returned a JSON 500 "Method not found" error. S3 clients including rclone expect XML-format errors, and the message gave no indication of why the operation was rejected.

This change adds an explicit `DeleteObject` handler that returns **403 Forbidden** with a standard S3 XML error body:

```xml
<Error>
  <Code>AccessDenied</Code>
  <Message>Auto Drive storage is immutable. Objects cannot be deleted from the Autonomys DSN.</Message>
</Error>
```

## Changes

- `apps/backend/src/app/controllers/s3/s3.ts` - add `deleteObjectHandler`
- `apps/backend/src/app/controllers/s3/http.ts` - wire `DeleteObject` into `S3HandlerConfig` and `getS3Method` detection

## What rclone users will see

Before:
```
ERROR : file.txt: Couldn't delete: 500 Internal Server Error
```

After:
```
ERROR : file.txt: Couldn't delete: 403 Forbidden: Auto Drive storage is immutable. Objects cannot be deleted from the Autonomys DSN.
```

Closes #679
Part of milestone: [rclone S3 Compatibility](https://github.com/autonomys/auto-drive/milestone/4)