### PR TITLE
fix(s3): return MD5 ETag from ListObjectsV2 (not the CID)

### DIFF
--- a/apps/backend/__tests__/integration/s3-sdk/index.spec.ts
+++ b/apps/backend/__tests__/integration/s3-sdk/index.spec.ts
@@ -283,6 +283,24 @@ describe('AWS S3 - SDK', () => {
       }
     })
 
+    it('should return the MD5 ETag (not the CID), matching HeadObject', async () => {
+      // Regression: the listing previously returned the CID as the ETag, so
+      // checksum-verifying clients (rclone, AWS CLI) could not validate against
+      // a listing. Every listed ETag must be a quoted 32-hex MD5 (a CID would
+      // not match), and must equal the ETag HeadObject returns for that object.
+      const list = await s3Client.send(
+        new ListObjectsV2Command({ Bucket: ListBucket }),
+      )
+      const entry = list.Contents!.find((c) => c.Key === 'a.txt')
+      expect(entry).toBeDefined()
+      expect(entry!.ETag).toMatch(MD5_ETAG_RE)
+
+      const head = await s3Client.send(
+        new HeadObjectCommand({ Bucket, Key: 'list-test/a.txt' }),
+      )
+      expect(entry!.ETag).toBe(head.ETag)
+    })
+
     it('should filter by prefix', async () => {
       const result = await s3Client.send(
         new ListObjectsV2Command({ Bucket: ListBucket, Prefix: 'subdir/' }),

--- a/apps/backend/__tests__/unit/core/s3.spec.ts
+++ b/apps/backend/__tests__/unit/core/s3.spec.ts
@@ -381,6 +381,7 @@ describe('S3UseCases', () => {
       cid: 'cid',
       size: 0n,
       lastModified: new Date(0),
+      md5: null,
     })
 
     it('advances continuation token past a folded CommonPrefix when the DB batch is exhausted inside one prefix group', async () => {

--- a/apps/backend/src/app/controllers/s3/s3.ts
+++ b/apps/backend/src/app/controllers/s3/s3.ts
@@ -363,8 +363,10 @@ export const listObjectsV2Handler = async (req: Request, res: Response) => {
       Key: obj.key,
       Size: obj.size.toString(),
       LastModified: obj.lastModified.toISOString(),
-      // CID is used as the ETag on this branch (before MD5 support).
-      ETag: `"${obj.cid}"`,
+      // Return the stored MD5 so clients (rclone, AWS CLI) can verify
+      // checksums from the listing, matching HeadObject. Legacy objects with
+      // no stored md5 fall back to the CID, which remains in x-amz-meta-cid.
+      ETag: obj.md5 ? `"${obj.md5}"` : `"${obj.cid}"`,
     }))
   }
 

--- a/apps/backend/src/infrastructure/repositories/s3/objectMappings.ts
+++ b/apps/backend/src/infrastructure/repositories/s3/objectMappings.ts
@@ -22,6 +22,8 @@ export interface S3ObjectListing {
   /** Object size in bytes joined from the metadata table; 0 when not yet indexed. */
   size: bigint
   lastModified: Date
+  /** MD5 stored at upload; null for objects uploaded before MD5 ETag support. */
+  md5: string | null
 }
 
 interface S3KeyMappingDB {
@@ -164,6 +166,7 @@ const listObjects = async (
     SELECT
       om.key,
       om.cid,
+      om.md5,
       COALESCE(m.total_size, 0) AS size,
       om.updated_at
     FROM "S3".object_mappings om
@@ -198,6 +201,7 @@ const listObjects = async (
   const result = await db.query<{
     key: string
     cid: string
+    md5: string | null
     size: string // pg returns bigint as string
     updated_at: Date
   }>({ text, values })
@@ -207,6 +211,7 @@ const listObjects = async (
     cid: row.cid,
     size: BigInt(row.size),
     lastModified: row.updated_at,
+    md5: row.md5 ?? null,
   }))
 }
 


### PR DESCRIPTION
## Summary

HeadObject was fixed to return the stored MD5 as the ETag (#695), but the **ListObjectsV2 listing path was missed** and still returned the **CID** as the ETag. Clients that verify checksums from a listing (rclone, AWS CLI) can't use a CID as an MD5, so they fall back to a `HeadObject` per object to get the hash.

The `md5` is already stored on `S3.object_mappings` (HeadObject reads it) — the listing query simply didn't select it.

## Changes
- `repositories/s3/objectMappings.ts`: add `md5` to `S3ObjectListing`, select `om.md5` in the `listObjects` query, map it through.
- `controllers/s3/s3.ts`: `listObjectsV2Handler` now emits `ETag: obj.md5 ? "<md5>" : "<cid>"` — real MD5, falling back to the CID for legacy objects with no stored md5 (matching HeadObject; CID stays in `x-amz-meta-cid`).
- Test: assert listed ETags are MD5 format **and equal HeadObject's ETag** for the same object. Updated the `buildListResult` unit fixture for the new field.

`md5` rides along on `S3ObjectListing` through `buildListResult`, so no use-case changes were needed.

## Context
Surfaced while validating rclone against the deployed S3 API. The production smoke test (incl. `rclone check`) already passes **because** rclone falls back to HeadObject for the hash — so this is a **correctness + performance** improvement (self-consistent listings, no N extra HEAD requests), not a functional blocker.

Note: rclone also requires `list_version = 2` in its remote config, because our API implements ListObjectsV2 only (not V1). Documented separately in the rclone docs; server-side ListObjectsV1 support is a possible follow-up.

## Test plan
- [x] `yarn backend test --testPathPattern='s3-sdk|core/s3'` → 40/40 pass
- [x] Build + lint clean
- [ ] Post-deploy: re-run `scripts/test-s3-compat.sh` (should still pass, now without per-object HEAD fallback) and an `rclone check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)