### PR TITLE
fix(backend): guard against NULL encoded_node in publishing pipeline

### DIFF
--- a/apps/backend/__tests__/unit/repositories/nodes.spec.ts
+++ b/apps/backend/__tests__/unit/repositories/nodes.spec.ts
@@ -370,22 +370,22 @@ describe('Nodes Repository', () => {
     expect(result?.piece_offset).toBe(100)
   })
 
-  it('should remove nodes by root CID', async () => {
+  it('should remove encoded_node only for published nodes by root CID', async () => {
     const rootCid = 'test-root-cid-remove'
     const nodes: Node[] = [
       {
-        cid: 'test-cid-remove-1',
+        cid: 'test-cid-remove-published',
         root_cid: rootCid,
         head_cid: 'test-head-cid-remove',
         type: 'file',
         encoded_node: 'test-encoded-node-remove-1',
         piece_index: null,
         piece_offset: null,
-        block_published_on: null,
+        block_published_on: 100,
         tx_published_on: null,
       },
       {
-        cid: 'test-cid-remove-2',
+        cid: 'test-cid-remove-unpublished',
         root_cid: rootCid,
         head_cid: 'test-head-cid-remove',
         type: 'file',
@@ -399,13 +399,16 @@ describe('Nodes Repository', () => {
 
     await nodesRepository.saveNodes(nodes)
     await nodesRepository.removeNodeDataByRootCid(rootCid)
-    const results = await nodesRepository.getNodesByRootCid(rootCid)
-    const fullNodes = await Promise.all(
-      results.map((r) => nodesRepository.getNode(r.cid)),
+
+    const publishedNode = await nodesRepository.getNode(
+      'test-cid-remove-published',
     )
-    fullNodes.forEach((n) => {
-      expect(n?.encoded_node).toBeNull()
-    })
+    expect(publishedNode?.encoded_node).toBeNull()
+
+    const unpublishedNode = await nodesRepository.getNode(
+      'test-cid-remove-unpublished',
+    )
+    expect(unpublishedNode?.encoded_node).toBe('test-encoded-node-remove-2')
   })
 
   it('should get nodes by CIDs', async () => {

--- a/apps/backend/src/core/objects/publishingRecovery.ts
+++ b/apps/backend/src/core/objects/publishingRecovery.ts
@@ -46,6 +46,22 @@ const processPublishingRecovery = async (): Promise<void> => {
 const runRecoveryBatch = async (): Promise<void> => {
   const maxPerCycle = config.publishingRecovery.maxObjectsPerCycle
 
+  // Surface objects that are stuck in an unrecoverable state — they have
+  // unpublished nodes whose encoded_node was already stripped (e.g. by
+  // archival before publishing completed).  These cannot be recovered
+  // automatically and need operational attention.
+  const unrecoverable =
+    await nodesRepository.getUnrecoverablePublishingRootCids(maxPerCycle)
+  if (unrecoverable.length > 0) {
+    logger.warn(
+      'Found %d objects with unrecoverable unpublished nodes (data stripped before publishing): %s',
+      unrecoverable.length,
+      unrecoverable
+        .map((r) => `${r.root_cid} (${r.unrecoverable_count} nodes)`)
+        .join(', '),
+    )
+  }
+
   const stuckRootCids = await nodesRepository.getStuckPublishingRootCids(
     maxPerCycle,
     config.publishingRecovery.stalenessThresholdBlocks,

--- a/apps/backend/src/infrastructure/repositories/objects/nodes.ts
+++ b/apps/backend/src/infrastructure/repositories/objects/nodes.ts
@@ -176,11 +176,22 @@ const setNodeArchivingData = async ({
   })
 }
 
+/**
+ * Removes encoded_node data for all *published* nodes under a root_cid.
+ *
+ * Only nodes with `block_published_on IS NOT NULL` are stripped — their
+ * data is already immutably on-chain and the local copy is no longer
+ * needed.  Unpublished nodes retain their encoded_node so the publishing
+ * recovery job can still re-enqueue them.
+ */
 const removeNodeDataByRootCid = async (rootCid: string) => {
   const db = await getDatabase()
 
   return db.query({
-    text: 'UPDATE nodes SET encoded_node = NULL WHERE root_cid = $1',
+    text: `UPDATE nodes
+           SET encoded_node = NULL
+           WHERE root_cid = $1
+             AND block_published_on IS NOT NULL`,
     values: [rootCid],
   })
 }
@@ -477,6 +488,38 @@ const getUnpublishedNodeCidsByRootCid = async (
     .then((e) => e.rows.map((r) => r.cid))
 }
 
+/**
+ * Returns root_cids that have nodes stuck in an unrecoverable state:
+ * `block_published_on IS NULL` (never published) AND `encoded_node IS NULL`
+ * (data already stripped, e.g. by a prior archival bug).
+ *
+ * These objects can never complete publishing from local state alone.
+ * The caller should surface them for operational attention.
+ */
+const getUnrecoverablePublishingRootCids = async (
+  limit: number,
+): Promise<{ root_cid: string; unrecoverable_count: number }[]> => {
+  const db = await getDatabase()
+
+  return db
+    .query<{ root_cid: string; unrecoverable_count: number }>({
+      text: `
+        SELECT root_cid,
+               COUNT(*) FILTER (
+                 WHERE block_published_on IS NULL AND encoded_node IS NULL
+               )::int AS unrecoverable_count
+        FROM nodes
+        GROUP BY root_cid
+        HAVING COUNT(*) FILTER (
+          WHERE block_published_on IS NULL AND encoded_node IS NULL
+        ) > 0
+        LIMIT $1
+      `,
+      values: [limit],
+    })
+    .then((e) => e.rows)
+}
+
 export const nodesRepository = {
   getNode,
   getNodeCount,
@@ -503,4 +546,5 @@ export const nodesRepository = {
   getFullyArchivedHeadCids,
   getStuckPublishingRootCids,
   getUnpublishedNodeCidsByRootCid,
+  getUnrecoverablePublishingRootCids,
 }

--- a/apps/backend/src/infrastructure/repositories/objects/nodes.ts
+++ b/apps/backend/src/infrastructure/repositories/objects/nodes.ts
@@ -421,6 +421,10 @@ const getFullyArchivedHeadCids = async (
  *
  * The staleness filter prevents false positives on objects that are
  * still being actively published in the normal pipeline.
+ *
+ * Objects where every unpublished node has `encoded_node IS NULL`
+ * (i.e. archived before publishing completed) are excluded — they
+ * are un-publishable and would only cause repeated failures.
  */
 const getStuckPublishingRootCids = async (
   limit: number,
@@ -436,6 +440,9 @@ const getStuckPublishingRootCids = async (
         GROUP BY root_cid
         HAVING COUNT(block_published_on) > 0
            AND COUNT(block_published_on) < COUNT(*)
+           AND COUNT(*) FILTER (
+             WHERE block_published_on IS NULL AND encoded_node IS NOT NULL
+           ) > 0
            AND MAX(block_published_on) + $2 < (
              SELECT MAX(block_published_on) FROM nodes
            )
@@ -448,6 +455,8 @@ const getStuckPublishingRootCids = async (
 
 /**
  * Returns CIDs of unpublished nodes for a given root_cid.
+ * Only returns nodes that still have encoded_node data — nodes whose
+ * data was removed (e.g. by archival) are un-publishable and excluded.
  */
 const getUnpublishedNodeCidsByRootCid = async (
   rootCid: string,
@@ -461,6 +470,7 @@ const getUnpublishedNodeCidsByRootCid = async (
         FROM nodes
         WHERE root_cid = $1
           AND block_published_on IS NULL
+          AND encoded_node IS NOT NULL
       `,
       values: [rootCid],
     })

--- a/apps/backend/src/infrastructure/services/upload/onchainPublisher/index.ts
+++ b/apps/backend/src/infrastructure/services/upload/onchainPublisher/index.ts
@@ -23,11 +23,30 @@ const publishNodes = async (cids: string[]) => {
   const repeatedNodes = nodes.filter((node) => publishedCidSet.has(node.cid))
   await NodesUseCases.handleRepeatedNodes(repeatedNodes)
 
-  // Nodes that are not known as published anywhere should be sent for publishing
-  const publishingNodes = nodes.filter((node) => !publishedCidSet.has(node.cid))
+  // Nodes that are not known as published anywhere should be sent for publishing.
+  // Filter out nodes whose encoded_node has been removed (e.g. after archival) —
+  // these are un-publishable and must not reach the Buffer.from() call.
+  const publishingNodes = nodes.filter(
+    (node) => !publishedCidSet.has(node.cid) && node.encoded_node != null,
+  )
+
+  const skippedNullCount = nodes.filter(
+    (node) => !publishedCidSet.has(node.cid) && node.encoded_node == null,
+  ).length
+  if (skippedNullCount > 0) {
+    logger.warn(
+      'Skipped %d nodes with NULL encoded_node (archived before publishing)',
+      skippedNullCount,
+    )
+  }
+
+  if (publishingNodes.length === 0) {
+    logger.info('No publishable nodes remaining after filtering')
+    return
+  }
 
   const transactions = publishingNodes.map((node) => {
-    const buffer = Buffer.from(node.encoded_node, 'base64')
+    const buffer = Buffer.from(node.encoded_node!, 'base64')
 
     return {
       module: 'system',


### PR DESCRIPTION
### Problem

The publishing recovery job (PR #701) re-enqueues `publish-nodes` tasks for objects stuck in partial-publishing state every 5 minutes. However, some of those nodes have `encoded_node = NULL` in the DB because `onObjectArchived` unconditionally strips node data via `removeNodeDataByRootCid` — even for nodes that were never published on-chain.

This causes `publishNodes` to crash on `Buffer.from(null, 'base64')`, dumping ~12 failed tasks per cycle into `frontend-errors` after retries exhaust. Over ~66 hours since the May 22 deploy this produced ~9,540 dead-letter messages, all from the same 5 stuck root CIDs (370 nodes total).

### Root cause

`removeNodeDataByRootCid` runs `UPDATE nodes SET encoded_node = NULL WHERE root_cid = $1` with no regard for publication status. When an object is archived while some nodes still have `block_published_on IS NULL`, those nodes become permanently un-publishable: they look unpublished to the recovery job but have no data to publish.

### Changes

**Commit 1 — Stop the crash and the re-enqueue loop**

- **`onchainPublisher/index.ts`**: Filter out nodes with `encoded_node == null` before `Buffer.from()`, log a warning for visibility, early-return when no publishable nodes remain.
- **`getUnpublishedNodeCidsByRootCid`**: Add `AND encoded_node IS NOT NULL` so the recovery job never enqueues un-publishable nodes.
- **`getStuckPublishingRootCids`**: Add a `FILTER` clause excluding objects where every unpublished node has already been stripped — they would only produce no-op task cycles.

**Commit 2 — Fix the root cause + surface existing broken data**

- **`removeNodeDataByRootCid`**: Add `AND block_published_on IS NOT NULL` so archival only strips `encoded_node` from nodes that are confirmed on-chain. Unpublished nodes retain their data for recovery.
- **New `getUnrecoverablePublishingRootCids` query**: Detects objects with nodes in the broken state (`block_published_on IS NULL AND encoded_node IS NULL`) from before this fix.
- **`publishingRecovery.ts`**: Logs a `warn` each cycle listing any unrecoverable objects by root_cid and node count, surfacing them for operational attention.

### Operational follow-up (not in this PR)

The 5 existing broken root CIDs need a one-off DB heal to write verified `piece_index`/`piece_offset` values. This PR prevents new objects from entering the broken state and stops the `frontend-errors` flood, but the existing 370 rows require manual resolution. After this PR deploys, those objects will appear in the recovery job warning logs.


Resolves step 1 in https://github.com/autonomys/auto-drive/issues/712 