### PR TITLE
fix: password input invisible (white-on-white) in upload encryption dialog

### DIFF
--- a/apps/frontend/src/components/molecules/ObjectDownloadModal.tsx
+++ b/apps/frontend/src/components/molecules/ObjectDownloadModal.tsx
@@ -275,7 +275,7 @@ export const ObjectDownloadModal = ({
                 id='password'
                 value={password ?? ''}
                 onChange={(e) => setPassword(e.target.value)}
-                className='block w-full rounded-md border border-gray-300 p-2 shadow-sm'
+                className='block w-full rounded-md border border-gray-300 bg-background p-2 text-foreground shadow-sm'
                 placeholder='Password'
               />
               <Button

--- a/apps/frontend/src/components/molecules/UploadingFileModal.tsx
+++ b/apps/frontend/src/components/molecules/UploadingFileModal.tsx
@@ -339,7 +339,7 @@ export const UploadingFileModal = ({
                     id='password'
                     value={password}
                     onChange={(e) => setPassword(e.target.value)}
-                    className='mt-1 block w-full rounded-md border border-gray-300 p-2 shadow-sm'
+                    className='mt-1 block w-full rounded-md border border-gray-300 bg-background p-2 text-foreground shadow-sm'
                     placeholder='Password'
                   />
                   <div className='flex justify-center gap-2'>

--- a/apps/frontend/src/components/molecules/UploadingFolderModal.tsx
+++ b/apps/frontend/src/components/molecules/UploadingFolderModal.tsx
@@ -215,7 +215,7 @@ export const UploadingFolderModal = ({
                     id='password'
                     value={password}
                     onChange={(e) => setPassword(e.target.value)}
-                    className='mt-1 block w-full rounded-md border border-background-hover p-2 shadow-sm'
+                    className='mt-1 block w-full rounded-md border border-background-hover bg-background p-2 text-foreground shadow-sm'
                     placeholder='Password'
                   />
                   <div className='flex justify-center gap-2'>


### PR DESCRIPTION
## Summary

- Add `bg-background` and `text-foreground` to the password `<input>` in `UploadingFileModal`, `UploadingFolderModal`, and `ObjectDownloadModal`
- Follows the pattern already used in `DefaultPasswordModal/index.tsx`
- No logic changes — CSS tokens only

Fixes #685

## Root cause

The upload and download modals were missing explicit background/text color tokens on the password field. The browser supplies a white background by default, while the dark theme applies white text globally, making typed characters invisible.

## Test plan

- [ ] Upload a file, type in the encryption password dialog — characters should be visible
- [ ] Upload a folder, type in the encryption password dialog — characters should be visible
- [ ] Download an encrypted file, type in the decryption password dialog — characters should be visible
- [ ] Verify light mode still looks correct
- [ ] Verify `DefaultPasswordModal` (Profile page) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)