### PR TITLE
fix(s3): reject unsupported operations with 501 instead of misrouting

### DIFF
--- a/apps/backend/__tests__/integration/s3-sdk/index.spec.ts
+++ b/apps/backend/__tests__/integration/s3-sdk/index.spec.ts
@@ -1,12 +1,16 @@
 import { dbMigration } from '../../utils/dbMigrate.js'
 import {
+  AbortMultipartUploadCommand,
   CompleteMultipartUploadCommand,
+  CopyObjectCommand,
   CreateMultipartUploadCommand,
   DeleteObjectCommand,
   GetObjectCommand,
   HeadObjectCommand,
   ListBucketsCommand,
+  ListMultipartUploadsCommand,
   ListObjectsV2Command,
+  ListPartsCommand,
   PutObjectCommand,
   S3Client,
   UploadPartCommand,
@@ -414,6 +418,69 @@ describe('AWS S3 - SDK', () => {
       await expect(s3Client.send(command)).rejects.toMatchObject({
         $metadata: { httpStatusCode: 404 },
       })
+    })
+  })
+
+  // Unsupported operations must be rejected with 501, not misrouted to a
+  // handler for a similarly-shaped request. The two reads (ListParts,
+  // ListMultipartUploads) and AbortMultipartUpload previously reached the
+  // multipart write handlers; CopyObject reached PutObject.
+  describe('Unsupported operations return 501 NotImplemented', () => {
+    it('CopyObject is rejected and creates no object', async () => {
+      const CopyKey = 'copy-dest.txt'
+      await expect(
+        s3Client.send(
+          new CopyObjectCommand({
+            Bucket,
+            Key: CopyKey,
+            CopySource: `${Bucket}/${Key}`,
+          }),
+        ),
+      ).rejects.toMatchObject({ $metadata: { httpStatusCode: 501 } })
+
+      // The misroute used to PutObject an empty body at the destination.
+      // Assert only that the object does not exist (HEAD rejects); the exact
+      // missing-key status is fixed separately (404 vs 500).
+      await expect(
+        s3Client.send(new HeadObjectCommand({ Bucket, Key: CopyKey })),
+      ).rejects.toThrow()
+    })
+
+    it('ListParts is rejected (must not finalise the upload)', async () => {
+      // A real, in-progress upload so a misroute would actually complete it.
+      const created = await s3Client.send(
+        new CreateMultipartUploadCommand({ Bucket, Key: 'listparts-probe.bin' }),
+      )
+      await expect(
+        s3Client.send(
+          new ListPartsCommand({
+            Bucket,
+            Key: 'listparts-probe.bin',
+            UploadId: created.UploadId!,
+          }),
+        ),
+      ).rejects.toMatchObject({ $metadata: { httpStatusCode: 501 } })
+    })
+
+    it('ListMultipartUploads is rejected', async () => {
+      await expect(
+        s3Client.send(new ListMultipartUploadsCommand({ Bucket })),
+      ).rejects.toMatchObject({ $metadata: { httpStatusCode: 501 } })
+    })
+
+    it('AbortMultipartUpload is rejected (must not finalise the upload)', async () => {
+      const created = await s3Client.send(
+        new CreateMultipartUploadCommand({ Bucket, Key: 'abort-probe.bin' }),
+      )
+      await expect(
+        s3Client.send(
+          new AbortMultipartUploadCommand({
+            Bucket,
+            Key: 'abort-probe.bin',
+            UploadId: created.UploadId!,
+          }),
+        ),
+      ).rejects.toMatchObject({ $metadata: { httpStatusCode: 501 } })
     })
   })
 

--- a/apps/backend/__tests__/integration/s3-sdk/index.spec.ts
+++ b/apps/backend/__tests__/integration/s3-sdk/index.spec.ts
@@ -421,10 +421,7 @@ describe('AWS S3 - SDK', () => {
     })
   })
 
