### PR TITLE
fix(backend): clear encoded_node when recovery-published node's objec…

### DIFF
--- a/apps/backend/__tests__/unit/repositories/nodes.spec.ts
+++ b/apps/backend/__tests__/unit/repositories/nodes.spec.ts
@@ -10,8 +10,9 @@ import {
   nodesRepository,
   Node,
 } from '../../../src/infrastructure/repositories/objects/nodes.js'
+import { metadataRepository } from '../../../src/infrastructure/repositories/objects/metadata.js'
 import { dbMigration } from '../../utils/dbMigrate.js'
-import { MetadataType } from '@autonomys/auto-dag-data'
+import { MetadataType, OffchainMetadata } from '@autonomys/auto-dag-data'
 
 describe('Nodes Repository', () => {
   beforeAll(async () => {
@@ -469,6 +470,44 @@ describe('Nodes Repository', () => {
 
     expect(result?.block_published_on).toBe(12345)
     expect(result?.tx_published_on).toBe('tx-hash')
+    expect(result?.encoded_node).toBe('test-encoded-node-published')
+  })
+
+  it('should clear encoded_node on publish when metadata is already archived', async () => {
+    const rootCid = 'test-root-cid-publish-archived'
+    const headCid = 'test-head-cid-publish-archived'
+    const metadata: OffchainMetadata = {
+      totalSize: 100n,
+      type: 'file',
+      dataCid: 'test-data-cid-publish-archived',
+      totalChunks: 1,
+      chunks: [],
+      name: 'test-file-publish-archived',
+    }
+
+    await metadataRepository.setMetadata(rootCid, headCid, metadata)
+    await metadataRepository.markAsArchived(headCid)
+
+    const node: Node = {
+      cid: 'test-cid-publish-after-archive',
+      root_cid: rootCid,
+      head_cid: headCid,
+      type: 'file',
+      encoded_node: 'data-that-should-be-cleared',
+      piece_index: null,
+      piece_offset: null,
+      block_published_on: null,
+      tx_published_on: null,
+    }
+
+    await nodesRepository.saveNode(node)
+    await nodesRepository.updateNodePublishedOn(node.cid, 99999, 'tx-recovery')
+
+    const result = await nodesRepository.getNode(node.cid)
+
+    expect(result?.block_published_on).toBe(99999)
+    expect(result?.tx_published_on).toBe('tx-recovery')
+    expect(result?.encoded_node).toBeNull()
   })
 
   it('should get uploaded nodes by root CID', async () => {

--- a/apps/backend/src/infrastructure/repositories/objects/nodes.ts
+++ b/apps/backend/src/infrastructure/repositories/objects/nodes.ts
@@ -223,7 +223,17 @@ const updateNodePublishedOn = async (
   const db = await getDatabase()
 
   return db.query({
-    text: 'UPDATE nodes SET block_published_on = $1, tx_published_on = $2 WHERE cid = $3',
+    text: `UPDATE nodes
+           SET block_published_on = $1,
+               tx_published_on = $2,
+               encoded_node = CASE
+                 WHEN EXISTS (
+                   SELECT 1 FROM metadata
+                   WHERE head_cid = nodes.head_cid AND is_archived = true
+                 ) THEN NULL
+                 ELSE encoded_node
+               END
+           WHERE cid = $3`,
     values: [blockPublishedOn, txPublishedOn, cid],
   })
 }


### PR DESCRIPTION
…t is already archived

After onObjectArchived runs, removeNodeDataByRootCid only strips encoded_node for nodes already published (block_published_on IS NOT NULL). Nodes published later via recovery get block_published_on set but never lose encoded_node, causing indefinite local payload retention.

Fix updateNodePublishedOn to conditionally clear encoded_node when the node's metadata is already marked archived. This is safe because at that point the data is confirmed on-chain and the archival cleanup won't fire again.