### PR TITLE
Fix/reconciliation transport and circuit breaker

### DIFF
--- a/apps/backend/.env.sample
+++ b/apps/backend/.env.sample
@@ -1,5 +1,5 @@
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres
-OBJECT_MAPPING_ARCHIVER_URL=wss://indexer.mainnet.autonomys.xyz/ # update to your if you want
+OBJECT_MAPPING_ARCHIVER_URL=wss://indexer.mainnet.autonomys.xyz/ws # update to your own; /ws path is required for HTTP RPC transport
 FILES_GATEWAY_URL=http://changeme.com # change to your own (or it'll fail when fetching archived files)
 FILES_GATEWAY_TOKEN=changeme # change to your own (or it'll fail when fetching archived files)
 AUTH_SERVICE_API_KEY=1234567890 # change to your own if updated in auth

--- a/apps/backend/src/core/objects/reconciliation.ts
+++ b/apps/backend/src/core/objects/reconciliation.ts
@@ -13,8 +13,8 @@ const logger = createLogger('useCases:objects:reconciliation')
 
 const BATCH_SIZE = 500
 
-// Track consecutive zero-progress runs to detect permanently unresolvable
-// nodes (the indexer also missed them and can't provide their data).
+// Track consecutive zero-progress runs to detect potential connectivity
+// issues with the indexer or genuinely unresolvable nodes.
 let consecutiveZeroProgressRuns = 0
 const ZERO_PROGRESS_WARN_THRESHOLD = 3
 
@@ -165,9 +165,9 @@ const runReconciliationBatch = async (): Promise<void> => {
     consecutiveZeroProgressRuns++
     if (consecutiveZeroProgressRuns >= ZERO_PROGRESS_WARN_THRESHOLD) {
       logger.error(
-        'Reconciliation made no progress for %d consecutive runs. ' +
-          '%d unreconciled nodes may be permanently unresolvable ' +
-          '(indexer also missing their data). Consider indexer-side backfill.',
+        'Reconciliation made no progress for %d consecutive runs (%d unreconciled nodes). ' +
+          'Possible causes: indexer connectivity issue, transport misconfiguration, ' +
+          'or hashes genuinely missing from the indexer DB.',
         consecutiveZeroProgressRuns,
         unreconciledNodes.length,
       )

--- a/apps/backend/src/infrastructure/services/dsn/objectMappingIndexerClient/index.ts
+++ b/apps/backend/src/infrastructure/services/dsn/objectMappingIndexerClient/index.ts
@@ -5,10 +5,14 @@ import { createLogger } from '../../../drivers/logger.js'
 const logger = createLogger('dsn:objectMappingIndexerClient')
 
 const getHttpUrl = (url: string) => {
-  if (url.startsWith('http://') || url.startsWith('https://')) {
-    return url
-  }
-  return url.replace(/^ws(s)?:\/\//, 'http$1://')
+  const httpUrl =
+    url.startsWith('http://') || url.startsWith('https://')
+      ? url
+      : url.replace(/^ws(s)?:\/\//, 'http$1://')
+  // The RPC server only accepts POST on the /ws path.
+  // Ensure the URL ends with /ws regardless of input format.
+  const normalized = httpUrl.replace(/\/+$/, '')
+  return normalized.endsWith('/ws') ? normalized : normalized + '/ws'
 }
 
 const httpClient = ObjectMappingIndexerRPCApi.createHttpClient(
@@ -52,7 +56,17 @@ const getObjectMappings = async (
         }
         consecutiveFailures = 0
       } catch (error) {
-        consecutiveFailures++
+        // "Object mapping not found" is an expected miss — the indexer
+        // simply doesn't have this hash. Only count genuine transport
+        // or server errors toward the circuit breaker.
+        const isNotFound =
+          error instanceof Error &&
+          error.message.includes('Object mapping not found')
+        if (isNotFound) {
+          consecutiveFailures = 0
+        } else {
+          consecutiveFailures++
+        }
         if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
           logger.warn(
             'Aborting individual lookups after %d consecutive failures (%d/%d resolved so far). Last error: %s',


### PR DESCRIPTION
## fix: reconciliation transport URL and circuit breaker (#700)

The reconciliation job (from #677) has never resolved any nodes in production — 275+ consecutive runs with 0 results. Two bugs in `objectMappingIndexerClient`, plus misleading diagnostics.

### Bug 1: HTTP POST sent to wrong path

`createHttpClient` sends `POST ${baseUrl}`, but the RPC server only accepts POST on `/ws`. The URL conversion (`wss://` → `https://`) didn't append `/ws`, so every request hit Express's 404.

Verified: `POST https://indexer.mainnet.autonomys.xyz/` → `Cannot POST /`
Verified: `POST https://indexer.mainnet.autonomys.xyz/ws` → returns mapping data

The indexer DB has complete data for all ~15K stuck nodes (confirmed via direct SQL and WebSocket RPC). Nothing was lost — the reconciliation just couldn't reach the data.

### Bug 2: Circuit breaker trips on expected misses

The indexer's `getObjectMappings` throws `'Object mapping not found'` for missing hashes. The fallback's circuit breaker counted these as failures, aborting after 10 consecutive misses. With the transport fix alone, any batch containing a missing hash would still fail.

### Changes

**`objectMappingIndexerClient/index.ts`**
- `getHttpUrl`: normalize URL to always end with `/ws`, handling trailing slashes and all input formats (`wss://`, `http://`, with or without `/ws`)
- Circuit breaker: don't count `'Object mapping not found'` RPC errors as transport failures

**`reconciliation.ts`**
- Fix misleading error message that claimed "indexer also missing their data" — the indexer has all the data, the transport was broken

**`.env.sample`**
- Update sample URL to include `/ws` path and remove trailing slash that would produce `//ws`

### Note

The production env var (`OBJECT_MAPPING_ARCHIVER_URL`) has already been updated to include `/ws`, which unblocked the reconciliation immediately. This code change is a defensive hardening so the transport works regardless of how the URL is configured — with or without `/ws`, with or without trailing slashes, using `wss://` or `http://`.

### Expected result

All ~15K stuck nodes resolve on the next reconciliation cycle (already in progress via the env var fix). This PR prevents the issue from recurring if the env var is ever changed back or set up without `/ws`.

Closes #700