-  // Unsupported operations must be rejected with 501, not misrouted to a
-  // handler for a similarly-shaped request. The two reads (ListParts,
-  // ListMultipartUploads) and AbortMultipartUpload previously reached the
-  // multipart write handlers; CopyObject reached PutObject.
+  // Unsupported operations must return 501, never reach a write handler.
   describe('Unsupported operations return 501 NotImplemented', () => {
     it('CopyObject is rejected and creates no object', async () => {
       const CopyKey = 'copy-dest.txt'

--- a/apps/backend/src/app/controllers/s3/http.ts
+++ b/apps/backend/src/app/controllers/s3/http.ts
@@ -1,6 +1,5 @@
 import { raw, Router, Request, Response } from 'express'
 import { asyncSafeHandler } from '../../../shared/utils/express.js'
-import { handleError } from '../../../errors/index.js'
 import { createLogger } from '../../../infrastructure/drivers/logger.js'
 import {
   completeMultipartUploadHandler,
@@ -10,6 +9,7 @@ import {
   headObjectHandler,
   listBucketsHandler,
   listObjectsV2Handler,
+  notImplementedHandler,
   putObjectHandler,
   uploadPartHandler,
 } from './s3.js'
@@ -32,47 +32,58 @@ const S3HandlerConfig: S3HandlerConfig = {
   DeleteObject: deleteObjectHandler,
   ListBuckets: listBucketsHandler,
   ListObjectsV2: listObjectsV2Handler,
+  // Recognised but unimplemented. Routed explicitly to a 501 so a request is
+  // never mistaken for a similarly-shaped supported one — e.g. GET ?uploadId
+  // (ListParts) must not reach CompleteMultipartUpload and finalise the
+  // upload.
+  CopyObject: notImplementedHandler,
+  ListParts: notImplementedHandler,
+  ListMultipartUploads: notImplementedHandler,
+  AbortMultipartUpload: notImplementedHandler,
+  PostObject: notImplementedHandler,
 }
 
-const getS3Method = (req: Request) => {
-  const { 'x-id': s3Method } = req.query
-  if (!s3Method) {
-    if ('uploads' in req.query) {
-      return 'CreateMultipartUpload'
-    }
-    if ('uploadId' in req.query && 'partNumber' in req.query) {
-      return 'UploadPart'
-    }
-    if ('uploadId' in req.query) {
-      return 'CompleteMultipartUpload'
-    }
-    if (req.query['list-type'] === '2') {
-      return 'ListObjectsV2'
-    }
-    if (req.method === 'HEAD') {
-      return 'HeadObject'
-    }
-    if (req.method === 'DELETE') {
-      return 'DeleteObject'
-    }
-    // Method-based fallbacks for clients that do not send the `x-id` query
-    // param (e.g. the AWS CLI / botocore). These must come after the more
-    // specific query-param checks above so multipart PUTs (uploadId +
-    // partNumber) and ListObjectsV2 GETs (list-type=2) are not misrouted.
-    if (req.method === 'GET') {
+// Resolve the S3 operation from the HTTP method first, then disambiguate by
+// query params / headers. Method-first matters: GET ?uploadId (ListParts) and
+// POST ?uploadId (CompleteMultipartUpload) share a query param but are
+// different operations, and only the latter is a write.
+const getS3Method = (req: Request): string => {
+  const q = req.query
+  const isCopy = req.headers['x-amz-copy-source'] != null
+
+  switch (req.method) {
+    case 'GET':
+      if ('uploadId' in q) return 'ListParts'
+      if ('uploads' in q) return 'ListMultipartUploads'
+      if (q['list-type'] === '2') return 'ListObjectsV2'
       return 'GetObject'
-    }
-    if (req.method === 'PUT') {
+    case 'HEAD':
+      return 'HeadObject'
+    case 'PUT':
+      if ('uploadId' in q && 'partNumber' in q) return 'UploadPart'
+      if (isCopy) return 'CopyObject'
       return 'PutObject'
-    }
+    case 'POST':
+      if ('uploads' in q) return 'CreateMultipartUpload'
+      if ('uploadId' in q) return 'CompleteMultipartUpload'
+      return 'PostObject'
+    case 'DELETE':
+      if ('uploadId' in q) return 'AbortMultipartUpload'
+      return 'DeleteObject'
+    default:
+      return 'Unknown'
   }
-  return s3Method
 }
 
-// ListBuckets: GET / with no key path
+// ListBuckets: GET / with no key path.  Bucket-level sub-resource requests
+// also land here when the bucket is the endpoint (e.g. ListMultipartUploads is
+// GET /?uploads); route those to 501 rather than returning the bucket list.
 s3Controller.get(
   '/',
   asyncSafeHandler(async (req: Request, res: Response) => {
+    if ('uploads' in req.query) {
+      return notImplementedHandler(req, res)
+    }
     return listBucketsHandler(req, res)
   }),
 )
@@ -93,8 +104,9 @@ s3Controller.use(
 
     const handler = S3HandlerConfig[s3Method as keyof typeof S3HandlerConfig]
     if (!handler) {
-      logger.error('Method not found')
-      return handleError(new Error('Method not found'), res)
+      // Unrecognised verb/shape — reject as unimplemented rather than 500.
+      logger.warn('Unsupported S3 request: %s %s', req.method, req.originalUrl)
+      return notImplementedHandler(req, res)
     }
 
     return handler(req, res)

--- a/apps/backend/src/app/controllers/s3/http.ts
+++ b/apps/backend/src/app/controllers/s3/http.ts
@@ -32,10 +32,7 @@ const S3HandlerConfig: S3HandlerConfig = {
   DeleteObject: deleteObjectHandler,
   ListBuckets: listBucketsHandler,
   ListObjectsV2: listObjectsV2Handler,
-  // Recognised but unimplemented. Routed explicitly to a 501 so a request is
-  // never mistaken for a similarly-shaped supported one — e.g. GET ?uploadId
-  // (ListParts) must not reach CompleteMultipartUpload and finalise the
-  // upload.
+  // Recognised but unimplemented — mapped to 501, never to a write handler.
   CopyObject: notImplementedHandler,
   ListParts: notImplementedHandler,
   ListMultipartUploads: notImplementedHandler,
@@ -43,10 +40,8 @@ const S3HandlerConfig: S3HandlerConfig = {
   PostObject: notImplementedHandler,
 }
 
-// Resolve the S3 operation from the HTTP method first, then disambiguate by
-// query params / headers. Method-first matters: GET ?uploadId (ListParts) and
-// POST ?uploadId (CompleteMultipartUpload) share a query param but are
-// different operations, and only the latter is a write.
+// Match on method first: the same query param (?uploadId, ?uploads) selects a
+// different operation per verb.
 const getS3Method = (req: Request): string => {
   const q = req.query
   const isCopy = req.headers['x-amz-copy-source'] != null
@@ -75,12 +70,10 @@ const getS3Method = (req: Request): string => {
   }
 }
 
-// ListBuckets: GET / with no key path.  Bucket-level sub-resource requests
-// also land here when the bucket is the endpoint (e.g. ListMultipartUploads is
-// GET /?uploads); route those to 501 rather than returning the bucket list.
 s3Controller.get(
   '/',
   asyncSafeHandler(async (req: Request, res: Response) => {
+    // ?uploads at the bucket root is ListMultipartUploads, not ListBuckets.
     if ('uploads' in req.query) {
       return notImplementedHandler(req, res)
     }
@@ -104,7 +97,6 @@ s3Controller.use(
 
     const handler = S3HandlerConfig[s3Method as keyof typeof S3HandlerConfig]
     if (!handler) {
-      // Unrecognised verb/shape — reject as unimplemented rather than 500.
       logger.warn('Unsupported S3 request: %s %s', req.method, req.originalUrl)
       return notImplementedHandler(req, res)
     }

--- a/apps/backend/src/app/controllers/s3/s3.ts
+++ b/apps/backend/src/app/controllers/s3/s3.ts
@@ -415,8 +415,6 @@ export const deleteObjectHandler = async (_req: Request, res: Response) => {
   })
 }
 
-// Reject operations the backend does not implement. Routed here explicitly so
-// they cannot reach a write handler for a similarly-shaped request.
 export const notImplementedHandler = async (_req: Request, res: Response) => {
   sendXML(res.status(501), 'Error', {
     Code: 'NotImplemented',

--- a/apps/backend/src/app/controllers/s3/s3.ts
+++ b/apps/backend/src/app/controllers/s3/s3.ts
@@ -414,3 +414,12 @@ export const deleteObjectHandler = async (_req: Request, res: Response) => {
       'Auto Drive storage is immutable. Objects cannot be deleted from the Autonomys DSN.',
   })
 }
+
+// Reject operations the backend does not implement. Routed here explicitly so
+// they cannot reach a write handler for a similarly-shaped request.
+export const notImplementedHandler = async (_req: Request, res: Response) => {
+  sendXML(res.status(501), 'Error', {
+    Code: 'NotImplemented',
+    Message: 'This S3 operation is not supported by Auto Drive.',
+  })
+}


### PR DESCRIPTION
Closes #729.

## What was wrong

`getS3Method` selected the handler from query parameters **without considering the HTTP method**, so operations the backend doesn't implement reached a handler for a similarly-shaped supported request. Because those handlers mutate state, a safe or unsupported request caused an unintended write:

| Request | Misrouted to | Unintended effect |
|---|---|---|
| `GET /?uploads` — ListMultipartUploads | `CreateMultipartUpload` | created an orphan multipart upload |
| `GET /key?uploadId` — ListParts | `CompleteMultipartUpload` | **finalized** the upload |
| `DELETE /key?uploadId` — AbortMultipartUpload | `CompleteMultipartUpload` | **finalized** instead of discarding |
| `PUT /key` + `x-amz-copy-source` — CopyObject | `PutObject` | wrote an **empty** object at the destination |

The two GET cases are the worst — an HTTP-safe method performing a write.

## Fix

Resolve the operation **method-first**, then disambiguate by query param / `x-amz-copy-source`. CopyObject, ListParts, ListMultipartUploads, AbortMultipartUpload, and POST-object route to a `notImplementedHandler` returning **501** with an S3 `<Error><Code>NotImplemented</Code>` body and no side effects.

Bucket-level `ListMultipartUploads` (`GET /?uploads`) lands on the separate `GET /` ListBuckets route when the bucket is the endpoint (so it returned the bucket list, not a write — but still wrong); guarded there too.

## Tests

Hermetic tests assert 501 for CopyObject, ListParts, ListMultipartUploads, and AbortMultipartUpload — including that CopyObject creates no destination object, and that ListParts/Abort run against a **live in-progress upload** so a misroute would actually finalize it (proving it no longer does).

## Notes

- CopyObject (a new key→same-CID mapping) and AbortMultipartUpload (cleanup) are natural cheap features here; this PR only stops the misrouting and rejects them cleanly. Worth separate feature issues if desired.
- The CopyObject "no side effect" check asserts the destination HEAD *rejects* rather than a specific status, since the missing-key 404 vs 500 behaviour is fixed independently in #724.

## Verification

- [x] `yarn backend build` clean
- [x] `yarn backend test` — 26 suites, **408 tests** (404 → 408 with 4 new)
- [x] backend/auth/frontend lint pass
- [x] Re-run `scripts/live-integration/test-s3-api.sh`; the CopyObject / ListMultipartUploads / ListParts probes flip from "accepted" to "rejected"

🤖 Generated with [Claude Code](https://claude.com/claude-code)