### PR TITLE
fix(s3): advance ListObjectsV2 continuation token past folded prefix

### DIFF
--- a/apps/backend/__tests__/unit/core/s3.spec.ts
+++ b/apps/backend/__tests__/unit/core/s3.spec.ts
@@ -369,4 +369,127 @@ describe('S3UseCases', () => {
       )
     })
   })
+
+  describe('listObjects', () => {
+    // dbLimit for delimiter listings is min(maxKeys * 10 + 100, 10_000), so
+    // maxKeys=2 yields dbLimit=120 — small enough to construct test data for.
+    const DELIMITER_DB_LIMIT = (maxKeys: number) =>
+      Math.min(maxKeys * 10 + 100, 10_000)
+
+    const makeListing = (key: string) => ({
+      key,
+      cid: 'cid',
+      size: 0n,
+      lastModified: new Date(0),
+    })
+
+    it('advances continuation token past a folded CommonPrefix when the DB batch is exhausted inside one prefix group', async () => {
+      // Regression test for Cursor Bugbot finding on PR #696 / #709.
+      //
+      // Scenario: maxKeys=2, delimiter='/', and a single virtual directory
+      // ('big/') contains more keys than fit in one DB batch.  Every fetched
+      // row folds into the same CommonPrefix, so the in-loop maxKeys cap is
+      // never hit and the loop exhausts the batch with isTruncated=false.
+      // The fallback branch must then set the continuation token to a value
+      // that sorts *after* every key in 'big/' — otherwise the next page
+      // re-scans the rest of that directory and emits 'big/' again.
+      const maxKeys = 2
+      const dbLimit = DELIMITER_DB_LIMIT(maxKeys)
+
+      // Fill the entire DB batch with keys that all fold into 'big/'.
+      const fullBatch = Array.from({ length: dbLimit }, (_, i) =>
+        makeListing(`big/${String(i).padStart(6, '0')}`),
+      )
+
+      jest
+        .spyOn(s3ObjectMappingsRepository, 'listObjects')
+        .mockResolvedValue(fullBatch as any)
+
+      const result = await S3UseCases.listObjects({
+        bucket: 'my-bucket',
+        prefix: '',
+        delimiter: '/',
+        maxKeys,
+        continuationToken: null,
+      })
+
+      expect(result.commonPrefixes).toEqual(['big/'])
+      expect(result.objects).toEqual([])
+      expect(result.isTruncated).toBe(true)
+      // Token must start with the folded prefix and sort strictly after every
+      // key inside it.  `￿` (U+FFFF) is the sentinel chosen for this purpose.
+      expect(result.nextContinuationToken).toBe('big/￿')
+      // Sanity: the token sorts after the last key we returned in the batch.
+      expect(
+        result.nextContinuationToken! > fullBatch[fullBatch.length - 1].key,
+      ).toBe(true)
+    })
+
+    it('uses the raw last key as the token when the last scanned key did not fold into a prefix', async () => {
+      // If the DB batch is full but the last key has no delimiter occurrence
+      // after the prefix, there's no CommonPrefix to skip past — fall back to
+      // the raw last key, which is the safe pre-fix behaviour.
+      const maxKeys = 2
+      const dbLimit = DELIMITER_DB_LIMIT(maxKeys)
+
+      // Pad the batch with folded entries, but make the LAST one a top-level
+      // key with no delimiter after the prefix.
+      const batch = [
+        ...Array.from({ length: dbLimit - 1 }, (_, i) =>
+          makeListing(`folder/${String(i).padStart(6, '0')}`),
+        ),
+        makeListing('zzz-top-level'),
+      ]
+
+      jest
+        .spyOn(s3ObjectMappingsRepository, 'listObjects')
+        .mockResolvedValue(batch as any)
+
+      const result = await S3UseCases.listObjects({
+        bucket: 'my-bucket',
+        prefix: '',
+        delimiter: '/',
+        maxKeys,
+        continuationToken: null,
+      })
+
+      expect(result.isTruncated).toBe(true)
+      // The last key doesn't fold into a CommonPrefix, so the token stays as
+      // the raw key — no sentinel needed.
+      expect(result.nextContinuationToken).toBe('zzz-top-level')
+    })
+
+    it('uses the raw last key as the token when no delimiter is set', async () => {
+      // Without a delimiter, the dbLimit is maxKeys + 1, and there are no
+      // CommonPrefixes to repeat — the safe fallback is just the last key.
+      const maxKeys = 2
+      const dbLimit = maxKeys + 1 // = 3
+
+      const batch = [
+        makeListing('a.txt'),
+        makeListing('b.txt'),
+        makeListing('c.txt'),
+      ]
+
+      jest
+        .spyOn(s3ObjectMappingsRepository, 'listObjects')
+        .mockResolvedValue(batch as any)
+
+      const result = await S3UseCases.listObjects({
+        bucket: 'my-bucket',
+        prefix: '',
+        delimiter: null,
+        maxKeys,
+        continuationToken: null,
+      })
+
+      // maxKeys=2 ⇒ first two keys returned, third triggers truncation in
+      // buildListResult (not the fallback), token = key just returned.
+      expect(result.objects.map((o) => o.key)).toEqual(['a.txt', 'b.txt'])
+      expect(result.isTruncated).toBe(true)
+      expect(result.nextContinuationToken).toBe('b.txt')
+      // dbLimit branch shouldn't have triggered, so no sentinel appended.
+      expect(batch.length).toBe(dbLimit)
+    })
+  })
 })

