### PR TITLE
fix(s3): support AWS CLI clients (dispatch fallbacks + raw body)

### DIFF
--- a/apps/backend/__tests__/integration/s3-sdk/index.spec.ts
+++ b/apps/backend/__tests__/integration/s3-sdk/index.spec.ts
@@ -415,4 +415,100 @@ describe('AWS S3 - SDK', () => {
       expect(result.Metadata?.cid).toBeDefined()
     })
   })
+
+  // Raw HTTP requests that mimic the AWS CLI / botocore, which (unlike the JS
+  // SDK used above) does NOT send the `x-id` query param for GetObject/
+  // PutObject and sends object bodies with no Content-Type header. These guard
+  // two regressions:
+  //   1. getS3Method must fall back to the HTTP method (GET->GetObject,
+  //      PUT->PutObject) when `x-id` is absent — otherwise dispatch returns
+  //      "Method not found".
+  //   2. The request body must be read as raw bytes regardless of Content-Type;
+  //      a missing Content-Type previously left req.body as {} and broke
+  //      uploads deep in the IPLD chunker.
+  describe('Raw HTTP requests (AWS CLI style: no x-id, no Content-Type)', () => {
+    const S3_BASE = `${BASE_PATH}/s3`
+    // handleS3Auth only needs an Authorization header containing
+    // `Credential=<alphanumeric>/`; AuthManager is mocked to return `user`.
+    const AUTH =
+      'AWS4-HMAC-SHA256 Credential=clitestkey/20200101/us-east-1/s3/aws4_request, SignedHeaders=host, Signature=deadbeef'
+
+    // Passing a Uint8Array/Buffer body to fetch leaves Content-Type unset,
+    // reproducing the AWS CLI's behaviour. No `x-id` query param is added.
+    const rawS3 = (method: string, path: string, body?: Uint8Array) =>
+      fetch(`${S3_BASE}${path}`, {
+        method,
+        headers: { Authorization: AUTH },
+        // Cast: TS 5.7 types Buffer/Uint8Array as Uint8Array<ArrayBufferLike>,
+        // which doesn't structurally match the DOM BodyInit union. A binary
+        // body still sends with no Content-Type, which is the point here.
+        body: body as unknown as BodyInit | undefined,
+      })
+
+    const CliBody = Buffer.from('hello from the aws cli')
+
+    it('PutObject without x-id/Content-Type stores the object', async () => {
+      const res = await rawS3('PUT', '/cli-test/hello.txt', CliBody)
+      expect(res.status).toBe(200)
+      expect(res.headers.get('etag')).toMatch(MD5_ETAG_RE)
+    }, 15_000)
+
+    it('GetObject without x-id returns the exact bytes', async () => {
+      const res = await rawS3('GET', '/cli-test/hello.txt')
+      expect(res.status).toBe(200)
+      const got = Buffer.from(await res.arrayBuffer())
+      expect(got).toEqual(CliBody)
+    }, 15_000)
+
+    it('multipart upload via raw requests round-trips (the original 500)', async () => {
+      const key = '/cli-test/mpu.bin'
+      const part1 = Buffer.from('AAAAAAAAAAAAAAAA')
+      const part2 = Buffer.from('BBBBBBBBBBBBBBBB')
+
+      const create = await rawS3('POST', `${key}?uploads`)
+      expect(create.status).toBe(200)
+      const uploadId = (await create.text()).match(
+        /<UploadId>([^<]+)<\/UploadId>/,
+      )?.[1]
+      expect(uploadId).toBeDefined()
+
+      // Parts must be uploaded sequentially (the chunker enforces ordering).
+      const up1 = await rawS3(
+        'PUT',
+        `${key}?partNumber=1&uploadId=${uploadId}`,
+        part1,
+      )
+      expect(up1.status).toBe(200)
+      const etag1 = up1.headers.get('etag')!
+      expect(etag1).toMatch(MD5_ETAG_RE)
+
+      const up2 = await rawS3(
+        'PUT',
+        `${key}?partNumber=2&uploadId=${uploadId}`,
+        part2,
+      )
+      expect(up2.status).toBe(200)
+      const etag2 = up2.headers.get('etag')!
+
+      // The part list in the body is used only to compute the composite ETag.
+      const completeBody = Buffer.from(
+        '<CompleteMultipartUpload>' +
+          `<Part><ETag>${etag1}</ETag><PartNumber>1</PartNumber></Part>` +
+          `<Part><ETag>${etag2}</ETag><PartNumber>2</PartNumber></Part>` +
+          '</CompleteMultipartUpload>',
+      )
+      const complete = await rawS3(
+        'POST',
+        `${key}?uploadId=${uploadId}`,
+        completeBody,
+      )
+      expect(complete.status).toBe(200)
+      expect(complete.headers.get('etag')).toMatch(MULTIPART_ETAG_RE)
+
+      const get = await rawS3('GET', key)
+      expect(get.status).toBe(200)
+      const got = Buffer.from(await get.arrayBuffer())
+      expect(got).toEqual(Buffer.concat([part1, part2]))
+    }, 30_000)
+  })
 })

