### PR TITLE
fix: include auto-design-system in Tailwind content scanning

### DIFF
--- a/apps/frontend/tailwind.config.ts
+++ b/apps/frontend/tailwind.config.ts
@@ -5,6 +5,7 @@ const config: Config = {
   content: [
     './src/**/*.{js,ts,jsx,tsx,mdx}',
     '../../packages/ui/src/**/*.{js,ts,jsx,tsx}',
+    '../../node_modules/@autonomys/auto-design-system/dist/**/*.{js,mjs}',
   ],
   darkMode: 'class',
   theme: {


### PR DESCRIPTION
## Summary
- File previews (especially code files like `.js`, `.ts`, etc.) were rendering as unreadable dark text on a dark background in light mode
- Root cause: The `@autonomys/auto-design-system` package's `TextViewer` component uses Tailwind classes like `text-gray-100` (light text for code on dark editor background), but these classes were never generated because the package wasn't included in the Tailwind `content` config
- Fix: Add `../../node_modules/@autonomys/auto-design-system/dist/**/*.{js,mjs}` to the Tailwind content scanning paths so all utility classes used by the design system are generated

## Test plan
- [x] Open a code file preview (e.g. [this app.js](https://explorer.ai3.storage/mainnet/drive/metadata/bafkr6idh7pnzsitzyeqt7aatggf3pl3j6gfnmrthy4b7qjyt2uargnas6u)) in light mode and verify text is readable (light text on dark code-editor background)
- [x] Verify the preview is also readable in dark mode
- [x] Verify other preview types (images, PDF, plain text) still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)