--- a/apps/backend/src/core/s3/index.ts
+++ b/apps/backend/src/core/s3/index.ts
@@ -197,7 +197,31 @@ const listObjects = async (
   // harmless, but silently dropping data is not.
   if (!isTruncated && allMatching.length === dbLimit) {
     isTruncated = true
-    nextContinuationToken = allMatching[allMatching.length - 1].key
+    const lastKey = allMatching[allMatching.length - 1].key
+
+    // If the last scanned key folded into a CommonPrefix, the naive choice
+    // `lastKey` would land *inside* a virtual directory we've already
+    // represented in commonPrefixes.  The next page's `key > token` query
+    // would then return the remaining keys in that directory, which would
+    // re-fold into — and re-emit — the same CommonPrefix entry.
+    //
+    // Advance the token past every key that could possibly fold into that
+    // prefix by appending a high-sort sentinel.  `￿` (encoded as
+    // 0xEF 0xBF 0xBF in UTF-8) sorts after every realistic S3 key character,
+    // so `key > token` skips the rest of the directory and resumes at the
+    // first key that falls outside it.
+    if (delimiter) {
+      const afterPrefix = lastKey.slice(prefix.length)
+      const delimIdx = afterPrefix.indexOf(delimiter)
+      if (delimIdx >= 0) {
+        const lastFoldedPrefix = prefix + afterPrefix.slice(0, delimIdx + 1)
+        nextContinuationToken = lastFoldedPrefix + '￿'
+      } else {
+        nextContinuationToken = lastKey
+      }
+    } else {
+      nextContinuationToken = lastKey
+    }
   }
 
   return {


### PR DESCRIPTION
## Summary

Fixes the duplicate-`CommonPrefixes` bug Cursor Bugbot flagged on [PR #696](https://github.com/autonomys/auto-drive/pull/696#discussion_r3265123834) and [PR #709](https://github.com/autonomys/auto-drive/pull/709#discussion_r3288865588).

When the DB batch in `listObjects` is exhausted with every row folding into a single `CommonPrefix`, the truncation fallback was setting `nextContinuationToken` to the **last raw key scanned** — a key that lives *inside* the folded virtual directory. The next page's `key > token` query then returned the remaining keys in the same directory and re-emitted the same `CommonPrefixes` entry.

The fix detects when the last scanned key folded into a `CommonPrefix` and advances the token to `<foldedPrefix>+￿`, so the next page resumes after the entire virtual directory. Non-delimiter and non-folded cases keep the previous last-key fallback.

The earlier reply in [#696 (comment)](https://github.com/autonomys/auto-drive/pull/696#discussion_r3265173584) considered dropping the truncation guard to avoid the duplicate — but that would re-introduce silent data loss when a prefix group is larger than the DB fetch limit (>10,000 keys). This change keeps the guard *and* eliminates the duplicate. ~26 lines in the use case + 123 lines of unit tests, no test surgery elsewhere.

## Test plan

- [x] `yarn workspace backend test __tests__/unit/core/s3.spec.ts` — 15/15 pass, including 3 new tests:
  - `advances continuation token past a folded CommonPrefix when the DB batch is exhausted inside one prefix group` (regression test for the bug)
  - `uses the raw last key as the token when the last scanned key did not fold into a prefix`
  - `uses the raw last key as the token when no delimiter is set`
- [x] `yarn workspace backend lint` clean
- [x] `tsc --noEmit -p tsconfig.test.json` clean
- [x] CI green
- [ ] Integration smoke against staging once deployed: list a virtual directory with >10k keys under `maxKeys=2` and confirm each page advances past the previous directory rather than repeating it

🤖 Generated with [Claude Code](https://claude.com/claude-code)