--- a/apps/backend/src/app/apis/download.ts
+++ b/apps/backend/src/app/apis/download.ts
@@ -15,6 +15,26 @@ const createServer = async () => {
   logger.debug('Initializing download API server')
   const app = express()
 
+  if (config.express.corsAllowedOrigins) {
+    logger.debug(
+      'Configuring CORS with allowed origins: %j',
+      config.express.corsAllowedOrigins,
+    )
+    app.use(
+      cors({
+        origin: config.express.corsAllowedOrigins,
+      }),
+    )
+  } else {
+    logger.warn('CORS is not configured - no allowed origins specified, blocking cross-origin requests')
+  }
+
+  // The S3 controller handles its own raw body parsing (binary object
+  // payloads). It is mounted before the JSON/urlencoded parsers below so those
+  // never run for /s3 — otherwise body-parser would set req.body to {} and the
+  // raw object bytes would be lost.
+  app.use('/s3', s3Controller)
+
   app.use(
     express.json({
       limit: config.express.requestSizeLimit,
@@ -36,22 +56,7 @@ const createServer = async () => {
     config.express.requestSizeLimit,
   )
 
-  if (config.express.corsAllowedOrigins) {
-    logger.debug(
-      'Configuring CORS with allowed origins: %j',
-      config.express.corsAllowedOrigins,
-    )
-    app.use(
-      cors({
-        origin: config.express.corsAllowedOrigins,
-      }),
-    )
-  } else {
-    logger.warn('CORS is not configured - no allowed origins specified, blocking cross-origin requests')
-  }
-
   app.use('/downloads', downloadController)
-  app.use('/s3', s3Controller)
   app.use('/features', featuresController)
 
   logger.debug('Download controller mounted at /downloads')

--- a/apps/backend/src/app/controllers/s3/http.ts
+++ b/apps/backend/src/app/controllers/s3/http.ts
@@ -55,6 +55,16 @@ const getS3Method = (req: Request) => {
     if (req.method === 'DELETE') {
       return 'DeleteObject'
     }
+    // Method-based fallbacks for clients that do not send the `x-id` query
+    // param (e.g. the AWS CLI / botocore). These must come after the more
+    // specific query-param checks above so multipart PUTs (uploadId +
+    // partNumber) and ListObjectsV2 GETs (list-type=2) are not misrouted.
+    if (req.method === 'GET') {
+      return 'GetObject'
+    }
+    if (req.method === 'PUT') {
+      return 'PutObject'
+    }
   }
   return s3Method
 }
@@ -69,8 +79,13 @@ s3Controller.get(
 
 s3Controller.use(
   '/:key(*)',
+  // S3 object bodies are opaque binary payloads. Always read the request body
+  // as raw bytes regardless of (or the absence of) a Content-Type header.
+  // `type: '*/*'` is insufficient: type-is returns false when no Content-Type
+  // header is present, which the AWS CLI omits on PutObject/UploadPart — that
+  // left req.body as `{}` and broke uploads.
   raw({
-    type: '*/*',
+    type: () => true,
     limit: '100mb',
   }),
   asyncSafeHandler(async (req: Request, res: Response) => {


### PR DESCRIPTION
## Summary

The S3-compatible API only worked with clients that send the `x-id` query param **and** a `Content-Type` header (the AWS JS SDK does both). The **AWS CLI / botocore omits both**, which is why the `scripts/test-s3-compat.sh` smoke test failed against production on every object read/write while DeleteObject (hardcoded 403) and CreateMultipartUpload (no body) passed.

Two distinct bugs, both pre-existing in `main`, both in the public `download-api` code path:

1. **Dispatch** — `getS3Method` resolved the operation only from `x-id`, with fallbacks for `HEAD`/`DELETE` only. A plain `GET`/`PUT` with no `x-id` fell through to `undefined` → **"Method not found"** (the GetObject/PutObject 500s).
2. **Request body** — the S3 raw parser used `type: '*/*'`, but `type-is` returns `false` when there is **no `Content-Type` header**, so the body was never read. Combined with the global `express.json()` (which sets `req.body = req.body || {}` before its own content-type check), `req.body` arrived as `{}` → `Buffer.concat` TypeError deep in the upload path (the UploadPart 500s). The `Invalid part index` error was a cascade of the failed first part.

## Changes

- `getS3Method`: add `GET → GetObject` and `PUT → PutObject` fallbacks, ordered **after** the existing multipart (`uploadId`/`partNumber`) and `list-type=2` checks so those aren't misrouted.
- S3 raw body parser: `type: () => true` — object bodies are opaque binary; always read them as raw bytes regardless of Content-Type.
- `download.ts`: mount the S3 controller **before** the global JSON/urlencoded parsers so they never touch `/s3` (and moved `cors()` above it so `/s3` still gets CORS).

No behavior change for non-`/s3` routes. Build + lint pass.

## Test plan

- [ ] **Needs a real round-trip with the AWS CLI** (not just the JS SDK, which masks both bugs). Run `scripts/test-s3-compat.sh` against a deploy of this branch:
  - [ ] PutObject / GetObject / HeadObject succeed (no more "Method not found" / 500)
  - [ ] Multipart upload + composite ETag succeeds
  - [ ] DeleteObject still returns 403
  - [ ] ListBuckets / ListObjectsV2 unaffected
- [ ] TODO (follow-up): add an automated test that exercises the no-`x-id` / no-`Content-Type` path so this can't regress — the existing SDK-based integration tests won't catch it.

Related: nginx exposure of `/s3` (#708, merged) and rclone docs (#698).

🤖 Generated with [Claude Code](https://claude.com/claude-code)