### PR TITLE
fix(s3): add /s3 location block to public nginx config

### DIFF
--- a/nginx/backend.mainnet.public.conf
+++ b/nginx/backend.mainnet.public.conf
@@ -58,6 +58,39 @@ server {
 	    rewrite /api/(.*) /$1  break;
     }
 
+    location /s3 {
+        limit_req zone=mylimit burst=200 nodelay;
+        limit_conn addr 5;
+        limit_req_log_level warn;
+
+        proxy_request_buffering off;
+        proxy_buffering off;
+        proxy_pass http://127.0.0.1:3000;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_http_version 1.1;
+
+        proxy_read_timeout 600;
+        proxy_send_timeout 600;
+
+        add_header 'Access-Control-Allow-Origin' '*' always;
+        add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, HEAD, OPTIONS' always;
+        add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,Content-MD5,x-amz-content-sha256,x-amz-date,x-amz-security-token,x-amz-user-agent,x-amz-decoded-content-length,x-amz-checksum-crc64nvme,x-amz-trailer' always;
+        add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range,ETag,x-amz-meta-cid,x-amz-request-id,x-amz-id-2' always;
+        add_header 'Access-Control-Max-Age' '3600' always;
+
+        if ($request_method = 'OPTIONS') {
+            add_header 'Access-Control-Allow-Origin' '*' always;
+            add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, HEAD, OPTIONS' always;
+            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,Content-MD5,x-amz-content-sha256,x-amz-date,x-amz-security-token,x-amz-user-agent,x-amz-decoded-content-length,x-amz-checksum-crc64nvme,x-amz-trailer' always;
+            add_header 'Access-Control-Max-Age' 1728000 always;
+            add_header 'Content-Type' 'text/plain charset=UTF-8' always;
+            add_header 'Content-Length' 0 always;
+            return 204;
+        }
+    }
+
     location /file {
         # Apply rate limiting
         limit_req zone=mylimit burst=200 nodelay;


### PR DESCRIPTION
## Summary

- The S3 controller has been mounted at `/s3` on the download API since PR #446 (Aug 2025), but **no nginx location block was ever added** to route external `/s3` requests to Express on any host.
- The download API runs on `auto-drive-mainnet-public` at port 3000. This PR adds the missing `/s3` block to `backend.mainnet.public.conf`, proxying to `127.0.0.1:3000` — the same upstream used by `/file` and `/folder`.
- Includes `proxy_request_buffering off` and 600s timeouts for streaming large multipart uploads, plus S3-appropriate CORS headers (PUT/DELETE/HEAD + AWS SDK headers like `x-amz-content-sha256`, `Content-MD5`, etc.).

**No existing routing is affected** — this is a pure insertion of a new location block.

## Post deploy tests

- [ ] `sudo nginx -t` passes on the public box after copying the config
- [ ] `curl -I https://public.auto-drive.autonomys.xyz/s3/test` returns 401 (Express auth rejection, not nginx 404)