### PR TITLE
fix(backend): prevent negative underflow in stuck-publishing stalenes…

### DIFF
--- a/apps/backend/src/infrastructure/repositories/objects/nodes.ts
+++ b/apps/backend/src/infrastructure/repositories/objects/nodes.ts
@@ -436,9 +436,9 @@ const getStuckPublishingRootCids = async (
         GROUP BY root_cid
         HAVING COUNT(block_published_on) > 0
            AND COUNT(block_published_on) < COUNT(*)
-           AND MAX(block_published_on) < (
+           AND MAX(block_published_on) + $2 < (
              SELECT MAX(block_published_on) FROM nodes
-           ) - $2
+           )
         LIMIT $1
       `,
       values: [limit, stalenessThresholdBlocks],


### PR DESCRIPTION
…s check

Move the staleness threshold to the left side of the comparison so the query works correctly when the global max block height is below the configured threshold (default 1000). Previously the right-hand side could go negative, causing the recovery job to silently find zero stuck objects.