### PR TITLE
fix: preserve pagination state on back navigation from metadata page

### DIFF
--- a/apps/frontend/src/components/organisms/FileTable/state.tsx
+++ b/apps/frontend/src/components/organisms/FileTable/state.tsx
@@ -116,7 +116,6 @@ export const useFileTableState = create<FileTableStore>()((set, get) => {
         fetcher: null,
         isInitialized: false,
       });
-      resetParams();
     },
     initFromUrl: () => {
       if (get().isInitialized) return;


### PR DESCRIPTION
## Summary
- Fixes the back button (both browser and UI) forgetting page/limit query parameters when navigating back from a metadata detail page to a file listing page
- Root cause: `resetState()` called `resetParams()` which stripped URL query params via `history.replaceState` **before** `initFromUrl()` could read them on the subsequent mount
- The one-line fix removes the `resetParams()` call from `resetState()` — URL params are naturally absent on forward navigation (new pages) and naturally present on back navigation (browser history restore), so `initFromUrl()` correctly handles both cases

## Test plan
- [x] Navigate to `/drive/global`, change page to 2 and limit to 50
- [x] Click a file to go to `/drive/metadata/{cid}`
- [x] Click the back button (both browser back and UI back button) — verify page=2 and limit=50 are preserved
- [x] Navigate between different file listing pages (global → my files via sidebar) — verify pagination resets to defaults as expected
- [x] Change sort order, navigate to metadata, go back — verify sort is preserved

Closes #692

🤖 Generated with [Claude Code](https://claude.com/claude-code)