### PR TITLE
fix(s3): HeadObject returns 200 with ContentLength and Last-Modified

### DIFF
--- a/apps/backend/__tests__/integration/s3-sdk/index.spec.ts
+++ b/apps/backend/__tests__/integration/s3-sdk/index.spec.ts
@@ -432,6 +432,17 @@ describe('AWS S3 - SDK', () => {
       // CID must be present in the custom header
       expect(result.Metadata?.cid).toBeDefined()
     })
+
+    // HeadObject must return 200 with the headers GET would send. A prior
+    // 204 stripped Content-Length/Content-Type; Last-Modified was never set.
+    it('should return ContentLength, ContentType and LastModified on HeadObject', async () => {
+      // `Key`/`Body` is a plain (uncompressed, unencrypted) object.
+      const result = await s3Client.send(new HeadObjectCommand({ Bucket, Key }))
+
+      expect(result.ContentLength).toBe(Body.length)
+      expect(result.LastModified).toBeInstanceOf(Date)
+      expect(result.ContentType).toBeTruthy()
+    })
   })
 
   // Raw HTTP requests that mimic the AWS CLI / botocore, which (unlike the JS

--- a/apps/backend/src/app/controllers/s3/s3.ts
+++ b/apps/backend/src/app/controllers/s3/s3.ts
@@ -142,6 +142,7 @@ export const getObjectHandler = async (req: Request, res: Response) => {
     byteRange: resultingByteRange,
     cid,
     etag,
+    lastModified,
   } = downloadResult.value
 
   handleDownloadResponseHeaders(req, res, metadata, {
@@ -155,6 +156,7 @@ export const getObjectHandler = async (req: Request, res: Response) => {
   if (etag) res.set('ETag', etag)
   // Always expose the CID so clients that understand Autonomys can use it.
   res.set('x-amz-meta-cid', cid)
+  res.set('Last-Modified', lastModified.toUTCString())
 
   pipeline(await startDownload(), res, (err: Error | null) => {
     if (err) {
@@ -189,6 +191,7 @@ export const headObjectHandler = async (req: Request, res: Response) => {
     byteRange: resultingByteRange,
     cid,
     etag,
+    lastModified,
   } = downloadResult.value
 
   handleDownloadResponseHeaders(req, res, metadata, {
@@ -202,8 +205,12 @@ export const headObjectHandler = async (req: Request, res: Response) => {
   if (etag) res.set('ETag', etag)
   // Always expose the CID so clients that understand Autonomys can use it.
   res.set('x-amz-meta-cid', cid)
+  res.set('Last-Modified', lastModified.toUTCString())
 
-  res.sendStatus(204)
+  // 200, not 204: HeadObject returns the headers GET would send (Content-Length,
+  // Content-Type, …) with an empty body. A 204 is defined as bodiless, so Node
+  // strips those content headers.
+  res.status(200).end()
 }
 
 export const createMultipartUploadHandler = async (

--- a/apps/backend/src/core/s3/index.ts
+++ b/apps/backend/src/core/s3/index.ts
@@ -67,6 +67,8 @@ type GetObjectUseCaseResult = GetObjectCommandResult & {
   cid: string
   /** null for objects uploaded before MD5 ETag support was introduced. */
   etag: string | null
+  /** Mapping's last-write time, surfaced as the S3 Last-Modified header. */
+  lastModified: Date
 }
 
 const getObject = async (
@@ -97,6 +99,7 @@ const getObject = async (
     // Objects uploaded before this feature have null md5; fall back to null
     // so the controller can omit the ETag header for legacy objects.
     etag: mapping.md5 ? formatETag(mapping.md5) : null,
+    lastModified: mapping.updatedAt,
   }))
 }
 


### PR DESCRIPTION
Closes #727.

## What was wrong

`HeadObject` on a non-empty object returned `Content-Length: 0` and no `Last-Modified`. From the S3 live-integration test (#719):

```
HeadObject header round-trips
  ✗  HeadObject — ContentLength wrong        head=0 file=43
  ✗  HeadObject — LastModified missing from response
  ℹ  HeadObject — ContentType is '' (PUT set 'text/plain')
```

GET was unaffected — only HEAD.

## Two root causes

**1. HEAD responded 204, stripping content headers.** `headObjectHandler` called the shared header helpers (which correctly set `Content-Length` from `metadata.size` and `Content-Type`), then ended with `res.sendStatus(204)`. A `204 No Content` is defined as bodiless, so Node strips `Content-Length` and `Content-Type` — the AWS SDK then reports `ContentLength: 0` and empty `ContentType`. GET works because it streams a 200/206 body, so the headers survive. The empty `ContentType` (reported as info) shares this cause.

**2. `Last-Modified` was set by neither helper.** `handleDownloadResponseHeaders` / `handleS3DownloadResponseHeaders` in `@autonomys/file-server` never set it (confirmed against the dist). The SDK's IPLD metadata carries no S3-mapping timestamp, so it belongs in the backend.

## Fix

- `headObjectHandler`: `res.sendStatus(204)` → `res.status(200).end()`, preserving the headers the helpers set (fixes ContentLength **and** ContentType).
- Thread `mapping.updatedAt` through `getObject` as `lastModified` and set `Last-Modified` (`toUTCString()`, RFC 7231) on both GET and HEAD. `updatedAt` is bumped on every PUT (`ON CONFLICT … updated_at = NOW()`), so it is the correct object-last-modified source.

## Test

New hermetic HEAD test against a plain object asserts `ContentLength === Body.length`, `LastModified instanceof Date`, and `ContentType` truthy. The existing HEAD test covers a compressed+encrypted object (where the stored size has different semantics), so this uses a clean plain object.

## Verification

- [x] `yarn backend build` clean
- [x] `yarn backend test` — 26 suites, **405 tests** (404 → 405)
- [x] backend/auth/frontend lint pass
- [x] Re-run `scripts/live-integration/test-s3-api.sh`; the two HEAD failures become `ok` and the ContentType info becomes a pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)