### PR TITLE
fix(frontend): preview compressed non-encrypted files

### DIFF
--- a/apps/frontend/__tests__/unit/components/filePreviewDecode.spec.ts
+++ b/apps/frontend/__tests__/unit/components/filePreviewDecode.spec.ts
@@ -250,6 +250,26 @@ describe('loadPlaintextBytes', () => {
     ).rejects.toThrow('Aborted');
   });
 
+  it('aborts when the signal fires after the final chunk but before return', async () => {
+    const controller = new AbortController();
+    // The abort lands once the stream has fully drained — after the last chunk
+    // is yielded but before collectStream assembles/returns the buffer. The
+    // loop-top guard never sees it, so only a post-loop re-check throws.
+    const api = {
+      downloadObject: jest.fn().mockResolvedValue(
+        (async function* () {
+          yield Buffer.from(PNG_MAGIC);
+          controller.abort();
+        })(),
+      ),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    await expect(
+      loadPlaintextBytes(api, metadataOf(), undefined, controller.signal),
+    ).rejects.toThrow('Aborted');
+  });
+
   it('wraps a failing decrypt step in a DecryptionError', async () => {
     const api = apiWithRawBytes(new Uint8Array([0xaa, 0xbb]));
     // Web Crypto surfaces wrong-password / corrupt-ciphertext as a throw while

--- a/apps/frontend/__tests__/unit/components/filePreviewDecode.spec.ts
+++ b/apps/frontend/__tests__/unit/components/filePreviewDecode.spec.ts
@@ -117,6 +117,9 @@ describe('loadPlaintextBytes', () => {
 
     expect(api.downloadObject).toHaveBeenCalledWith(TEST_CID, {
       skipDecryption: true,
+      // The abort signal is forwarded so a preview timeout / superseded request
+      // tears down the in-flight HTTP request rather than hanging on it.
+      signal: notAborted,
     });
     expect(Array.from(result)).toEqual(Array.from(PNG_MAGIC));
     expect(mockDecryptFile).not.toHaveBeenCalled();

--- a/apps/frontend/__tests__/unit/components/filePreviewDecode.spec.ts
+++ b/apps/frontend/__tests__/unit/components/filePreviewDecode.spec.ts
@@ -1,0 +1,240 @@
+/**
+ * Unit tests for the transport-agnostic preview decode pipeline
+ * (`components/molecules/FilePreview/decode.ts`).
+ *
+ * These cover the defensive logic that makes previews work regardless of how
+ * the gateway labels the response body:
+ *   - `looksLikeZlib` — the O(1) zlib-header sniff.
+ *   - `loadPlaintextBytes` — always pulls RAW stored bytes (skipDecryption),
+ *     then decrypts/decompresses client-side, inflating only when the bytes
+ *     genuinely carry a zlib header.
+ *
+ * The SDK stream transforms are mocked the same way as `downloadObject.spec.ts`.
+ */
+
+// ---------------------------------------------------------------------------
+// Module mocks — declared before imports so Jest hoists them. decode.ts
+// dynamically imports decryptFile/decompressFile from this module.
+// ---------------------------------------------------------------------------
+
+const mockDecryptFile = jest.fn();
+const mockDecompressFile = jest.fn();
+jest.mock('@autonomys/auto-dag-data', () => ({
+  decryptFile: mockDecryptFile,
+  decompressFile: mockDecompressFile,
+}));
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+
+import zlib from 'node:zlib';
+import {
+  looksLikeZlib,
+  loadPlaintextBytes,
+} from '../../../src/components/molecules/FilePreview/decode';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const TEST_CID = 'bafkr6itest000000000000000000000000000000000000000000000000';
+
+/** Build an async iterable of Buffer chunks from one or more byte arrays. */
+const streamOf = (...buffers: Uint8Array[]): AsyncIterable<Buffer> =>
+  (async function* () {
+    for (const b of buffers) {
+      yield Buffer.from(b);
+    }
+  })();
+
+/** Single-chunk async iterable, as the SDK transforms would return. */
+const iterableOf = (bytes: Uint8Array): AsyncIterable<Buffer> => streamOf(bytes);
+
+/** Minimal Api stand-in exposing only the method decode.ts uses. */
+const apiWithRawBytes = (raw: Uint8Array) =>
+  ({
+    downloadObject: jest.fn().mockResolvedValue(streamOf(raw)),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  }) as any;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const metadataOf = (uploadOptions?: any): any => ({
+  type: 'file',
+  dataCid: TEST_CID,
+  name: 'file.bin',
+  uploadOptions: uploadOptions ?? {},
+});
+
+const PNG_MAGIC = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a]);
+const ZLIB_BYTES = new Uint8Array(zlib.deflateSync(Buffer.from('hello world')));
+const RAW_DEFLATE = new Uint8Array(
+  zlib.deflateRawSync(Buffer.from('hello world')),
+);
+const GZIP_BYTES = new Uint8Array(zlib.gzipSync(Buffer.from('hello world')));
+
+const notAborted = new AbortController().signal;
+
+// ---------------------------------------------------------------------------
+// looksLikeZlib
+// ---------------------------------------------------------------------------
+
+describe('looksLikeZlib', () => {
+  it('returns true for real zlib-wrapped (RFC 1950) data', () => {
+    expect(looksLikeZlib(ZLIB_BYTES)).toBe(true);
+  });
+
+  it('returns false for raw DEFLATE without a zlib header', () => {
+    expect(looksLikeZlib(RAW_DEFLATE)).toBe(false);
+  });
+
+  it('returns false for gzip data (0x1f 0x8b)', () => {
+    expect(looksLikeZlib(GZIP_BYTES)).toBe(false);
+  });
+
+  it('returns false for an uncompressed PNG header', () => {
+    expect(looksLikeZlib(PNG_MAGIC)).toBe(false);
+  });
+
+  it('returns false for too-short input', () => {
+    expect(looksLikeZlib(new Uint8Array([0x78]))).toBe(false);
+    expect(looksLikeZlib(new Uint8Array([]))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadPlaintextBytes
+// ---------------------------------------------------------------------------
+
+describe('loadPlaintextBytes', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('plain (no encryption/compression) returns the raw bytes untouched', async () => {
+    const api = apiWithRawBytes(PNG_MAGIC);
+
+    const result = await loadPlaintextBytes(api, metadataOf(), undefined, notAborted);
+
+    expect(api.downloadObject).toHaveBeenCalledWith(TEST_CID, {
+      skipDecryption: true,
+    });
+    expect(Array.from(result)).toEqual(Array.from(PNG_MAGIC));
+    expect(mockDecryptFile).not.toHaveBeenCalled();
+    expect(mockDecompressFile).not.toHaveBeenCalled();
+  });
+
+  it('compressed + real zlib bytes → calls decompressFile', async () => {
+    const inflated = new Uint8Array([1, 2, 3, 4]);
+    const api = apiWithRawBytes(ZLIB_BYTES);
+    mockDecompressFile.mockReturnValue(iterableOf(inflated));
+
+    const result = await loadPlaintextBytes(
+      api,
+      metadataOf({ compression: { algorithm: 'ZLIB' } }),
+      undefined,
+      notAborted,
+    );
+
+    expect(mockDecompressFile).toHaveBeenCalledTimes(1);
+    expect(mockDecompressFile).toHaveBeenCalledWith(expect.anything(), {
+      algorithm: 'ZLIB',
+    });
+    expect(Array.from(result)).toEqual(Array.from(inflated));
+  });
+
+  it('compressed flag but bytes are NOT zlib (mismatch) → passes through raw, no inflate', async () => {
+    const api = apiWithRawBytes(PNG_MAGIC);
+
+    const result = await loadPlaintextBytes(
+      api,
+      metadataOf({ compression: { algorithm: 'ZLIB' } }),
+      undefined,
+      notAborted,
+    );
+
+    expect(mockDecompressFile).not.toHaveBeenCalled();
+    expect(Array.from(result)).toEqual(Array.from(PNG_MAGIC));
+  });
+
+  it('encrypted without a password throws before any download work', async () => {
+    const api = apiWithRawBytes(PNG_MAGIC);
+
+    await expect(
+      loadPlaintextBytes(
+        api,
+        metadataOf({ encryption: { algorithm: 'AES_256_GCM' } }),
+        undefined,
+        notAborted,
+      ),
+    ).rejects.toThrow('Password is required to decrypt the file');
+  });
+
+  it('encrypted + compressed → decrypts, then inflates when decrypted bytes are zlib', async () => {
+    const plaintext = new Uint8Array([9, 9, 9]);
+    const api = apiWithRawBytes(new Uint8Array([0xaa, 0xbb])); // ciphertext
+    // decryptFile yields zlib-wrapped bytes; decompressFile yields plaintext.
+    mockDecryptFile.mockReturnValue(iterableOf(ZLIB_BYTES));
+    mockDecompressFile.mockReturnValue(iterableOf(plaintext));
+
+    const result = await loadPlaintextBytes(
+      api,
+      metadataOf({
+        encryption: { algorithm: 'AES_256_GCM' },
+        compression: { algorithm: 'ZLIB' },
+      }),
+      'secret',
+      notAborted,
+    );
+
+    expect(mockDecryptFile).toHaveBeenCalledWith(expect.anything(), 'secret', {
+      algorithm: 'AES_256_GCM',
+    });
+    expect(mockDecompressFile).toHaveBeenCalledTimes(1);
+    expect(Array.from(result)).toEqual(Array.from(plaintext));
+  });
+
+  it('encrypted + compressed but decrypted bytes are NOT zlib → decrypts only, no inflate', async () => {
+    const plaintext = new Uint8Array([...PNG_MAGIC]);
+    const api = apiWithRawBytes(new Uint8Array([0xaa, 0xbb]));
+    mockDecryptFile.mockReturnValue(iterableOf(plaintext));
+
+    const result = await loadPlaintextBytes(
+      api,
+      metadataOf({
+        encryption: { algorithm: 'AES_256_GCM' },
+        compression: { algorithm: 'ZLIB' },
+      }),
+      'secret',
+      notAborted,
+    );
+
+    expect(mockDecryptFile).toHaveBeenCalledTimes(1);
+    expect(mockDecompressFile).not.toHaveBeenCalled();
+    expect(Array.from(result)).toEqual(Array.from(plaintext));
+  });
+
+  it('encrypted only (no compression) → decrypts, never inflates', async () => {
+    const plaintext = new Uint8Array([7, 7]);
+    const api = apiWithRawBytes(new Uint8Array([0xaa, 0xbb]));
+    mockDecryptFile.mockReturnValue(iterableOf(plaintext));
+
+    const result = await loadPlaintextBytes(
+      api,
+      metadataOf({ encryption: { algorithm: 'AES_256_GCM' } }),
+      'secret',
+      notAborted,
+    );
+
+    expect(mockDecryptFile).toHaveBeenCalledTimes(1);
+    expect(mockDecompressFile).not.toHaveBeenCalled();
+    expect(Array.from(result)).toEqual(Array.from(plaintext));
+  });
+
+  it('aborts collection when the signal is already aborted', async () => {
+    const api = apiWithRawBytes(PNG_MAGIC);
+    const aborted = AbortSignal.abort();
+
+    await expect(
+      loadPlaintextBytes(api, metadataOf(), undefined, aborted),
+    ).rejects.toThrow('Aborted');
+  });
+});

--- a/apps/frontend/__tests__/unit/components/filePreviewDecode.spec.ts
+++ b/apps/frontend/__tests__/unit/components/filePreviewDecode.spec.ts
@@ -32,6 +32,7 @@ import zlib from 'node:zlib';
 import {
   looksLikeZlib,
   loadPlaintextBytes,
+  DecryptionError,
 } from '../../../src/components/molecules/FilePreview/decode';
 
 // ---------------------------------------------------------------------------
@@ -155,7 +156,7 @@ describe('loadPlaintextBytes', () => {
     expect(Array.from(result)).toEqual(Array.from(PNG_MAGIC));
   });
 
-  it('encrypted without a password throws before any download work', async () => {
+  it('encrypted without a password throws a DecryptionError before any download work', async () => {
     const api = apiWithRawBytes(PNG_MAGIC);
 
     await expect(
@@ -166,6 +167,14 @@ describe('loadPlaintextBytes', () => {
         notAborted,
       ),
     ).rejects.toThrow('Password is required to decrypt the file');
+    await expect(
+      loadPlaintextBytes(
+        api,
+        metadataOf({ encryption: { algorithm: 'AES_256_GCM' } }),
+        undefined,
+        notAborted,
+      ),
+    ).rejects.toBeInstanceOf(DecryptionError);
   });
 
   it('encrypted + compressed → decrypts, then inflates when decrypted bytes are zlib', async () => {
@@ -236,5 +245,72 @@ describe('loadPlaintextBytes', () => {
     await expect(
       loadPlaintextBytes(api, metadataOf(), undefined, aborted),
     ).rejects.toThrow('Aborted');
+  });
+
+  it('wraps a failing decrypt step in a DecryptionError', async () => {
+    const api = apiWithRawBytes(new Uint8Array([0xaa, 0xbb]));
+    // Web Crypto surfaces wrong-password / corrupt-ciphertext as a throw while
+    // the transform stream is consumed.
+    mockDecryptFile.mockReturnValue(
+      (async function* () {
+        throw new Error('unable to authenticate data');
+        // eslint-disable-next-line no-unreachable
+        yield Buffer.from([]);
+      })(),
+    );
+
+    const promise = loadPlaintextBytes(
+      api,
+      metadataOf({ encryption: { algorithm: 'AES_256_GCM' } }),
+      'wrong-password',
+      notAborted,
+    );
+
+    await expect(promise).rejects.toBeInstanceOf(DecryptionError);
+    await expect(promise).rejects.toThrow(
+      'Invalid password or decryption failed',
+    );
+  });
+
+  it('does NOT mask a download/network failure on an encrypted file as a DecryptionError', async () => {
+    const networkError = new Error('Failed to fetch file: 404 Not Found');
+    const api = {
+      downloadObject: jest.fn().mockRejectedValue(networkError),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const promise = loadPlaintextBytes(
+      api,
+      metadataOf({ encryption: { algorithm: 'AES_256_GCM' } }),
+      'secret',
+      notAborted,
+    );
+
+    await expect(promise).rejects.toBe(networkError);
+    await expect(promise).rejects.not.toBeInstanceOf(DecryptionError);
+    // The decrypt step is never reached when the download itself fails.
+    expect(mockDecryptFile).not.toHaveBeenCalled();
+  });
+
+  it('propagates an abort during the decrypt step as an AbortError, not a DecryptionError', async () => {
+    const controller = new AbortController();
+    const api = apiWithRawBytes(new Uint8Array([0xaa, 0xbb]));
+    // The decrypt stream observes an abort mid-flight.
+    mockDecryptFile.mockReturnValue(
+      (async function* () {
+        controller.abort();
+        yield Buffer.from([0x01]);
+      })(),
+    );
+
+    const promise = loadPlaintextBytes(
+      api,
+      metadataOf({ encryption: { algorithm: 'AES_256_GCM' } }),
+      'secret',
+      controller.signal,
+    );
+
+    await expect(promise).rejects.toThrow('Aborted');
+    await expect(promise).rejects.not.toBeInstanceOf(DecryptionError);
   });
 });

--- a/apps/frontend/src/components/molecules/FilePreview/decode.ts
+++ b/apps/frontend/src/components/molecules/FilePreview/decode.ts
@@ -1,0 +1,98 @@
+import type { OffchainMetadata } from '@autonomys/auto-dag-data';
+import type { Api } from '../../../services/api';
+
+// Collect a download stream into a single contiguous byte array, bailing out
+// promptly if the preview request has been superseded/aborted.
+export const collectStream = async (
+  iterable: AsyncIterable<Buffer>,
+  signal: AbortSignal,
+): Promise<ArrayBuffer> => {
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of iterable) {
+    if (signal.aborted) {
+      throw new DOMException('Aborted', 'AbortError');
+    }
+    chunks.push(new Uint8Array(chunk));
+  }
+  const totalLength = chunks.reduce((acc, c) => acc + c.length, 0);
+  const combined = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const c of chunks) {
+    combined.set(c, offset);
+    offset += c.length;
+  }
+  return combined.buffer as ArrayBuffer;
+};
+
+// Cheap O(1) zlib (RFC 1950) header check matching what the SDK's Zlib
+// compressor emits on upload. Some objects are flagged `compression: ZLIB`
+// while their stored bytes are actually uncompressed (an upload-side mismatch);
+// sniffing lets us inflate only when the data really is compressed, instead of
+// attempting decompression and catching a thrown FlateError after the fact.
+export const looksLikeZlib = (bytes: Uint8Array): boolean =>
+  bytes.length >= 2 &&
+  (bytes[0] & 0x0f) === 8 &&
+  ((bytes[0] << 8) | bytes[1]) % 31 === 0;
+
+// Push a single in-memory buffer through one of the SDK's streaming transforms
+// (decrypt / decompress) and collect the result back into bytes. Feeding the
+// whole buffer as one chunk mirrors what the SDK's own `decryptFileData` does.
+const runStreamTransform = async (
+  bytes: Uint8Array,
+  transform: (input: AsyncIterable<Buffer>) => AsyncIterable<Buffer>,
+  signal: AbortSignal,
+): Promise<Uint8Array> => {
+  const source = (async function* () {
+    yield Buffer.from(bytes);
+  })();
+  return new Uint8Array(await collectStream(transform(source), signal));
+};
+
+// Resolve a previewable file to its plaintext bytes in a transport-agnostic way.
+// We always pull the RAW stored bytes (downloadObject uses ignoreEncoding=true,
+// and skipDecryption avoids any SDK-side transform), then decrypt/decompress
+// here. This makes previews work no matter how the gateway serves the body:
+// whether it decompresses server-side, mislabels it with `Content-Encoding:
+// deflate`, or returns the bytes verbatim — we never rely on the wire encoding.
+export const loadPlaintextBytes = async (
+  api: Api,
+  metadata: OffchainMetadata,
+  password: string | undefined,
+  signal: AbortSignal,
+): Promise<Uint8Array> => {
+  let bytes: Uint8Array = new Uint8Array(
+    await collectStream(
+      await api.downloadObject(metadata.dataCid, { skipDecryption: true }),
+      signal,
+    ),
+  );
+
+  // Stored layout is encrypt(compress(data)), so decrypt before decompressing.
+  const encryption = metadata.uploadOptions?.encryption;
+  if (encryption) {
+    if (!password) {
+      throw new Error('Password is required to decrypt the file');
+    }
+    const { decryptFile } = await import('@autonomys/auto-dag-data');
+    bytes = await runStreamTransform(
+      bytes,
+      (input) =>
+        decryptFile(input, password, { algorithm: encryption.algorithm }),
+      signal,
+    );
+  }
+
+  // Inflate only when the (now-decrypted) bytes actually carry a zlib header —
+  // some objects are flagged compressed but were stored raw.
+  const compression = metadata.uploadOptions?.compression;
+  if (compression && looksLikeZlib(bytes)) {
+    const { decompressFile } = await import('@autonomys/auto-dag-data');
+    bytes = await runStreamTransform(
+      bytes,
+      (input) => decompressFile(input, { algorithm: compression.algorithm }),
+      signal,
+    );
+  }
+
+  return bytes;
+};

--- a/apps/frontend/src/components/molecules/FilePreview/decode.ts
+++ b/apps/frontend/src/components/molecules/FilePreview/decode.ts
@@ -30,6 +30,12 @@ export const collectStream = async (
     }
     chunks.push(new Uint8Array(chunk));
   }
+  // Re-check after the stream drains: an abort that lands between the final
+  // chunk and the return would otherwise slip through, letting the caller
+  // commit data the preview meant to cancel.
+  if (signal.aborted) {
+    throw new DOMException('Aborted', 'AbortError');
+  }
   const totalLength = chunks.reduce((acc, c) => acc + c.length, 0);
   const combined = new Uint8Array(totalLength);
   let offset = 0;

--- a/apps/frontend/src/components/molecules/FilePreview/decode.ts
+++ b/apps/frontend/src/components/molecules/FilePreview/decode.ts
@@ -1,6 +1,22 @@
 import type { OffchainMetadata } from '@autonomys/auto-dag-data';
 import type { Api } from '../../../services/api';
 
+// Marks a failure that originated specifically from the client-side decryption
+// step (missing password, wrong password, corrupt ciphertext / failed auth
+// tag). Callers use this to distinguish a genuine password problem from
+// unrelated failures in the same pipeline — download/network errors, 404s,
+// download-limit responses, timeouts, or post-decrypt decompression failures —
+// which must NOT be reported to the user as "invalid password".
+export class DecryptionError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message);
+    this.name = 'DecryptionError';
+    if (options?.cause !== undefined) {
+      this.cause = options.cause;
+    }
+  }
+}
+
 // Collect a download stream into a single contiguous byte array, bailing out
 // promptly if the preview request has been superseded/aborted.
 export const collectStream = async (
@@ -71,15 +87,26 @@ export const loadPlaintextBytes = async (
   const encryption = metadata.uploadOptions?.encryption;
   if (encryption) {
     if (!password) {
-      throw new Error('Password is required to decrypt the file');
+      throw new DecryptionError('Password is required to decrypt the file');
     }
     const { decryptFile } = await import('@autonomys/auto-dag-data');
-    bytes = await runStreamTransform(
-      bytes,
-      (input) =>
-        decryptFile(input, password, { algorithm: encryption.algorithm }),
-      signal,
-    );
+    try {
+      bytes = await runStreamTransform(
+        bytes,
+        (input) =>
+          decryptFile(input, password, { algorithm: encryption.algorithm }),
+        signal,
+      );
+    } catch (err) {
+      // Don't swallow aborts (timeout / superseded preview) as a password
+      // failure — only genuine decrypt failures become DecryptionError.
+      if (err instanceof DOMException && err.name === 'AbortError') {
+        throw err;
+      }
+      throw new DecryptionError('Invalid password or decryption failed', {
+        cause: err,
+      });
+    }
   }
 
   // Inflate only when the (now-decrypted) bytes actually carry a zlib header —

--- a/apps/frontend/src/components/molecules/FilePreview/decode.ts
+++ b/apps/frontend/src/components/molecules/FilePreview/decode.ts
@@ -78,7 +78,14 @@ export const loadPlaintextBytes = async (
 ): Promise<Uint8Array> => {
   let bytes: Uint8Array = new Uint8Array(
     await collectStream(
-      await api.downloadObject(metadata.dataCid, { skipDecryption: true }),
+      // Pass `signal` so an abort (preview timeout / superseded request) tears
+      // down the in-flight HTTP request immediately, instead of leaving it to
+      // hang until the gateway responds — at which point `collectStream` would
+      // only notice the abort after the download had already completed.
+      await api.downloadObject(metadata.dataCid, {
+        skipDecryption: true,
+        signal,
+      }),
       signal,
     ),
   );

--- a/apps/frontend/src/components/molecules/FilePreview/index.tsx
+++ b/apps/frontend/src/components/molecules/FilePreview/index.tsx
@@ -30,6 +30,27 @@ export const FilePreview = ({ metadata }: { metadata: OffchainMetadata }) => {
   const [textContent, setTextContent] = useState<string | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
 
+  // Reset all preview state when the previewed object changes. The component is
+  // reused (not remounted) when navigating between files, so without this a
+  // stale decrypted blob — and a stale `isDecrypted` flag — would carry over to
+  // the next file. In particular `isDecrypted` left as `true` makes the
+  // no-password branch of `fetchFile` bail out early and render the previous
+  // file's decrypted content under the new file's metadata. Done during render
+  // (the React "adjust state on prop change" pattern) so the reset is visible to
+  // the `fetchFile` invocation triggered by the same metadata change.
+  const previewedCidRef = useRef(metadata.dataCid);
+  if (previewedCidRef.current !== metadata.dataCid) {
+    previewedCidRef.current = metadata.dataCid;
+    abortControllerRef.current?.abort();
+    setIsFilePreview(false);
+    setLoading(true);
+    setError(null);
+    setDecryptionError(null);
+    setIsDecrypted(false);
+    setFile(null);
+    setTextContent(null);
+  }
+
   const safeSetTextContent = useCallback((text: string) => {
     setTextContent(sanitizeHTML(text));
   }, []);

--- a/apps/frontend/src/components/molecules/FilePreview/index.tsx
+++ b/apps/frontend/src/components/molecules/FilePreview/index.tsx
@@ -13,106 +13,11 @@ import {
   NetworkId as AutoDriveNetworkId,
 } from '@auto-drive/ui';
 import { sanitizeHTML } from '../../../utils/sanitizeHTML';
-import { Api } from '../../../services/api';
+import { loadPlaintextBytes } from './decode';
+
 const PREVIEW_FETCH_TIMEOUT_MS = 15_000;
 
 const MAX_PREVIEW_SIZE = BigInt(100 * 1024 * 1024); // 100 MB (preview cap)
-
-// Collect a download stream into a single contiguous byte array, bailing out
-// promptly if the preview request has been superseded/aborted.
-const collectStream = async (
-  iterable: AsyncIterable<Buffer>,
-  signal: AbortSignal,
-): Promise<ArrayBuffer> => {
-  const chunks: Uint8Array[] = [];
-  for await (const chunk of iterable) {
-    if (signal.aborted) {
-      throw new DOMException('Aborted', 'AbortError');
-    }
-    chunks.push(new Uint8Array(chunk));
-  }
-  const totalLength = chunks.reduce((acc, c) => acc + c.length, 0);
-  const combined = new Uint8Array(totalLength);
-  let offset = 0;
-  for (const c of chunks) {
-    combined.set(c, offset);
-    offset += c.length;
-  }
-  return combined.buffer as ArrayBuffer;
-};
-
-// Cheap O(1) zlib (RFC 1950) header check matching what the SDK's Zlib
-// compressor emits on upload. Some objects are flagged `compression: ZLIB`
-// while their stored bytes are actually uncompressed (an upload-side mismatch);
-// sniffing lets us inflate only when the data really is compressed, instead of
-// attempting decompression and catching a thrown FlateError after the fact.
-const looksLikeZlib = (bytes: Uint8Array): boolean =>
-  bytes.length >= 2 &&
-  (bytes[0] & 0x0f) === 8 &&
-  ((bytes[0] << 8) | bytes[1]) % 31 === 0;
-
-// Push a single in-memory buffer through one of the SDK's streaming transforms
-// (decrypt / decompress) and collect the result back into bytes. Feeding the
-// whole buffer as one chunk mirrors what the SDK's own `decryptFileData` does.
-const runStreamTransform = async (
-  bytes: Uint8Array,
-  transform: (input: AsyncIterable<Buffer>) => AsyncIterable<Buffer>,
-  signal: AbortSignal,
-): Promise<Uint8Array> => {
-  const source = (async function* () {
-    yield Buffer.from(bytes);
-  })();
-  return new Uint8Array(await collectStream(transform(source), signal));
-};
-
-// Resolve a previewable file to its plaintext bytes in a transport-agnostic way.
-// We always pull the RAW stored bytes (downloadObject uses ignoreEncoding=true,
-// and skipDecryption avoids any SDK-side transform), then decrypt/decompress
-// here. This makes previews work no matter how the gateway serves the body:
-// whether it decompresses server-side, mislabels it with `Content-Encoding:
-// deflate`, or returns the bytes verbatim — we never rely on the wire encoding.
-const loadPlaintextBytes = async (
-  api: Api,
-  metadata: OffchainMetadata,
-  password: string | undefined,
-  signal: AbortSignal,
-): Promise<Uint8Array> => {
-  let bytes: Uint8Array = new Uint8Array(
-    await collectStream(
-      await api.downloadObject(metadata.dataCid, { skipDecryption: true }),
-      signal,
-    ),
-  );
-
-  // Stored layout is encrypt(compress(data)), so decrypt before decompressing.
-  const encryption = metadata.uploadOptions?.encryption;
-  if (encryption) {
-    if (!password) {
-      throw new Error('Password is required to decrypt the file');
-    }
-    const { decryptFile } = await import('@autonomys/auto-dag-data');
-    bytes = await runStreamTransform(
-      bytes,
-      (input) =>
-        decryptFile(input, password, { algorithm: encryption.algorithm }),
-      signal,
-    );
-  }
-
-  // Inflate only when the (now-decrypted) bytes actually carry a zlib header —
-  // some objects are flagged compressed but were stored raw.
-  const compression = metadata.uploadOptions?.compression;
-  if (compression && looksLikeZlib(bytes)) {
-    const { decompressFile } = await import('@autonomys/auto-dag-data');
-    bytes = await runStreamTransform(
-      bytes,
-      (input) => decompressFile(input, { algorithm: compression.algorithm }),
-      signal,
-    );
-  }
-
-  return bytes;
-};
 
 export const FilePreview = ({ metadata }: { metadata: OffchainMetadata }) => {
   const { network, api } = useNetwork();
@@ -171,7 +76,15 @@ export const FilePreview = ({ metadata }: { metadata: OffchainMetadata }) => {
       }
 
       // Encrypted files need a password before we can fetch + decrypt.
-      if (isEncrypted && !password && !isDecrypted) {
+      if (isEncrypted && !password) {
+        // Already decrypted: a state update (e.g. setIsDecrypted(true)) re-ran
+        // this effect with no password. Keep the existing decrypted preview
+        // rather than re-fetching, which would throw for lack of a password
+        // and surface a bogus "invalid password" error over a working preview.
+        if (isDecrypted) {
+          return;
+        }
+        // No password yet — show the password prompt instead of a preview.
         setIsFilePreview(false);
         setLoading(false);
         return;

--- a/apps/frontend/src/components/molecules/FilePreview/index.tsx
+++ b/apps/frontend/src/components/molecules/FilePreview/index.tsx
@@ -42,6 +42,14 @@ export const FilePreview = ({ metadata }: { metadata: OffchainMetadata }) => {
   if (previewedCidRef.current !== metadata.dataCid) {
     previewedCidRef.current = metadata.dataCid;
     abortControllerRef.current?.abort();
+    // Drop the ref to the aborted controller. The superseded guards in
+    // `fetchFile` compare controller identity, so a lingering ref would make the
+    // abandoned request still look "current": its late AbortError would clear
+    // `isFilePreview`/`loading` for the new file, and a late success could
+    // commit the previous file's blob under the new metadata. This matters most
+    // when the new file takes an early-return path (fast-path render,
+    // not-previewable, encrypted-without-password) that never reassigns the ref.
+    abortControllerRef.current = null;
     setIsFilePreview(false);
     setLoading(true);
     setError(null);

--- a/apps/frontend/src/components/molecules/FilePreview/index.tsx
+++ b/apps/frontend/src/components/molecules/FilePreview/index.tsx
@@ -171,12 +171,30 @@ export const FilePreview = ({ metadata }: { metadata: OffchainMetadata }) => {
           uploadOptions: metadata.uploadOptions ?? {},
           isEncrypted: false,
         });
+        // Re-check after every await: a file switch (which resets the ref) or a
+        // newer fetch can land while `processFileData`/`blob.text()` are pending.
+        // Without re-checking, a late success would commit this (now stale) blob
+        // under the newly selected file's metadata.
+        if (abortControllerRef.current !== controller) {
+          return;
+        }
+
+        // Read parsed text before committing anything, so the post-await guard
+        // covers it too and we never commit a half-updated preview.
+        let parsedText: string | null = null;
+        if (needsContentParsing(metadata)) {
+          parsedText = await blob.text();
+          if (abortControllerRef.current !== controller) {
+            return;
+          }
+        }
+
         setFile(blob);
         if (isEncrypted) {
           setIsDecrypted(true);
         }
-        if (needsContentParsing(metadata)) {
-          safeSetTextContent(await blob.text());
+        if (parsedText !== null) {
+          safeSetTextContent(parsedText);
         }
         setLoading(false);
       } catch (error) {

--- a/apps/frontend/src/components/molecules/FilePreview/index.tsx
+++ b/apps/frontend/src/components/molecules/FilePreview/index.tsx
@@ -14,12 +14,72 @@ import {
   NetworkId as AutoDriveNetworkId,
 } from '@auto-drive/ui';
 import { sanitizeHTML } from '../../../utils/sanitizeHTML';
+import { Api } from '../../../services/api';
 const PREVIEW_FETCH_TIMEOUT_MS = 15_000;
 
-const MAX_PREVIEW_SIZE = BigInt(100 * 1024 * 1024); // 100 MB
+const MAX_PREVIEW_SIZE = BigInt(100 * 1024 * 1024); // 100 MB (preview cap)
+
+// Collect a download stream into a single contiguous byte array, bailing out
+// promptly if the preview request has been superseded/aborted.
+const collectStream = async (
+  iterable: AsyncIterable<Buffer>,
+  signal: AbortSignal,
+): Promise<ArrayBuffer> => {
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of iterable) {
+    if (signal.aborted) {
+      throw new DOMException('Aborted', 'AbortError');
+    }
+    chunks.push(new Uint8Array(chunk));
+  }
+  const totalLength = chunks.reduce((acc, c) => acc + c.length, 0);
+  const combined = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const c of chunks) {
+    combined.set(c, offset);
+    offset += c.length;
+  }
+  return combined.buffer as ArrayBuffer;
+};
+
+// fflate throws FlateError (e.g. "invalid zlib data") when a file is flagged as
+// compressed but its stored bytes are actually raw/uncompressed.
+const isDecompressionError = (error: unknown): boolean => {
+  const message = error instanceof Error ? error.message.toLowerCase() : '';
+  const name = error instanceof Error ? error.name : '';
+  return (
+    message.includes('invalid zlib') ||
+    message.includes('invalid deflate') ||
+    message.includes('invalid block') ||
+    name === 'FlateError'
+  );
+};
+
+// Compressed (non-encrypted) files can't be previewed from the public gateway:
+// it serves them with `Content-Encoding: deflate`, which the browser fails to
+// decode. Stream them through the backend download API (raw bytes via
+// ignoreEncoding=true) and decompress client-side instead. Falls back to the
+// raw bytes when the stored data isn't actually compressed despite metadata.
+const fetchDecompressedBytes = async (
+  api: Api,
+  cid: string,
+  signal: AbortSignal,
+): Promise<ArrayBuffer> => {
+  try {
+    return await collectStream(await api.downloadObject(cid), signal);
+  } catch (error) {
+    if (signal.aborted || !isDecompressionError(error)) {
+      throw error;
+    }
+    return collectStream(
+      await api.downloadObject(cid, { skipDecryption: true }),
+      signal,
+    );
+  }
+};
 
 export const FilePreview = ({ metadata }: { metadata: OffchainMetadata }) => {
-  const { network } = useNetwork();
+  const { network, api } = useNetwork();
   const [isFilePreview, setIsFilePreview] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -45,6 +105,17 @@ export const FilePreview = ({ metadata }: { metadata: OffchainMetadata }) => {
 
   const gatewayUrl = EXTERNAL_ROUTES.gatewayObjectDownload(metadata.dataCid);
 
+  const isEncrypted = !!metadata.uploadOptions?.encryption;
+  const isCompressed = !!metadata.uploadOptions?.compression;
+
+  // The public gateway serves compressed (non-encrypted) files with
+  // `Content-Encoding: deflate`. Browsers fail to decode that response
+  // (broken <img>/ERR_CONTENT_DECODING_FAILED), so we must not hand the raw
+  // gateway URL to the previewer for those files — it would render the broken
+  // response instead of the decompressed blob we build below. The "View on
+  // gateway" link is hidden along with it since it is broken in-browser too.
+  const previewGatewayUrl = isCompressed && !isEncrypted ? null : gatewayUrl;
+
   const isPreviewable = useMemo(() => {
     if (metadata.type !== 'file') return false;
     if (metadata.totalSize > MAX_PREVIEW_SIZE) return false;
@@ -64,15 +135,17 @@ export const FilePreview = ({ metadata }: { metadata: OffchainMetadata }) => {
       }
 
       // If file is encrypted and no password provided, don't fetch
-      if (metadata.uploadOptions?.encryption && !password && !isDecrypted) {
+      if (isEncrypted && !password && !isDecrypted) {
         setIsFilePreview(false);
         setLoading(false);
         return;
       }
 
-      // For non-encrypted files that can be displayed directly,
-      // use gateway URL directly (no fetch needed)
-      if (!metadata.uploadOptions?.encryption && canDisplayDirectly(metadata)) {
+      // For non-encrypted, uncompressed files that can be displayed directly,
+      // use the gateway URL directly (no fetch needed). Compressed files are
+      // excluded here: the gateway returns them with `Content-Encoding: deflate`,
+      // which browsers cannot decode, so they take the decompress path below.
+      if (!isEncrypted && !isCompressed && canDisplayDirectly(metadata)) {
         setIsFilePreview(true);
         setFile(null);
         setLoading(false);
@@ -84,7 +157,7 @@ export const FilePreview = ({ metadata }: { metadata: OffchainMetadata }) => {
       const controller = new AbortController();
       abortControllerRef.current = controller;
 
-      // Abort the preview fetch if the gateway doesn't respond quickly.
+      // Abort the preview fetch if retrieval doesn't complete quickly.
       // Non-cached archived files can take 20+ minutes to reconstruct
       // from DSN — showing a loading spinner that long is worse than
       // showing no preview at all.
@@ -97,6 +170,36 @@ export const FilePreview = ({ metadata }: { metadata: OffchainMetadata }) => {
       setLoading(true);
 
       try {
+        // Compressed (non-encrypted) files can't be previewed via the gateway
+        // URL: the gateway sets `Content-Encoding: deflate` and the browser
+        // fails to decode it. Retrieve + decompress the bytes via the backend
+        // download API, then build a blob for the previewer.
+        if (!isEncrypted && isCompressed) {
+          const bytes = await fetchDecompressedBytes(
+            api,
+            metadata.dataCid,
+            controller.signal,
+          );
+          clearTimeout(timeoutId);
+          if (abortControllerRef.current !== controller) {
+            return;
+          }
+
+          const blob = await processFileData({
+            dataArrayBuffer: bytes,
+            name: metadata.name ?? '',
+            rawData: '',
+            uploadOptions: metadata.uploadOptions ?? {},
+            isEncrypted: false,
+          });
+          setFile(blob);
+          if (needsContentParsing(metadata)) {
+            safeSetTextContent(await blob.text());
+          }
+          setLoading(false);
+          return;
+        }
+
         const response = await fetch(gatewayUrl, {
           signal: controller.signal,
         });
@@ -142,11 +245,14 @@ export const FilePreview = ({ metadata }: { metadata: OffchainMetadata }) => {
         setLoading(false);
       } catch (error) {
         clearTimeout(timeoutId);
+        // A newer fetchFile call has superseded this one — don't touch state.
+        // This must run regardless of the error type: aborting a superseded
+        // request can surface as a decompression/network error rather than an
+        // AbortError, because the underlying download is not itself cancelable.
+        if (abortControllerRef.current !== controller) {
+          return;
+        }
         if (error instanceof DOMException && error.name === 'AbortError') {
-          if (abortControllerRef.current !== controller) {
-            // A newer fetchFile call replaced us — don't touch state.
-            return;
-          }
           // Our own timeout fired — hide the preview.
           setIsFilePreview(false);
           setLoading(false);
@@ -159,7 +265,16 @@ export const FilePreview = ({ metadata }: { metadata: OffchainMetadata }) => {
         setLoading(false);
       }
     },
-    [metadata, isDecrypted, isPreviewable, gatewayUrl, safeSetTextContent],
+    [
+      metadata,
+      isDecrypted,
+      isPreviewable,
+      isEncrypted,
+      isCompressed,
+      gatewayUrl,
+      api,
+      safeSetTextContent,
+    ],
   );
 
   useEffect(() => {
@@ -180,7 +295,7 @@ export const FilePreview = ({ metadata }: { metadata: OffchainMetadata }) => {
       decryptionError={decryptionError}
       isFilePreview={isFilePreview}
       textContent={textContent}
-      gatewayUrl={gatewayUrl}
+      gatewayUrl={previewGatewayUrl}
       handleDecrypt={fetchFile}
     />
   );

--- a/apps/frontend/src/components/molecules/FilePreview/index.tsx
+++ b/apps/frontend/src/components/molecules/FilePreview/index.tsx
@@ -13,7 +13,7 @@ import {
   NetworkId as AutoDriveNetworkId,
 } from '@auto-drive/ui';
 import { sanitizeHTML } from '../../../utils/sanitizeHTML';
-import { loadPlaintextBytes } from './decode';
+import { loadPlaintextBytes, DecryptionError } from './decode';
 
 const PREVIEW_FETCH_TIMEOUT_MS = 15_000;
 
@@ -186,10 +186,13 @@ export const FilePreview = ({ metadata }: { metadata: OffchainMetadata }) => {
           setLoading(false);
           return;
         }
-        // Encrypted files surface a dedicated message + inline password retry,
-        // since the most likely failure here is a wrong password.
-        if (isEncrypted) {
-          setDecryptionError('Invalid password or decryption failed');
+        // Only a genuine decryption failure (missing/wrong password, corrupt
+        // ciphertext) gets the dedicated message + inline password retry. Other
+        // failures on an encrypted file — network errors, 404s, download
+        // limits, post-decrypt decompression failures — must surface as a real
+        // error rather than blaming the password the user already got right.
+        if (error instanceof DecryptionError) {
+          setDecryptionError(error.message);
           setLoading(false);
           return;
         }

--- a/apps/frontend/src/components/molecules/FilePreview/index.tsx
+++ b/apps/frontend/src/components/molecules/FilePreview/index.tsx
@@ -5,7 +5,6 @@ import {
   canDisplayDirectly,
   needsContentParsing,
   processFileData,
-  decryptFileData,
 } from '@autonomys/auto-dag-data';
 import { useNetwork } from '../../../contexts/network';
 import { NetworkId as AutoUtilsNetworkId } from '@autonomys/auto-utils';
@@ -42,40 +41,77 @@ const collectStream = async (
   return combined.buffer as ArrayBuffer;
 };
 
-// fflate throws FlateError (e.g. "invalid zlib data") when a file is flagged as
-// compressed but its stored bytes are actually raw/uncompressed.
-const isDecompressionError = (error: unknown): boolean => {
-  const message = error instanceof Error ? error.message.toLowerCase() : '';
-  const name = error instanceof Error ? error.name : '';
-  return (
-    message.includes('invalid zlib') ||
-    message.includes('invalid deflate') ||
-    message.includes('invalid block') ||
-    name === 'FlateError'
-  );
+// Cheap O(1) zlib (RFC 1950) header check matching what the SDK's Zlib
+// compressor emits on upload. Some objects are flagged `compression: ZLIB`
+// while their stored bytes are actually uncompressed (an upload-side mismatch);
+// sniffing lets us inflate only when the data really is compressed, instead of
+// attempting decompression and catching a thrown FlateError after the fact.
+const looksLikeZlib = (bytes: Uint8Array): boolean =>
+  bytes.length >= 2 &&
+  (bytes[0] & 0x0f) === 8 &&
+  ((bytes[0] << 8) | bytes[1]) % 31 === 0;
+
+// Push a single in-memory buffer through one of the SDK's streaming transforms
+// (decrypt / decompress) and collect the result back into bytes. Feeding the
+// whole buffer as one chunk mirrors what the SDK's own `decryptFileData` does.
+const runStreamTransform = async (
+  bytes: Uint8Array,
+  transform: (input: AsyncIterable<Buffer>) => AsyncIterable<Buffer>,
+  signal: AbortSignal,
+): Promise<Uint8Array> => {
+  const source = (async function* () {
+    yield Buffer.from(bytes);
+  })();
+  return new Uint8Array(await collectStream(transform(source), signal));
 };
 
-// Compressed (non-encrypted) files can't be previewed from the public gateway:
-// it serves them with `Content-Encoding: deflate`, which the browser fails to
-// decode. Stream them through the backend download API (raw bytes via
-// ignoreEncoding=true) and decompress client-side instead. Falls back to the
-// raw bytes when the stored data isn't actually compressed despite metadata.
-const fetchDecompressedBytes = async (
+// Resolve a previewable file to its plaintext bytes in a transport-agnostic way.
+// We always pull the RAW stored bytes (downloadObject uses ignoreEncoding=true,
+// and skipDecryption avoids any SDK-side transform), then decrypt/decompress
+// here. This makes previews work no matter how the gateway serves the body:
+// whether it decompresses server-side, mislabels it with `Content-Encoding:
+// deflate`, or returns the bytes verbatim — we never rely on the wire encoding.
+const loadPlaintextBytes = async (
   api: Api,
-  cid: string,
+  metadata: OffchainMetadata,
+  password: string | undefined,
   signal: AbortSignal,
-): Promise<ArrayBuffer> => {
-  try {
-    return await collectStream(await api.downloadObject(cid), signal);
-  } catch (error) {
-    if (signal.aborted || !isDecompressionError(error)) {
-      throw error;
+): Promise<Uint8Array> => {
+  let bytes: Uint8Array = new Uint8Array(
+    await collectStream(
+      await api.downloadObject(metadata.dataCid, { skipDecryption: true }),
+      signal,
+    ),
+  );
+
+  // Stored layout is encrypt(compress(data)), so decrypt before decompressing.
+  const encryption = metadata.uploadOptions?.encryption;
+  if (encryption) {
+    if (!password) {
+      throw new Error('Password is required to decrypt the file');
     }
-    return collectStream(
-      await api.downloadObject(cid, { skipDecryption: true }),
+    const { decryptFile } = await import('@autonomys/auto-dag-data');
+    bytes = await runStreamTransform(
+      bytes,
+      (input) =>
+        decryptFile(input, password, { algorithm: encryption.algorithm }),
       signal,
     );
   }
+
+  // Inflate only when the (now-decrypted) bytes actually carry a zlib header —
+  // some objects are flagged compressed but were stored raw.
+  const compression = metadata.uploadOptions?.compression;
+  if (compression && looksLikeZlib(bytes)) {
+    const { decompressFile } = await import('@autonomys/auto-dag-data');
+    bytes = await runStreamTransform(
+      bytes,
+      (input) => decompressFile(input, { algorithm: compression.algorithm }),
+      signal,
+    );
+  }
+
+  return bytes;
 };
 
 export const FilePreview = ({ metadata }: { metadata: OffchainMetadata }) => {
@@ -134,17 +170,17 @@ export const FilePreview = ({ metadata }: { metadata: OffchainMetadata }) => {
         return;
       }
 
-      // If file is encrypted and no password provided, don't fetch
+      // Encrypted files need a password before we can fetch + decrypt.
       if (isEncrypted && !password && !isDecrypted) {
         setIsFilePreview(false);
         setLoading(false);
         return;
       }
 
-      // For non-encrypted, uncompressed files that can be displayed directly,
-      // use the gateway URL directly (no fetch needed). Compressed files are
-      // excluded here: the gateway returns them with `Content-Encoding: deflate`,
-      // which browsers cannot decode, so they take the decompress path below.
+      // Fast path: plain, directly-renderable media. Let the browser stream it
+      // straight from the gateway URL (native range support, nothing buffered
+      // into JS memory). Safe because uncompressed files carry no
+      // `Content-Encoding`, so the gateway cannot mislabel the body.
       if (!isEncrypted && !isCompressed && canDisplayDirectly(metadata)) {
         setIsFilePreview(true);
         setFile(null);
@@ -170,84 +206,42 @@ export const FilePreview = ({ metadata }: { metadata: OffchainMetadata }) => {
       setLoading(true);
 
       try {
-        // Compressed (non-encrypted) files can't be previewed via the gateway
-        // URL: the gateway sets `Content-Encoding: deflate` and the browser
-        // fails to decode it. Retrieve + decompress the bytes via the backend
-        // download API, then build a blob for the previewer.
-        if (!isEncrypted && isCompressed) {
-          const bytes = await fetchDecompressedBytes(
-            api,
-            metadata.dataCid,
-            controller.signal,
-          );
-          clearTimeout(timeoutId);
-          if (abortControllerRef.current !== controller) {
-            return;
-          }
-
-          const blob = await processFileData({
-            dataArrayBuffer: bytes,
-            name: metadata.name ?? '',
-            rawData: '',
-            uploadOptions: metadata.uploadOptions ?? {},
-            isEncrypted: false,
-          });
-          setFile(blob);
-          if (needsContentParsing(metadata)) {
-            safeSetTextContent(await blob.text());
-          }
-          setLoading(false);
+        // Everything that can't be rendered straight from a URL (compressed,
+        // encrypted, or text we need to read into memory) goes through one
+        // defensive path: fetch the raw stored bytes once and decode them
+        // client-side, independent of the gateway's wire encoding.
+        const bytes = await loadPlaintextBytes(
+          api,
+          metadata,
+          password,
+          controller.signal,
+        );
+        clearTimeout(timeoutId);
+        // A newer fetchFile call has superseded this one — don't touch state.
+        if (abortControllerRef.current !== controller) {
           return;
         }
 
-        const response = await fetch(gatewayUrl, {
-          signal: controller.signal,
+        const blob = await processFileData({
+          dataArrayBuffer: bytes.buffer as ArrayBuffer,
+          name: metadata.name ?? '',
+          rawData: '',
+          uploadOptions: metadata.uploadOptions ?? {},
+          isEncrypted: false,
         });
-        if (!response.ok) {
-          clearTimeout(timeoutId);
-          throw new Error(
-            `Failed to fetch file: ${response.status} ${response.statusText}`,
-          );
-        }
-        const blob = await response.blob();
-        clearTimeout(timeoutId);
         setFile(blob);
-        // For text-based files, also read the content
-        if (needsContentParsing(metadata)) {
-          const text = await blob.text();
-          safeSetTextContent(text);
+        if (isEncrypted) {
+          setIsDecrypted(true);
         }
-        // Handle decryption if needed
-        if (metadata.uploadOptions?.encryption && password) {
-          try {
-            const encryptedFileData = {
-              dataArrayBuffer: await blob.arrayBuffer(),
-              name: metadata.name ?? '',
-              rawData: '',
-              uploadOptions: metadata.uploadOptions,
-              isEncrypted: true,
-            };
-            const decryptedFileData = await decryptFileData(
-              password,
-              encryptedFileData,
-            );
-            const decryptedBlob = await processFileData(decryptedFileData);
-            setFile(decryptedBlob);
-            setIsDecrypted(true);
-            setLoading(false);
-            return;
-          } catch {
-            setDecryptionError('Invalid password or decryption failed');
-            setLoading(false);
-            return;
-          }
+        if (needsContentParsing(metadata)) {
+          safeSetTextContent(await blob.text());
         }
         setLoading(false);
       } catch (error) {
         clearTimeout(timeoutId);
         // A newer fetchFile call has superseded this one — don't touch state.
         // This must run regardless of the error type: aborting a superseded
-        // request can surface as a decompression/network error rather than an
+        // request can surface as a decode/network error rather than an
         // AbortError, because the underlying download is not itself cancelable.
         if (abortControllerRef.current !== controller) {
           return;
@@ -255,6 +249,13 @@ export const FilePreview = ({ metadata }: { metadata: OffchainMetadata }) => {
         if (error instanceof DOMException && error.name === 'AbortError') {
           // Our own timeout fired — hide the preview.
           setIsFilePreview(false);
+          setLoading(false);
+          return;
+        }
+        // Encrypted files surface a dedicated message + inline password retry,
+        // since the most likely failure here is a wrong password.
+        if (isEncrypted) {
+          setDecryptionError('Invalid password or decryption failed');
           setLoading(false);
           return;
         }
@@ -271,7 +272,6 @@ export const FilePreview = ({ metadata }: { metadata: OffchainMetadata }) => {
       isPreviewable,
       isEncrypted,
       isCompressed,
-      gatewayUrl,
       api,
       safeSetTextContent,
     ],

--- a/apps/frontend/src/services/api.ts
+++ b/apps/frontend/src/services/api.ts
@@ -425,9 +425,10 @@ export const createApiService = ({
       password?: string;
       skipDecryption?: boolean;
       authMode?: 'auto' | 'anonymous' | 'session';
+      signal?: AbortSignal;
     },
   ): Promise<AsyncIterable<Buffer>> => {
-    const { password, skipDecryption, authMode = 'auto' } = options ?? {};
+    const { password, skipDecryption, authMode = 'auto', signal } = options ?? {};
     const session = await getAuthSession().catch(() => null);
 
     if (
@@ -461,7 +462,7 @@ export const createApiService = ({
     if (!skipDecryption) {
       const metadataRes = await api.sendAPIRequest(
         `/objects/${cid}/metadata`,
-        { method: 'GET' },
+        { method: 'GET', signal },
       );
       if (!metadataRes.ok) {
         throw new Error('Failed to retrieve file metadata');
@@ -471,7 +472,7 @@ export const createApiService = ({
 
     const response = await api.sendDownloadRequest(
       `/downloads/${cid}?ignoreEncoding=true`,
-      { method: 'GET' },
+      { method: 'GET', signal },
     );
     if (!response.ok) {
       let errorMsg: string;


### PR DESCRIPTION
Compressed (non-encrypted) files failed to preview because the public gateway serves them with Content-Encoding: deflate, which browsers fail to decode (broken <img> / ERR_CONTENT_DECODING_FAILED). All necessary fixes are implemented on the gateway side, nevertheless, the decoding is still affected. 

Make previews transport-agnostic so they render regardless of how the gateway/backend labels the body:

- Keep a zero-cost fast path: plain, directly-renderable media still streams straight from the gateway URL (native range support, nothing buffered into memory).
- Route everything else (compressed, encrypted, or text) through one defensive path that fetches the raw stored bytes (ignoreEncoding=true + skipDecryption) and decrypts/decompresses client-side, never trusting the wire encoding.
- Sniff the zlib header before inflating, so files flagged ZLIB but stored uncompressed pass through instead of throwing — no second fetch, no exception-driven fallback.
- Decrypt via decryptFile directly to avoid the SDK's decryptFileData always-decompressing
- Pass gatewayUrl=null for compressed non-encrypted files so the previewer uses the decoded blob, and prevent a superseded preview run from clobbering state with a stale error.

Addresses the front-end part of: https://github.com/autonomys/auto-drive/issues/736
