### PR TITLE
fix: Decrypt File button invisible in light theme

### DIFF
--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -20,7 +20,7 @@ All colors MUST be HSL.
     --auto-drive-primary: 234 50% 48%;
     --auto-drive-primary-foreground: 0 0% 100%;
     --auto-drive-secondary: 243 75% 59%;
-    --auto-drive-accent: 264 83% 70%;
+    --auto-drive-accent: 234 50% 48%;
 
     /* Background gradients */
     --gradient-main: linear-gradient(

--- a/apps/frontend/src/components/molecules/FilePreview/index.tsx
+++ b/apps/frontend/src/components/molecules/FilePreview/index.tsx
@@ -176,6 +176,7 @@ export const FilePreview = ({ metadata }: { metadata: OffchainMetadata }) => {
       loading={loading}
       file={file}
       error={error}
+      isAutoDrive
       decryptionError={decryptionError}
       isFilePreview={isFilePreview}
       textContent={textContent}

--- a/apps/frontend/src/components/organisms/ObjectDetails/ObjectDetailsActions.tsx
+++ b/apps/frontend/src/components/organisms/ObjectDetails/ObjectDetailsActions.tsx
@@ -108,7 +108,7 @@ export const ObjectDetailsActions = ({
       </Button>
       {isCached === false && (
         <Button
-          variant='lightAccent'
+          variant='primary'
           className={cn(
             'inline-flex items-center text-sm',
             (object.tags.includes(ObjectTag.Banned) || isBringingToCache) &&

--- a/apps/frontend/tailwind.config.ts
+++ b/apps/frontend/tailwind.config.ts
@@ -78,6 +78,10 @@ const config: Config = {
           secondary: 'hsl(var(--auto-drive-secondary))',
           accent: 'hsl(var(--auto-drive-accent))',
         },
+        'auto-explorer': {
+          buttonLightFrom: 'hsl(var(--auto-drive-primary))',
+          buttonDarkFrom: 'hsl(var(--auto-drive-primary))',
+        },
         success: {
           DEFAULT: 'hsl(var(--success))',
           foreground: 'hsl(var(--success-foreground))',


### PR DESCRIPTION
## Summary
- The "Decrypt File" button in the encrypted file preview was invisible in light theme (white text on transparent background) — fixed by passing `isAutoDrive` prop to `AutoFilePreview`
- Changed `--auto-drive-accent` CSS variable from purple to blue to match the primary theme color
- The decryption password modal's "Confirm" button was also invisible — the design system uses `auto-explorer-buttonLightFrom`/`buttonDarkFrom` classes which had no color defined in the Tailwind config. Added mappings to the primary blue.
- Changed the "Bring to Cache" button from `lightAccent` to `primary` variant for visual consistency with the Download button

## Test plan
- [x] View an encrypted file in light theme — verify the "Decrypt File" button is visible and blue
- [x] Click "Decrypt File" and verify the password modal's "Confirm" button is visible and blue
- [x] Verify both buttons look correct in dark theme
- [x] Verify the "Bring to Cache" button matches the "Download" button style
- [x] Verify no other UI elements are affected by the color changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)