### PR TITLE
Admin credits: dedicated screen, combined refunds, mandatory refund tx hash

### DIFF
--- a/apps/backend/__tests__/unit/useCases/credits.spec.ts
+++ b/apps/backend/__tests__/unit/useCases/credits.spec.ts
@@ -381,6 +381,13 @@ describe('CreditsUseCases', () => {
 
   const VALID_TX_HASH = `0x${'a'.repeat(64)}`
 
+  // purchased_credits ids are UUIDs; the use cases reject anything else
+  // with 400 before reaching the repository.
+  const BATCH_1 = '11111111-1111-4111-8111-111111111111'
+  const BATCH_2 = '22222222-2222-4222-8222-222222222222'
+  const BATCH_3 = '33333333-3333-4333-8333-333333333333'
+  const MISSING_ID = '99999999-9999-4999-8999-999999999999'
+
   describe('refundBatch', () => {
     it('returns 403 ForbiddenError for non-admin user', async () => {
       const markSpy = jest
@@ -389,7 +396,7 @@ describe('CreditsUseCases', () => {
 
       const result = await CreditsUseCases.refundBatch(
         nonAdminUser,
-        'credit-1',
+        BATCH_1,
         VALID_TX_HASH,
       )
 
@@ -406,7 +413,7 @@ describe('CreditsUseCases', () => {
       for (const missing of [undefined, null, '', '   ']) {
         const result = await CreditsUseCases.refundBatch(
           adminUser,
-          'credit-1',
+          BATCH_1,
           missing,
         )
 
@@ -436,7 +443,7 @@ describe('CreditsUseCases', () => {
       for (const hash of malformed) {
         const result = await CreditsUseCases.refundBatch(
           adminUser,
-          'credit-1',
+          BATCH_1,
           hash,
         )
 
@@ -444,6 +451,27 @@ describe('CreditsUseCases', () => {
         expect(result._unsafeUnwrapErr()).toBeInstanceOf(BadRequestError)
       }
 
+      expect(markSpy).not.toHaveBeenCalled()
+    })
+
+    it('returns 400 BadRequestError for a non-UUID batch id', async () => {
+      const markSpy = jest
+        .spyOn(purchasedCreditsRepository, 'markAsRefunded')
+        .mockResolvedValue({ found: true, row: makeCreditRow() })
+
+      for (const invalid of ['credit-1', 'not-a-uuid', '11111111', '']) {
+        const result = await CreditsUseCases.refundBatch(
+          adminUser,
+          invalid,
+          VALID_TX_HASH,
+        )
+
+        expect(result.isErr()).toBe(true)
+        expect(result._unsafeUnwrapErr()).toBeInstanceOf(BadRequestError)
+      }
+
+      // Must never reach the repository, where a non-UUID id would fail the
+      // Postgres uuid cast and surface as a 500.
       expect(markSpy).not.toHaveBeenCalled()
     })
 
@@ -460,12 +488,12 @@ describe('CreditsUseCases', () => {
 
       const result = await CreditsUseCases.refundBatch(
         adminUser,
-        'credit-1',
+        BATCH_1,
         `  ${VALID_TX_HASH}  `,
       )
 
       expect(result.isOk()).toBe(true)
-      expect(markSpy).toHaveBeenCalledWith('credit-1', VALID_TX_HASH)
+      expect(markSpy).toHaveBeenCalledWith(BATCH_1, VALID_TX_HASH)
     })
 
     it('returns 404 NotFoundError when the batch does not exist', async () => {
@@ -475,7 +503,7 @@ describe('CreditsUseCases', () => {
 
       const result = await CreditsUseCases.refundBatch(
         adminUser,
-        'missing-id',
+        MISSING_ID,
         VALID_TX_HASH,
       )
 
@@ -490,7 +518,7 @@ describe('CreditsUseCases', () => {
 
       const result = await CreditsUseCases.refundBatch(
         adminUser,
-        'credit-1',
+        BATCH_1,
         VALID_TX_HASH,
       )
 
@@ -515,7 +543,7 @@ describe('CreditsUseCases', () => {
 
       const result = await CreditsUseCases.refundBatches(
         nonAdminUser,
-        ['credit-1'],
+        [BATCH_1],
         VALID_TX_HASH,
       )
 
@@ -534,7 +562,7 @@ describe('CreditsUseCases', () => {
           alreadyRefundedIds: [],
         })
 
-      for (const invalid of [undefined, null, [], ['credit-1', ''], 'credit-1', [42]]) {
+      for (const invalid of [undefined, null, [], [BATCH_1, ''], BATCH_1, [42]]) {
         const result = await CreditsUseCases.refundBatches(
           adminUser,
           invalid,
@@ -545,6 +573,29 @@ describe('CreditsUseCases', () => {
         expect(result._unsafeUnwrapErr()).toBeInstanceOf(BadRequestError)
       }
 
+      expect(markSpy).not.toHaveBeenCalled()
+    })
+
+    it('returns 400 BadRequestError listing non-UUID batch ids', async () => {
+      const markSpy = jest
+        .spyOn(purchasedCreditsRepository, 'markManyAsRefunded')
+        .mockResolvedValue({
+          missingIds: [],
+          accountIds: ['account-id'],
+          refundedRows: [],
+          alreadyRefundedIds: [],
+        })
+
+      const result = await CreditsUseCases.refundBatches(
+        adminUser,
+        [BATCH_1, 'not-a-uuid'],
+        VALID_TX_HASH,
+      )
+
+      expect(result.isErr()).toBe(true)
+      const error = result._unsafeUnwrapErr()
+      expect(error).toBeInstanceOf(BadRequestError)
+      expect(error.message).toContain('not-a-uuid')
       expect(markSpy).not.toHaveBeenCalled()
     })
 
@@ -560,7 +611,7 @@ describe('CreditsUseCases', () => {
 
       const result = await CreditsUseCases.refundBatches(
         adminUser,
-        ['credit-1', 'credit-2'],
+        [BATCH_1, BATCH_2],
         undefined,
       )
 
@@ -581,7 +632,7 @@ describe('CreditsUseCases', () => {
 
       const result = await CreditsUseCases.refundBatches(
         adminUser,
-        ['credit-1', 'credit-2'],
+        [BATCH_1, BATCH_2],
         VALID_TX_HASH,
       )
 
@@ -602,12 +653,12 @@ describe('CreditsUseCases', () => {
           missingIds: [],
           accountIds: [],
           refundedRows: [],
-          alreadyRefundedIds: ['credit-1', 'credit-2'],
+          alreadyRefundedIds: [BATCH_1, BATCH_2],
         })
 
       const result = await CreditsUseCases.refundBatches(
         adminUser,
-        ['credit-1', 'credit-2'],
+        [BATCH_1, BATCH_2],
         VALID_TX_HASH,
       )
 
@@ -622,7 +673,7 @@ describe('CreditsUseCases', () => {
       jest
         .spyOn(purchasedCreditsRepository, 'markManyAsRefunded')
         .mockResolvedValue({
-          missingIds: ['missing-1'],
+          missingIds: [MISSING_ID],
           accountIds: ['account-id'],
           refundedRows: [],
           alreadyRefundedIds: [],
@@ -630,14 +681,14 @@ describe('CreditsUseCases', () => {
 
       const result = await CreditsUseCases.refundBatches(
         adminUser,
-        ['credit-1', 'missing-1'],
+        [BATCH_1, MISSING_ID],
         VALID_TX_HASH,
       )
 
       expect(result.isErr()).toBe(true)
       const error = result._unsafeUnwrapErr()
       expect(error).toBeInstanceOf(NotFoundError)
-      expect(error.message).toContain('missing-1')
+      expect(error.message).toContain(MISSING_ID)
     })
 
     it('refunds several batches with one tx hash and de-duplicates ids', async () => {
@@ -647,15 +698,15 @@ describe('CreditsUseCases', () => {
           missingIds: [],
           accountIds: ['account-id'],
           refundedRows: [
-            makeCreditRow({ id: 'credit-1', refundedAt: now }),
-            makeCreditRow({ id: 'credit-2', refundedAt: now }),
+            makeCreditRow({ id: BATCH_1, refundedAt: now }),
+            makeCreditRow({ id: BATCH_2, refundedAt: now }),
           ],
-          alreadyRefundedIds: ['credit-3'],
+          alreadyRefundedIds: [BATCH_3],
         })
 
       const result = await CreditsUseCases.refundBatches(
         adminUser,
-        ['credit-1', 'credit-2', 'credit-2', 'credit-3'],
+        [BATCH_1, BATCH_2, BATCH_2, BATCH_3],
         VALID_TX_HASH,
       )
 
@@ -665,7 +716,7 @@ describe('CreditsUseCases', () => {
         alreadyRefundedCount: 1,
       })
       expect(markSpy).toHaveBeenCalledWith(
-        ['credit-1', 'credit-2', 'credit-3'],
+        [BATCH_1, BATCH_2, BATCH_3],
         VALID_TX_HASH,
       )
     })

--- a/apps/backend/__tests__/unit/useCases/credits.spec.ts
+++ b/apps/backend/__tests__/unit/useCases/credits.spec.ts
@@ -537,6 +537,7 @@ describe('CreditsUseCases', () => {
         .mockResolvedValue({
           missingIds: [],
           accountIds: ['account-id'],
+          walletAddresses: ['0xwallet-1'],
           refundedRows: [makeCreditRow()],
           alreadyRefundedIds: [],
         })
@@ -558,6 +559,7 @@ describe('CreditsUseCases', () => {
         .mockResolvedValue({
           missingIds: [],
           accountIds: ['account-id'],
+          walletAddresses: ['0xwallet-1'],
           refundedRows: [],
           alreadyRefundedIds: [],
         })
@@ -582,6 +584,7 @@ describe('CreditsUseCases', () => {
         .mockResolvedValue({
           missingIds: [],
           accountIds: ['account-id'],
+          walletAddresses: ['0xwallet-1'],
           refundedRows: [],
           alreadyRefundedIds: [],
         })
@@ -605,6 +608,7 @@ describe('CreditsUseCases', () => {
         .mockResolvedValue({
           missingIds: [],
           accountIds: ['account-id'],
+          walletAddresses: ['0xwallet-1'],
           refundedRows: [],
           alreadyRefundedIds: [],
         })
@@ -626,6 +630,7 @@ describe('CreditsUseCases', () => {
         .mockResolvedValue({
           missingIds: [],
           accountIds: ['account-a', 'account-b'],
+          walletAddresses: ['0xwallet-1'],
           refundedRows: [],
           alreadyRefundedIds: [],
         })
@@ -642,6 +647,54 @@ describe('CreditsUseCases', () => {
       expect(error.message).toContain('same account')
     })
 
+    it('returns 400 BadRequestError when batches were paid from different wallets', async () => {
+      // Same account, but the batches were purchased from two different EVM
+      // wallets — one refund transfer can only go back to one wallet.
+      jest
+        .spyOn(purchasedCreditsRepository, 'markManyAsRefunded')
+        .mockResolvedValue({
+          missingIds: [],
+          accountIds: ['account-id'],
+          walletAddresses: ['0xwallet-1', '0xwallet-2'],
+          refundedRows: [],
+          alreadyRefundedIds: [],
+        })
+
+      const result = await CreditsUseCases.refundBatches(
+        adminUser,
+        [BATCH_1, BATCH_2],
+        VALID_TX_HASH,
+      )
+
+      expect(result.isErr()).toBe(true)
+      const error = result._unsafeUnwrapErr()
+      expect(error).toBeInstanceOf(BadRequestError)
+      expect(error.message).toContain('same purchasing wallet')
+    })
+
+    it('returns 400 BadRequestError when wallets differ by known vs unknown', async () => {
+      // A batch with no recorded from_address (legacy intent) cannot be
+      // combined with a batch paid from a known wallet.
+      jest
+        .spyOn(purchasedCreditsRepository, 'markManyAsRefunded')
+        .mockResolvedValue({
+          missingIds: [],
+          accountIds: ['account-id'],
+          walletAddresses: ['0xwallet-1', null],
+          refundedRows: [],
+          alreadyRefundedIds: [],
+        })
+
+      const result = await CreditsUseCases.refundBatches(
+        adminUser,
+        [BATCH_1, BATCH_2],
+        VALID_TX_HASH,
+      )
+
+      expect(result.isErr()).toBe(true)
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(BadRequestError)
+    })
+
     it('succeeds idempotently when every batch is already refunded', async () => {
       // Already-refunded rows are excluded from the single-account check
       // (they keep their original tx hash), so a retry where everything is
@@ -652,6 +705,7 @@ describe('CreditsUseCases', () => {
         .mockResolvedValue({
           missingIds: [],
           accountIds: [],
+          walletAddresses: [],
           refundedRows: [],
           alreadyRefundedIds: [BATCH_1, BATCH_2],
         })
@@ -675,6 +729,7 @@ describe('CreditsUseCases', () => {
         .mockResolvedValue({
           missingIds: [MISSING_ID],
           accountIds: ['account-id'],
+          walletAddresses: ['0xwallet-1'],
           refundedRows: [],
           alreadyRefundedIds: [],
         })
@@ -697,6 +752,7 @@ describe('CreditsUseCases', () => {
         .mockResolvedValue({
           missingIds: [],
           accountIds: ['account-id'],
+          walletAddresses: ['0xwallet-1'],
           refundedRows: [
             makeCreditRow({ id: BATCH_1, refundedAt: now }),
             makeCreditRow({ id: BATCH_2, refundedAt: now }),

--- a/apps/backend/__tests__/unit/useCases/credits.spec.ts
+++ b/apps/backend/__tests__/unit/useCases/credits.spec.ts
@@ -2,7 +2,11 @@ import { jest } from '@jest/globals'
 import { CreditsUseCases } from '../../../src/core/users/credits.js'
 import { purchasedCreditsRepository } from '../../../src/infrastructure/repositories/users/purchasedCredits.js'
 import { AccountsUseCases } from '../../../src/core/users/accounts.js'
-import { ForbiddenError } from '../../../src/errors/index.js'
+import {
+  BadRequestError,
+  ForbiddenError,
+  NotFoundError,
+} from '../../../src/errors/index.js'
 import {
   type Account,
   type PurchasedCredit,
@@ -66,6 +70,7 @@ const makeCreditRow = (
   expiresAt: FUTURE_EXPIRY,
   expired: false,
   refundedAt: null,
+  refundTxHash: null,
   createdAt: now,
   updatedAt: now,
   ...overrides,
@@ -367,6 +372,275 @@ describe('CreditsUseCases', () => {
       expect(
         purchasedCreditsRepository.getExpiringCreditsAggregate,
       ).toHaveBeenCalledWith(30)
+    })
+  })
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // refundBatch
+  // ──────────────────────────────────────────────────────────────────────────
+
+  const VALID_TX_HASH = `0x${'a'.repeat(64)}`
+
+  describe('refundBatch', () => {
+    it('returns 403 ForbiddenError for non-admin user', async () => {
+      const markSpy = jest
+        .spyOn(purchasedCreditsRepository, 'markAsRefunded')
+        .mockResolvedValue({ found: true, row: makeCreditRow() })
+
+      const result = await CreditsUseCases.refundBatch(
+        nonAdminUser,
+        'credit-1',
+        VALID_TX_HASH,
+      )
+
+      expect(result.isErr()).toBe(true)
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(ForbiddenError)
+      expect(markSpy).not.toHaveBeenCalled()
+    })
+
+    it('returns 400 BadRequestError when no tx hash is provided', async () => {
+      const markSpy = jest
+        .spyOn(purchasedCreditsRepository, 'markAsRefunded')
+        .mockResolvedValue({ found: true, row: makeCreditRow() })
+
+      for (const missing of [undefined, null, '', '   ']) {
+        const result = await CreditsUseCases.refundBatch(
+          adminUser,
+          'credit-1',
+          missing,
+        )
+
+        expect(result.isErr()).toBe(true)
+        expect(result._unsafeUnwrapErr()).toBeInstanceOf(BadRequestError)
+      }
+
+      // The batch must never be marked as refunded without a tx hash.
+      expect(markSpy).not.toHaveBeenCalled()
+    })
+
+    it('returns 400 BadRequestError for malformed tx hashes', async () => {
+      const markSpy = jest
+        .spyOn(purchasedCreditsRepository, 'markAsRefunded')
+        .mockResolvedValue({ found: true, row: makeCreditRow() })
+
+      const malformed = [
+        'not-a-hash',
+        '0x1234', // too short
+        `0x${'a'.repeat(63)}`, // 63 hex chars
+        `0x${'a'.repeat(65)}`, // 65 hex chars
+        `0x${'g'.repeat(64)}`, // non-hex characters
+        `${'a'.repeat(64)}`, // missing 0x prefix
+        12345, // not a string
+      ]
+
+      for (const hash of malformed) {
+        const result = await CreditsUseCases.refundBatch(
+          adminUser,
+          'credit-1',
+          hash,
+        )
+
+        expect(result.isErr()).toBe(true)
+        expect(result._unsafeUnwrapErr()).toBeInstanceOf(BadRequestError)
+      }
+
+      expect(markSpy).not.toHaveBeenCalled()
+    })
+
+    it('marks the batch as refunded with the trimmed tx hash', async () => {
+      const markSpy = jest
+        .spyOn(purchasedCreditsRepository, 'markAsRefunded')
+        .mockResolvedValue({
+          found: true,
+          row: makeCreditRow({
+            refundedAt: now,
+            refundTxHash: VALID_TX_HASH,
+          }),
+        })
+
+      const result = await CreditsUseCases.refundBatch(
+        adminUser,
+        'credit-1',
+        `  ${VALID_TX_HASH}  `,
+      )
+
+      expect(result.isOk()).toBe(true)
+      expect(markSpy).toHaveBeenCalledWith('credit-1', VALID_TX_HASH)
+    })
+
+    it('returns 404 NotFoundError when the batch does not exist', async () => {
+      jest
+        .spyOn(purchasedCreditsRepository, 'markAsRefunded')
+        .mockResolvedValue({ found: false, row: null })
+
+      const result = await CreditsUseCases.refundBatch(
+        adminUser,
+        'missing-id',
+        VALID_TX_HASH,
+      )
+
+      expect(result.isErr()).toBe(true)
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(NotFoundError)
+    })
+
+    it('is a no-op returning ok() when the batch is already refunded', async () => {
+      jest
+        .spyOn(purchasedCreditsRepository, 'markAsRefunded')
+        .mockResolvedValue({ found: true, row: null })
+
+      const result = await CreditsUseCases.refundBatch(
+        adminUser,
+        'credit-1',
+        VALID_TX_HASH,
+      )
+
+      expect(result.isOk()).toBe(true)
+    })
+  })
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // refundBatches
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('refundBatches', () => {
+    it('returns 403 ForbiddenError for non-admin user', async () => {
+      const markSpy = jest
+        .spyOn(purchasedCreditsRepository, 'markManyAsRefunded')
+        .mockResolvedValue({
+          missingIds: [],
+          accountIds: ['account-id'],
+          refundedRows: [makeCreditRow()],
+          alreadyRefundedIds: [],
+        })
+
+      const result = await CreditsUseCases.refundBatches(
+        nonAdminUser,
+        ['credit-1'],
+        VALID_TX_HASH,
+      )
+
+      expect(result.isErr()).toBe(true)
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(ForbiddenError)
+      expect(markSpy).not.toHaveBeenCalled()
+    })
+
+    it('returns 400 BadRequestError for an empty or invalid batchIds payload', async () => {
+      const markSpy = jest
+        .spyOn(purchasedCreditsRepository, 'markManyAsRefunded')
+        .mockResolvedValue({
+          missingIds: [],
+          accountIds: ['account-id'],
+          refundedRows: [],
+          alreadyRefundedIds: [],
+        })
+
+      for (const invalid of [undefined, null, [], ['credit-1', ''], 'credit-1', [42]]) {
+        const result = await CreditsUseCases.refundBatches(
+          adminUser,
+          invalid,
+          VALID_TX_HASH,
+        )
+
+        expect(result.isErr()).toBe(true)
+        expect(result._unsafeUnwrapErr()).toBeInstanceOf(BadRequestError)
+      }
+
+      expect(markSpy).not.toHaveBeenCalled()
+    })
+
+    it('returns 400 BadRequestError when no tx hash is provided and updates nothing', async () => {
+      const markSpy = jest
+        .spyOn(purchasedCreditsRepository, 'markManyAsRefunded')
+        .mockResolvedValue({
+          missingIds: [],
+          accountIds: ['account-id'],
+          refundedRows: [],
+          alreadyRefundedIds: [],
+        })
+
+      const result = await CreditsUseCases.refundBatches(
+        adminUser,
+        ['credit-1', 'credit-2'],
+        undefined,
+      )
+
+      expect(result.isErr()).toBe(true)
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(BadRequestError)
+      expect(markSpy).not.toHaveBeenCalled()
+    })
+
+    it('returns 400 BadRequestError when batches span multiple accounts', async () => {
+      jest
+        .spyOn(purchasedCreditsRepository, 'markManyAsRefunded')
+        .mockResolvedValue({
+          missingIds: [],
+          accountIds: ['account-a', 'account-b'],
+          refundedRows: [],
+          alreadyRefundedIds: [],
+        })
+
+      const result = await CreditsUseCases.refundBatches(
+        adminUser,
+        ['credit-1', 'credit-2'],
+        VALID_TX_HASH,
+      )
+
+      expect(result.isErr()).toBe(true)
+      const error = result._unsafeUnwrapErr()
+      expect(error).toBeInstanceOf(BadRequestError)
+      expect(error.message).toContain('same account')
+    })
+
+    it('returns 404 NotFoundError listing missing ids', async () => {
+      jest
+        .spyOn(purchasedCreditsRepository, 'markManyAsRefunded')
+        .mockResolvedValue({
+          missingIds: ['missing-1'],
+          accountIds: ['account-id'],
+          refundedRows: [],
+          alreadyRefundedIds: [],
+        })
+
+      const result = await CreditsUseCases.refundBatches(
+        adminUser,
+        ['credit-1', 'missing-1'],
+        VALID_TX_HASH,
+      )
+
+      expect(result.isErr()).toBe(true)
+      const error = result._unsafeUnwrapErr()
+      expect(error).toBeInstanceOf(NotFoundError)
+      expect(error.message).toContain('missing-1')
+    })
+
+    it('refunds several batches with one tx hash and de-duplicates ids', async () => {
+      const markSpy = jest
+        .spyOn(purchasedCreditsRepository, 'markManyAsRefunded')
+        .mockResolvedValue({
+          missingIds: [],
+          accountIds: ['account-id'],
+          refundedRows: [
+            makeCreditRow({ id: 'credit-1', refundedAt: now }),
+            makeCreditRow({ id: 'credit-2', refundedAt: now }),
+          ],
+          alreadyRefundedIds: ['credit-3'],
+        })
+
+      const result = await CreditsUseCases.refundBatches(
+        adminUser,
+        ['credit-1', 'credit-2', 'credit-2', 'credit-3'],
+        VALID_TX_HASH,
+      )
+
+      expect(result.isOk()).toBe(true)
+      expect(result._unsafeUnwrap()).toEqual({
+        refundedCount: 2,
+        alreadyRefundedCount: 1,
+      })
+      expect(markSpy).toHaveBeenCalledWith(
+        ['credit-1', 'credit-2', 'credit-3'],
+        VALID_TX_HASH,
+      )
     })
   })
 })

--- a/apps/backend/__tests__/unit/useCases/credits.spec.ts
+++ b/apps/backend/__tests__/unit/useCases/credits.spec.ts
@@ -591,6 +591,33 @@ describe('CreditsUseCases', () => {
       expect(error.message).toContain('same account')
     })
 
+    it('succeeds idempotently when every batch is already refunded', async () => {
+      // Already-refunded rows are excluded from the single-account check
+      // (they keep their original tx hash), so a retry where everything is
+      // already refunded returns ok — even across accounts (accountIds only
+      // reflects rows still pending refund, here none).
+      jest
+        .spyOn(purchasedCreditsRepository, 'markManyAsRefunded')
+        .mockResolvedValue({
+          missingIds: [],
+          accountIds: [],
+          refundedRows: [],
+          alreadyRefundedIds: ['credit-1', 'credit-2'],
+        })
+
+      const result = await CreditsUseCases.refundBatches(
+        adminUser,
+        ['credit-1', 'credit-2'],
+        VALID_TX_HASH,
+      )
+
+      expect(result.isOk()).toBe(true)
+      expect(result._unsafeUnwrap()).toEqual({
+        refundedCount: 0,
+        alreadyRefundedCount: 2,
+      })
+    })
+
     it('returns 404 NotFoundError listing missing ids', async () => {
       jest
         .spyOn(purchasedCreditsRepository, 'markManyAsRefunded')

--- a/apps/backend/migrations/20260611000000-purchased-credits-refund-tx-hash.js
+++ b/apps/backend/migrations/20260611000000-purchased-credits-refund-tx-hash.js
@@ -1,0 +1,53 @@
+'use strict'
+
+var dbm
+var type
+var seed
+var fs = require('fs')
+var path = require('path')
+var Promise
+
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  var filePath = path.join(
+    __dirname,
+    'sqls',
+    '20260611000000-purchased-credits-refund-tx-hash-up.sql',
+  )
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+      resolve(data)
+    })
+  }).then(function (data) {
+    return db.runSql(data)
+  })
+}
+
+exports.down = function (db) {
+  var filePath = path.join(
+    __dirname,
+    'sqls',
+    '20260611000000-purchased-credits-refund-tx-hash-down.sql',
+  )
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+      resolve(data)
+    })
+  }).then(function (data) {
+    return db.runSql(data)
+  })
+}
+
+exports._meta = {
+  version: 1,
+}

--- a/apps/backend/migrations/sqls/20260611000000-purchased-credits-refund-tx-hash-down.sql
+++ b/apps/backend/migrations/sqls/20260611000000-purchased-credits-refund-tx-hash-down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE purchased_credits
+  DROP COLUMN refund_tx_hash;

--- a/apps/backend/migrations/sqls/20260611000000-purchased-credits-refund-tx-hash-up.sql
+++ b/apps/backend/migrations/sqls/20260611000000-purchased-credits-refund-tx-hash-up.sql
@@ -1,0 +1,11 @@
+-- Add refund transaction hash tracking to purchased_credits.
+--
+-- refund_tx_hash: On-chain transaction hash of the AI3 refund transfer the
+--                 admin executed before marking the batch as refunded.
+--                 Mandatory for every new refund — the refund endpoints
+--                 reject requests without it. Multiple batches refunded in
+--                 a single on-chain transaction share the same hash.
+--                 NULL only on rows refunded before this column existed.
+
+ALTER TABLE purchased_credits
+  ADD COLUMN refund_tx_hash VARCHAR(255);

--- a/apps/backend/src/app/controllers/credits.ts
+++ b/apps/backend/src/app/controllers/credits.ts
@@ -151,6 +151,7 @@ creditsController.get(
       result.value.map((batch) => ({
         ...serializeCredit(batch),
         userPublicId: batch.userPublicId,
+        fromAddress: batch.fromAddress ?? null,
       })),
     )
   }),
@@ -202,7 +203,9 @@ creditsController.get(
 // Admin-only: marks several credit batches as refunded in one atomic
 // operation. Body: { batchIds: string[], refundTxHash: string }.
 // The refund transaction hash is mandatory — the same hash is recorded on
-// every batch (one on-chain AI3 transfer can cover multiple batches).
+// every batch (one on-chain AI3 transfer can cover multiple batches of the
+// same account paid from the same purchasing wallet; spanning accounts or
+// paying wallets is rejected with 400).
 // All-or-nothing: if any id is unknown nothing is updated (404).
 // Already-refunded batches are skipped (idempotent).
 // Returns 403 for non-admin callers, 400 for missing/malformed input.

--- a/apps/backend/src/app/controllers/credits.ts
+++ b/apps/backend/src/app/controllers/credits.ts
@@ -198,9 +198,53 @@ creditsController.get(
 )
 
 // ---------------------------------------------------------------------------
+// POST /credits/batches/refund
+// Admin-only: marks several credit batches as refunded in one atomic
+// operation. Body: { batchIds: string[], refundTxHash: string }.
+// The refund transaction hash is mandatory — the same hash is recorded on
+// every batch (one on-chain AI3 transfer can cover multiple batches).
+// All-or-nothing: if any id is unknown nothing is updated (404).
+// Already-refunded batches are skipped (idempotent).
+// Returns 403 for non-admin callers, 400 for missing/malformed input.
+//
+// NOTE: registered BEFORE POST /credits/batches/:id/refund so the literal
+// path segment "refund" is not captured as an :id parameter.
+// ---------------------------------------------------------------------------
+
+creditsController.post(
+  '/batches/refund',
+  asyncSafeHandler(async (req, res) => {
+    const user = await handleAuth(req, res)
+    if (!user) {
+      return
+    }
+
+    const { batchIds, refundTxHash } = req.body ?? {}
+
+    const result = await handleInternalErrorResult(
+      CreditsUseCases.refundBatches(user, batchIds, refundTxHash),
+      'Failed to refund credit batches',
+    )
+    if (result.isErr()) {
+      handleError(result.error, res)
+      return
+    }
+
+    res.status(200).json({
+      ok: true,
+      refundedCount: result.value.refundedCount,
+      alreadyRefundedCount: result.value.alreadyRefundedCount,
+    })
+  }),
+)
+
+// ---------------------------------------------------------------------------
 // POST /credits/batches/:id/refund
 // Admin-only: marks a credit batch as refunded (zeros remaining bytes,
-// sets refunded = true). Idempotent — safe to call multiple times.
+// sets refunded_at, records the mandatory refund transaction hash).
+// Body: { refundTxHash: string } — required; requests without a valid
+// 0x-prefixed 64-hex-char hash are rejected with 400 and the batch is NOT
+// marked as refunded. Idempotent — safe to call multiple times.
 // Returns 403 for non-admin callers, 404 if the batch is not found.
 // ---------------------------------------------------------------------------
 
@@ -213,9 +257,10 @@ creditsController.post(
     }
 
     const { id } = req.params
+    const { refundTxHash } = req.body ?? {}
 
     const result = await handleInternalErrorResult(
-      CreditsUseCases.refundBatch(user, id),
+      CreditsUseCases.refundBatch(user, id, refundTxHash),
       'Failed to refund credit batch',
     )
     if (result.isErr()) {

--- a/apps/backend/src/core/users/credits.ts
+++ b/apps/backend/src/core/users/credits.ts
@@ -1,4 +1,10 @@
-import { PurchasedCredit, User, UserRole, UserWithOrganization } from '@auto-drive/models'
+import {
+  EVM_TX_HASH_REGEX,
+  PurchasedCredit,
+  User,
+  UserRole,
+  UserWithOrganization,
+} from '@auto-drive/models'
 import {
   AdminCreditBatchRow,
   AdminUserCreditBatchRow,
@@ -187,10 +193,9 @@ const getUserBatches = async (
 // ---------------------------------------------------------------------------
 // Refund transaction hash validation
 // Every refund must record the on-chain transaction hash of the AI3 transfer
-// the admin executed. Strict EVM format: 0x followed by 64 hex characters.
+// the admin executed. Strict EVM format (EVM_TX_HASH_REGEX from
+// @auto-drive/models, shared with the frontend refund modal).
 // ---------------------------------------------------------------------------
-
-const REFUND_TX_HASH_REGEX = /^0x[0-9a-fA-F]{64}$/
 
 // purchased_credits.id is a UUID column. Validating ids here returns a clean
 // 400 instead of letting Postgres fail the `::uuid` cast (which would
@@ -209,7 +214,7 @@ const validateRefundTxHash = (
     )
   }
   const trimmed = refundTxHash.trim()
-  if (!REFUND_TX_HASH_REGEX.test(trimmed)) {
+  if (!EVM_TX_HASH_REGEX.test(trimmed)) {
     return err(
       new BadRequestError(
         'Invalid refund transaction hash: expected 0x followed by 64 hex characters',

--- a/apps/backend/src/core/users/credits.ts
+++ b/apps/backend/src/core/users/credits.ts
@@ -192,6 +192,12 @@ const getUserBatches = async (
 
 const REFUND_TX_HASH_REGEX = /^0x[0-9a-fA-F]{64}$/
 
+// purchased_credits.id is a UUID column. Validating ids here returns a clean
+// 400 instead of letting Postgres fail the `::uuid` cast (which would
+// surface as a 500). Any UUID version is accepted.
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
 const validateRefundTxHash = (
   refundTxHash: unknown,
 ): Result<string, BadRequestError> => {
@@ -231,6 +237,10 @@ const refundBatch = async (
 ): Promise<Result<void, ForbiddenError | NotFoundError | BadRequestError>> => {
   if (executor.role !== UserRole.Admin) {
     return err(new ForbiddenError('Admin access required'))
+  }
+
+  if (!UUID_REGEX.test(batchId)) {
+    return err(new BadRequestError('Invalid batch id: expected a UUID'))
   }
 
   const txHashResult = validateRefundTxHash(refundTxHash)
@@ -306,6 +316,15 @@ const refundBatches = async (
   }
 
   const uniqueIds = [...new Set(batchIds.map((id) => id.trim()))]
+
+  const invalidIds = uniqueIds.filter((id) => !UUID_REGEX.test(id))
+  if (invalidIds.length > 0) {
+    return err(
+      new BadRequestError(
+        `Invalid batch ids (expected UUIDs): ${invalidIds.join(', ')}`,
+      ),
+    )
+  }
 
   const txHashResult = validateRefundTxHash(refundTxHash)
   if (txHashResult.isErr()) {

--- a/apps/backend/src/core/users/credits.ts
+++ b/apps/backend/src/core/users/credits.ts
@@ -6,7 +6,11 @@ import {
 } from '../../infrastructure/repositories/users/purchasedCredits.js'
 import { AccountsUseCases } from './accounts.js'
 import { config } from '../../config.js'
-import { ForbiddenError, NotFoundError } from '../../errors/index.js'
+import {
+  BadRequestError,
+  ForbiddenError,
+  NotFoundError,
+} from '../../errors/index.js'
 import { err, ok, Result } from 'neverthrow'
 import { hasGoogleAuth } from '../featureFlags/index.js'
 import { createLogger } from '../../infrastructure/drivers/logger.js'
@@ -181,22 +185,63 @@ const getUserBatches = async (
 }
 
 // ---------------------------------------------------------------------------
+// Refund transaction hash validation
+// Every refund must record the on-chain transaction hash of the AI3 transfer
+// the admin executed. Strict EVM format: 0x followed by 64 hex characters.
+// ---------------------------------------------------------------------------
+
+const REFUND_TX_HASH_REGEX = /^0x[0-9a-fA-F]{64}$/
+
+const validateRefundTxHash = (
+  refundTxHash: unknown,
+): Result<string, BadRequestError> => {
+  if (typeof refundTxHash !== 'string' || refundTxHash.trim() === '') {
+    return err(
+      new BadRequestError(
+        'A refund transaction hash is required to mark a batch as refunded',
+      ),
+    )
+  }
+  const trimmed = refundTxHash.trim()
+  if (!REFUND_TX_HASH_REGEX.test(trimmed)) {
+    return err(
+      new BadRequestError(
+        'Invalid refund transaction hash: expected 0x followed by 64 hex characters',
+      ),
+    )
+  }
+  return ok(trimmed)
+}
+
+// ---------------------------------------------------------------------------
 // refundBatch
 // Admin-only: zeros the remaining bytes for a specific credit batch and marks
-// it as refunded. Idempotent — calling it on an already-refunded row is a
-// no-op that still returns ok() so the UI can safely retry on network errors.
-// Returns 403 for non-admin callers, 404 if the batch does not exist.
+// it as refunded, recording the mandatory on-chain refund transaction hash.
+// Idempotent — calling it on an already-refunded row is a no-op that still
+// returns ok() so the UI can safely retry on network errors (the original
+// refund_tx_hash is preserved).
+// Returns 403 for non-admin callers, 404 if the batch does not exist,
+// 400 if the transaction hash is missing or malformed.
 // ---------------------------------------------------------------------------
 
 const refundBatch = async (
   executor: User,
   batchId: string,
-): Promise<Result<void, ForbiddenError | NotFoundError>> => {
+  refundTxHash: unknown,
+): Promise<Result<void, ForbiddenError | NotFoundError | BadRequestError>> => {
   if (executor.role !== UserRole.Admin) {
     return err(new ForbiddenError('Admin access required'))
   }
 
-  const { found, row } = await purchasedCreditsRepository.markAsRefunded(batchId)
+  const txHashResult = validateRefundTxHash(refundTxHash)
+  if (txHashResult.isErr()) {
+    return err(txHashResult.error)
+  }
+
+  const { found, row } = await purchasedCreditsRepository.markAsRefunded(
+    batchId,
+    txHashResult.value,
+  )
   if (!found) {
     return err(new NotFoundError('Credit batch not found'))
   }
@@ -204,6 +249,7 @@ const refundBatch = async (
   if (row) {
     logger.info('Admin marked credit batch as refunded', {
       batchId,
+      refundTxHash: txHashResult.value,
       adminPublicId: executor.publicId,
     })
   } else {
@@ -216,6 +262,89 @@ const refundBatch = async (
   return ok(undefined)
 }
 
+// ---------------------------------------------------------------------------
+// refundBatches
+// Admin-only: marks several credit batches as refunded in one atomic
+// operation, recording the same on-chain refund transaction hash on each
+// (one AI3 transfer can cover multiple batches of the same account).
+// All-or-nothing: if any batch id does not exist nothing is updated and a
+// 404 listing the missing ids is returned. All batches must belong to the
+// same account — a combined refund spanning several accounts is rejected
+// with 400 and nothing is updated, since one on-chain transfer can only go
+// to a single wallet. Already-refunded batches are skipped (idempotent),
+// mirroring refundBatch.
+// Returns 403 for non-admin callers, 400 if the transaction hash is missing
+// or malformed, or if no batch ids are provided.
+// ---------------------------------------------------------------------------
+
+export type RefundBatchesSummary = {
+  refundedCount: number
+  alreadyRefundedCount: number
+}
+
+const refundBatches = async (
+  executor: User,
+  batchIds: unknown,
+  refundTxHash: unknown,
+): Promise<
+  Result<RefundBatchesSummary, ForbiddenError | NotFoundError | BadRequestError>
+> => {
+  if (executor.role !== UserRole.Admin) {
+    return err(new ForbiddenError('Admin access required'))
+  }
+
+  if (
+    !Array.isArray(batchIds) ||
+    batchIds.length === 0 ||
+    !batchIds.every((id) => typeof id === 'string' && id.trim() !== '')
+  ) {
+    return err(
+      new BadRequestError('batchIds must be a non-empty array of batch ids'),
+    )
+  }
+
+  const uniqueIds = [...new Set(batchIds.map((id) => id.trim()))]
+
+  const txHashResult = validateRefundTxHash(refundTxHash)
+  if (txHashResult.isErr()) {
+    return err(txHashResult.error)
+  }
+
+  const result = await purchasedCreditsRepository.markManyAsRefunded(
+    uniqueIds,
+    txHashResult.value,
+  )
+
+  if (result.missingIds.length > 0) {
+    return err(
+      new NotFoundError(
+        `Credit batches not found: ${result.missingIds.join(', ')}`,
+      ),
+    )
+  }
+
+  if (result.accountIds.length > 1) {
+    return err(
+      new BadRequestError(
+        'All batches in a combined refund must belong to the same account',
+      ),
+    )
+  }
+
+  logger.info('Admin marked credit batches as refunded', {
+    batchIds: uniqueIds,
+    refundedCount: result.refundedRows.length,
+    alreadyRefundedCount: result.alreadyRefundedIds.length,
+    refundTxHash: txHashResult.value,
+    adminPublicId: executor.publicId,
+  })
+
+  return ok({
+    refundedCount: result.refundedRows.length,
+    alreadyRefundedCount: result.alreadyRefundedIds.length,
+  })
+}
+
 export const CreditsUseCases = {
   getSummary,
   getBatches,
@@ -224,4 +353,5 @@ export const CreditsUseCases = {
   getAllBatches,
   getUserBatches,
   refundBatch,
+  refundBatches,
 }

--- a/apps/backend/src/core/users/credits.ts
+++ b/apps/backend/src/core/users/credits.ts
@@ -268,11 +268,13 @@ const refundBatch = async (
 // operation, recording the same on-chain refund transaction hash on each
 // (one AI3 transfer can cover multiple batches of the same account).
 // All-or-nothing: if any batch id does not exist nothing is updated and a
-// 404 listing the missing ids is returned. All batches must belong to the
-// same account — a combined refund spanning several accounts is rejected
-// with 400 and nothing is updated, since one on-chain transfer can only go
-// to a single wallet. Already-refunded batches are skipped (idempotent),
-// mirroring refundBatch.
+// 404 listing the missing ids is returned. All batches still pending a
+// refund must belong to the same account — a combined refund spanning
+// several accounts is rejected with 400 and nothing is updated, since one
+// on-chain transfer can only go to a single wallet. Already-refunded
+// batches are skipped (idempotent, mirroring refundBatch) and are excluded
+// from the account check, so retries succeed even if the already-refunded
+// rows belong to different accounts.
 // Returns 403 for non-admin callers, 400 if the transaction hash is missing
 // or malformed, or if no batch ids are provided.
 // ---------------------------------------------------------------------------

--- a/apps/backend/src/core/users/credits.ts
+++ b/apps/backend/src/core/users/credits.ts
@@ -279,12 +279,13 @@ const refundBatch = async (
 // (one AI3 transfer can cover multiple batches of the same account).
 // All-or-nothing: if any batch id does not exist nothing is updated and a
 // 404 listing the missing ids is returned. All batches still pending a
-// refund must belong to the same account — a combined refund spanning
-// several accounts is rejected with 400 and nothing is updated, since one
-// on-chain transfer can only go to a single wallet. Already-refunded
-// batches are skipped (idempotent, mirroring refundBatch) and are excluded
-// from the account check, so retries succeed even if the already-refunded
-// rows belong to different accounts.
+// refund must belong to the same account AND have been paid from the same
+// purchasing wallet (the intent's from_address) — one on-chain refund
+// transfer goes back to a single wallet, so a combined refund spanning
+// accounts or paying wallets is rejected with 400 and nothing is updated.
+// Already-refunded batches are skipped (idempotent, mirroring refundBatch)
+// and are excluded from both checks, so retries succeed even if the
+// already-refunded rows belong to different accounts or wallets.
 // Returns 403 for non-admin callers, 400 if the transaction hash is missing
 // or malformed, or if no batch ids are provided.
 // ---------------------------------------------------------------------------
@@ -348,6 +349,14 @@ const refundBatches = async (
     return err(
       new BadRequestError(
         'All batches in a combined refund must belong to the same account',
+      ),
+    )
+  }
+
+  if (result.walletAddresses.length > 1) {
+    return err(
+      new BadRequestError(
+        'All batches in a combined refund must have been paid from the same purchasing wallet',
       ),
     )
   }

--- a/apps/backend/src/infrastructure/repositories/users/purchasedCredits.ts
+++ b/apps/backend/src/infrastructure/repositories/users/purchasedCredits.ts
@@ -625,6 +625,9 @@ const markManyAsRefunded = async (
   try {
     await client.query('BEGIN')
 
+    // ORDER BY id makes the row locks acquire in a deterministic order so
+    // two overlapping combined-refund transactions cannot deadlock by
+    // locking the same rows in opposite orders.
     const existing = await client.query<{
       id: string
       account_id: string
@@ -633,6 +636,7 @@ const markManyAsRefunded = async (
       `SELECT id, account_id, refunded_at
        FROM purchased_credits
        WHERE id = ANY($1::uuid[])
+       ORDER BY id
        FOR UPDATE`,
       [ids],
     )

--- a/apps/backend/src/infrastructure/repositories/users/purchasedCredits.ts
+++ b/apps/backend/src/infrastructure/repositories/users/purchasedCredits.ts
@@ -617,20 +617,26 @@ const markAsRefunded = async (
 // All-or-nothing on existence: if any id does not exist the transaction is
 // rolled back and missingIds is returned so the caller can 404 precisely.
 // All batches that are actually going to be refunded must belong to the
-// SAME account — one on-chain AI3 transfer goes to a single wallet, so a
-// combined refund spanning several accounts is always a mistake. Rows that
-// are already refunded are skipped (idempotent, mirroring the single-row
-// behaviour) and keep their original tx hash, so they are excluded from the
-// account check — a retry where everything is already refunded succeeds
-// regardless of accounts. If the still-pending rows span multiple accounts
-// the transaction is rolled back and accountIds lists the offenders so the
-// caller can 400.
+// SAME account AND have been paid from the SAME purchasing wallet (the
+// intent's from_address) — one on-chain AI3 refund transfer goes back to a
+// single wallet, so a combined refund spanning accounts or paying wallets
+// is always a mistake. Rows that are already refunded are skipped
+// (idempotent, mirroring the single-row behaviour) and keep their original
+// tx hash, so they are excluded from both checks — a retry where everything
+// is already refunded succeeds regardless. If the still-pending rows span
+// multiple accounts or wallets the transaction is rolled back and
+// accountIds / walletAddresses list the offenders so the caller can 400.
+// Batches whose intent has no from_address recorded (legacy rows) are
+// grouped under null: they can be combined with each other but not with
+// batches paid from a known wallet.
 // ---------------------------------------------------------------------------
 
 export type BatchRefundResult = {
   missingIds: string[]
   /** Distinct account ids across the batches still pending refund. */
   accountIds: string[]
+  /** Distinct paying wallets (intents.from_address) across pending rows. */
+  walletAddresses: (string | null)[]
   refundedRows: PurchasedCredit[]
   alreadyRefundedIds: string[]
 }
@@ -646,6 +652,7 @@ const markManyAsRefunded = async (
     return {
       missingIds: malformedIds,
       accountIds: [],
+      walletAddresses: [],
       refundedRows: [],
       alreadyRefundedIds: [],
     }
@@ -659,17 +666,20 @@ const markManyAsRefunded = async (
 
     // ORDER BY id makes the row locks acquire in a deterministic order so
     // two overlapping combined-refund transactions cannot deadlock by
-    // locking the same rows in opposite orders.
+    // locking the same rows in opposite orders. FOR UPDATE OF pc locks only
+    // the purchased_credits rows, not the joined intents.
     const existing = await client.query<{
       id: string
       account_id: string
       refunded_at: Date | null
+      from_address: string | null
     }>(
-      `SELECT id, account_id, refunded_at
-       FROM purchased_credits
-       WHERE id = ANY($1::uuid[])
-       ORDER BY id
-       FOR UPDATE`,
+      `SELECT pc.id, pc.account_id, pc.refunded_at, i.from_address
+       FROM purchased_credits pc
+       JOIN intents i ON i.id = pc.intent_id
+       WHERE pc.id = ANY($1::uuid[])
+       ORDER BY pc.id
+       FOR UPDATE OF pc`,
       [ids],
     )
 
@@ -677,19 +687,34 @@ const markManyAsRefunded = async (
     const missingIds = ids.filter((id) => !existingIds.has(id))
 
     // Only rows still pending a refund are updated (and get the tx hash);
-    // already-refunded rows are idempotent no-ops, so the single-account
-    // constraint applies to the pending rows alone.
+    // already-refunded rows are idempotent no-ops, so the single-account /
+    // single-wallet constraints apply to the pending rows alone.
     const pendingRows = existing.rows.filter((r) => r.refunded_at === null)
     const accountIds = [...new Set(pendingRows.map((r) => r.account_id))]
+    const walletAddresses = [
+      ...new Set(pendingRows.map((r) => r.from_address)),
+    ]
 
     if (missingIds.length > 0) {
       await client.query('ROLLBACK')
-      return { missingIds, accountIds, refundedRows: [], alreadyRefundedIds: [] }
+      return {
+        missingIds,
+        accountIds,
+        walletAddresses,
+        refundedRows: [],
+        alreadyRefundedIds: [],
+      }
     }
 
-    if (accountIds.length > 1) {
+    if (accountIds.length > 1 || walletAddresses.length > 1) {
       await client.query('ROLLBACK')
-      return { missingIds: [], accountIds, refundedRows: [], alreadyRefundedIds: [] }
+      return {
+        missingIds: [],
+        accountIds,
+        walletAddresses,
+        refundedRows: [],
+        alreadyRefundedIds: [],
+      }
     }
 
     const alreadyRefundedIds = existing.rows
@@ -713,6 +738,7 @@ const markManyAsRefunded = async (
     return {
       missingIds: [],
       accountIds,
+      walletAddresses,
       refundedRows: updated.rows.map(mapRow),
       alreadyRefundedIds,
     }
@@ -788,12 +814,16 @@ const getByUserPublicId = async (
 
 export type AdminCreditBatchRow = PurchasedCredit & {
   userPublicId: string
+  /** EVM wallet that paid for the batch (intents.from_address), if known. */
+  fromAddress: string | null
 }
 
 const getAllWithUserPublicId = async (): Promise<AdminCreditBatchRow[]> => {
   const db = await getDatabase()
-  const result = await db.query<DBPurchasedCredit & { user_public_id: string }>(
-    `SELECT pc.*, i.user_public_id
+  const result = await db.query<
+    DBPurchasedCredit & { user_public_id: string; from_address: string | null }
+  >(
+    `SELECT pc.*, i.user_public_id, i.from_address
      FROM purchased_credits pc
      JOIN intents i ON i.id = pc.intent_id
      ORDER BY pc.purchased_at DESC`,
@@ -801,6 +831,7 @@ const getAllWithUserPublicId = async (): Promise<AdminCreditBatchRow[]> => {
   return result.rows.map((row) => ({
     ...mapRow(row),
     userPublicId: row.user_public_id,
+    fromAddress: row.from_address ?? null,
   }))
 }
 

--- a/apps/backend/src/infrastructure/repositories/users/purchasedCredits.ts
+++ b/apps/backend/src/infrastructure/repositories/users/purchasedCredits.ts
@@ -555,18 +555,35 @@ const createPurchasedCreditWithCapCheck = async (
 }
 
 // ---------------------------------------------------------------------------
+// UUID guard
+// purchased_credits.id is a UUID column; comparing it against a malformed
+// string (or casting one via ::uuid[]) makes Postgres throw, which would
+// surface as a 500. The use cases already reject non-UUID ids with 400, but
+// the repository treats them as "not found" as well so no caller can
+// trigger a cast error.
+// ---------------------------------------------------------------------------
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+// ---------------------------------------------------------------------------
 // markAsRefunded
 // Admin action: zero out remaining bytes for a single purchased_credits row
 // and mark it as refunded, recording the on-chain transaction hash of the
 // AI3 refund transfer.  Called after an admin has processed an out-of-band
 // refund (manual AI3 transfer back to the user's wallet).
 // Returns the updated row so the caller can echo it back to the client.
+// Malformed (non-UUID) ids are reported as not found.
 // ---------------------------------------------------------------------------
 
 const markAsRefunded = async (
   id: string,
   refundTxHash: string,
 ): Promise<{ found: boolean; row: PurchasedCredit | null }> => {
+  if (!UUID_REGEX.test(id)) {
+    return { found: false, row: null }
+  }
+
   const db = await getDatabase()
   const result = await db.query<DBPurchasedCredit>(
     `UPDATE purchased_credits
@@ -622,6 +639,18 @@ const markManyAsRefunded = async (
   ids: string[],
   refundTxHash: string,
 ): Promise<BatchRefundResult> => {
+  // Malformed ids can never match a row; report them as missing instead of
+  // letting the ::uuid[] cast throw (which would surface as a 500).
+  const malformedIds = ids.filter((id) => !UUID_REGEX.test(id))
+  if (malformedIds.length > 0) {
+    return {
+      missingIds: malformedIds,
+      accountIds: [],
+      refundedRows: [],
+      alreadyRefundedIds: [],
+    }
+  }
+
   const db = await getDatabase()
   const client = await db.connect()
 

--- a/apps/backend/src/infrastructure/repositories/users/purchasedCredits.ts
+++ b/apps/backend/src/infrastructure/repositories/users/purchasedCredits.ts
@@ -24,6 +24,7 @@ type DBPurchasedCredit = {
   expires_at: Date
   expired: boolean
   refunded_at: Date | null
+  refund_tx_hash: string | null
   created_at: Date
   updated_at: Date
 }
@@ -40,6 +41,7 @@ const mapRow = (row: DBPurchasedCredit): PurchasedCredit => ({
   expiresAt: row.expires_at,
   expired: row.expired,
   refundedAt: row.refunded_at,
+  refundTxHash: row.refund_tx_hash,
   createdAt: row.created_at,
   updatedAt: row.updated_at,
 })
@@ -555,13 +557,15 @@ const createPurchasedCreditWithCapCheck = async (
 // ---------------------------------------------------------------------------
 // markAsRefunded
 // Admin action: zero out remaining bytes for a single purchased_credits row
-// and mark it as refunded.  Called after an admin has processed an
-// out-of-band refund (e.g. manual AI3 transfer back to the user's wallet).
+// and mark it as refunded, recording the on-chain transaction hash of the
+// AI3 refund transfer.  Called after an admin has processed an out-of-band
+// refund (manual AI3 transfer back to the user's wallet).
 // Returns the updated row so the caller can echo it back to the client.
 // ---------------------------------------------------------------------------
 
 const markAsRefunded = async (
   id: string,
+  refundTxHash: string,
 ): Promise<{ found: boolean; row: PurchasedCredit | null }> => {
   const db = await getDatabase()
   const result = await db.query<DBPurchasedCredit>(
@@ -569,11 +573,12 @@ const markAsRefunded = async (
      SET upload_bytes_remaining   = 0,
          download_bytes_remaining = 0,
          refunded_at              = NOW(),
+         refund_tx_hash           = $2,
          updated_at               = NOW()
      WHERE id = $1
        AND refunded_at IS NULL
      RETURNING *`,
-    [id],
+    [id, refundTxHash],
   )
 
   if (result.rows[0]) {
@@ -585,6 +590,98 @@ const markAsRefunded = async (
     [id],
   )
   return { found: exists.rows.length > 0, row: null }
+}
+
+// ---------------------------------------------------------------------------
+// markManyAsRefunded
+// Admin action: batch variant of markAsRefunded. Marks every given batch as
+// refunded in a single transaction, recording the same on-chain refund
+// transaction hash on each row (one AI3 transfer can cover several batches).
+// All-or-nothing on existence: if any id does not exist the transaction is
+// rolled back and missingIds is returned so the caller can 404 precisely.
+// All batches must belong to the SAME account — one on-chain AI3 transfer
+// goes to a single wallet, so a combined refund spanning several accounts
+// is always a mistake. If the ids span multiple accounts the transaction is
+// rolled back and accountIds lists the offenders so the caller can 400.
+// Rows that are already refunded are skipped (idempotent), mirroring the
+// single-row behaviour.
+// ---------------------------------------------------------------------------
+
+export type BatchRefundResult = {
+  missingIds: string[]
+  /** Distinct account ids covered by the requested batches. */
+  accountIds: string[]
+  refundedRows: PurchasedCredit[]
+  alreadyRefundedIds: string[]
+}
+
+const markManyAsRefunded = async (
+  ids: string[],
+  refundTxHash: string,
+): Promise<BatchRefundResult> => {
+  const db = await getDatabase()
+  const client = await db.connect()
+
+  try {
+    await client.query('BEGIN')
+
+    const existing = await client.query<{
+      id: string
+      account_id: string
+      refunded_at: Date | null
+    }>(
+      `SELECT id, account_id, refunded_at
+       FROM purchased_credits
+       WHERE id = ANY($1::uuid[])
+       FOR UPDATE`,
+      [ids],
+    )
+
+    const existingIds = new Set(existing.rows.map((r) => r.id))
+    const missingIds = ids.filter((id) => !existingIds.has(id))
+    const accountIds = [...new Set(existing.rows.map((r) => r.account_id))]
+
+    if (missingIds.length > 0) {
+      await client.query('ROLLBACK')
+      return { missingIds, accountIds, refundedRows: [], alreadyRefundedIds: [] }
+    }
+
+    if (accountIds.length > 1) {
+      await client.query('ROLLBACK')
+      return { missingIds: [], accountIds, refundedRows: [], alreadyRefundedIds: [] }
+    }
+
+    const alreadyRefundedIds = existing.rows
+      .filter((r) => r.refunded_at !== null)
+      .map((r) => r.id)
+
+    const updated = await client.query<DBPurchasedCredit>(
+      `UPDATE purchased_credits
+       SET upload_bytes_remaining   = 0,
+           download_bytes_remaining = 0,
+           refunded_at              = NOW(),
+           refund_tx_hash           = $2,
+           updated_at               = NOW()
+       WHERE id = ANY($1::uuid[])
+         AND refunded_at IS NULL
+       RETURNING *`,
+      [ids, refundTxHash],
+    )
+
+    await client.query('COMMIT')
+    return {
+      missingIds: [],
+      accountIds,
+      refundedRows: updated.rows.map(mapRow),
+      alreadyRefundedIds,
+    }
+  } catch (error) {
+    await client.query('ROLLBACK')
+    logger.error(error, 'markManyAsRefunded: transaction failed, rolled back')
+    throw error
+  } finally {
+    client.release()
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -684,5 +781,6 @@ export const purchasedCreditsRepository = {
   getByAccountId,
   getAllWithUserPublicId,
   markAsRefunded,
+  markManyAsRefunded,
   getByUserPublicId,
 }

--- a/apps/backend/src/infrastructure/repositories/users/purchasedCredits.ts
+++ b/apps/backend/src/infrastructure/repositories/users/purchasedCredits.ts
@@ -599,17 +599,20 @@ const markAsRefunded = async (
 // transaction hash on each row (one AI3 transfer can cover several batches).
 // All-or-nothing on existence: if any id does not exist the transaction is
 // rolled back and missingIds is returned so the caller can 404 precisely.
-// All batches must belong to the SAME account — one on-chain AI3 transfer
-// goes to a single wallet, so a combined refund spanning several accounts
-// is always a mistake. If the ids span multiple accounts the transaction is
-// rolled back and accountIds lists the offenders so the caller can 400.
-// Rows that are already refunded are skipped (idempotent), mirroring the
-// single-row behaviour.
+// All batches that are actually going to be refunded must belong to the
+// SAME account — one on-chain AI3 transfer goes to a single wallet, so a
+// combined refund spanning several accounts is always a mistake. Rows that
+// are already refunded are skipped (idempotent, mirroring the single-row
+// behaviour) and keep their original tx hash, so they are excluded from the
+// account check — a retry where everything is already refunded succeeds
+// regardless of accounts. If the still-pending rows span multiple accounts
+// the transaction is rolled back and accountIds lists the offenders so the
+// caller can 400.
 // ---------------------------------------------------------------------------
 
 export type BatchRefundResult = {
   missingIds: string[]
-  /** Distinct account ids covered by the requested batches. */
+  /** Distinct account ids across the batches still pending refund. */
   accountIds: string[]
   refundedRows: PurchasedCredit[]
   alreadyRefundedIds: string[]
@@ -643,7 +646,12 @@ const markManyAsRefunded = async (
 
     const existingIds = new Set(existing.rows.map((r) => r.id))
     const missingIds = ids.filter((id) => !existingIds.has(id))
-    const accountIds = [...new Set(existing.rows.map((r) => r.account_id))]
+
+    // Only rows still pending a refund are updated (and get the tx hash);
+    // already-refunded rows are idempotent no-ops, so the single-account
+    // constraint applies to the pending rows alone.
+    const pendingRows = existing.rows.filter((r) => r.refunded_at === null)
+    const accountIds = [...new Set(pendingRows.map((r) => r.account_id))]
 
     if (missingIds.length > 0) {
       await client.query('ROLLBACK')

--- a/apps/frontend/src/app/[chain]/drive/admin/credits/page.tsx
+++ b/apps/frontend/src/app/[chain]/drive/admin/credits/page.tsx
@@ -1,0 +1,12 @@
+import { AdminCredits } from '@/components/views/AdminPanel/AdminCredits';
+import { UserProtectedLayout } from '@/components/layouts/UserProtectedLayout';
+
+export const dynamic = 'force-dynamic';
+
+export default async function Page() {
+  return (
+    <UserProtectedLayout>
+      <AdminCredits />
+    </UserProtectedLayout>
+  );
+}

--- a/apps/frontend/src/components/views/AdminPanel/AdminCredits.tsx
+++ b/apps/frontend/src/components/views/AdminPanel/AdminCredits.tsx
@@ -250,12 +250,21 @@ const UserBatchGroupSection = ({
           </span>
         )}
       </div>
-      <Link
-        href={ROUTES.adminUserCredits(networkId, group.userPublicId)}
-        className='text-xs text-blue-500 hover:underline'
-      >
-        {group.refundableCount > 0 ? 'Process refunds →' : 'View details →'}
-      </Link>
+      <div className='flex items-center gap-3'>
+        <Link
+          href={ROUTES.adminOrganization(networkId, group.batches[0].accountId)}
+          className='text-xs text-blue-500 hover:underline'
+          title={`View account ${group.batches[0].accountId} — uploads and downloads`}
+        >
+          Account →
+        </Link>
+        <Link
+          href={ROUTES.adminUserCredits(networkId, group.userPublicId)}
+          className='text-xs text-blue-500 hover:underline'
+        >
+          {group.refundableCount > 0 ? 'Process refunds →' : 'View details →'}
+        </Link>
+      </div>
     </div>
 
     {/* Batch rows — hidden until the admin expands the account. */}

--- a/apps/frontend/src/components/views/AdminPanel/AdminCredits.tsx
+++ b/apps/frontend/src/components/views/AdminPanel/AdminCredits.tsx
@@ -133,22 +133,28 @@ const OverCapPanel = ({
 };
 
 // ---------------------------------------------------------------------------
-// Per-account batch group
-// Batches are grouped by accountId — credits belong to the shared
-// organization account, and several users of the same organization can each
-// purchase credits for it. Grouping by user would split one account into
-// multiple summary lines with incorrect totals.
+// Per-purchasing-wallet batch group
+// Batches are grouped by `batch.accountId`, the org-level storage account
+// referred to as the "purchasing wallet" in the admin UI — credits belong
+// to the shared organization account, and several users of the same
+// organization can each purchase credits for it. Grouping by user would
+// split one purchasing wallet into multiple summary lines with incorrect
+// totals; grouping by the paying EVM address would be wrong too, since it
+// varies per batch and the combined-refund constraint is per purchasing
+// wallet, not per address.
 // Each group renders as a single collapsed summary line (batch count,
 // purchased / remaining / expired storage). The admin can toggle each
-// account open to see the full batch list (with the purchasing user per
-// row) and spot accounts with refundable (expired, unused, not-yet-refunded)
-// batches to process together on the per-user refund screen.
+// purchasing wallet open to see the full batch list (with the purchasing
+// user per row) and spot wallets with refundable (expired, unused,
+// not-yet-refunded) batches to process together on the per-user refund
+// screen.
 // ---------------------------------------------------------------------------
 
-type AccountBatchGroup = {
-  accountId: string;
+type PurchasingWalletBatchGroup = {
+  /** batch.accountId — the org-level storage account. */
+  purchasingWalletId: string;
   batches: AdminCreditBatch[];
-  /** Distinct publicIds of the users who purchased for this account. */
+  /** Distinct publicIds of the users who purchased for this wallet. */
   userPublicIds: string[];
   refundableCount: number;
   refundedCount: number;
@@ -160,9 +166,9 @@ type AccountBatchGroup = {
   totalExpiredUnused: number;
 };
 
-const groupBatchesByAccount = (
+const groupBatchesByPurchasingWallet = (
   batches: AdminCreditBatch[],
-): AccountBatchGroup[] => {
+): PurchasingWalletBatchGroup[] => {
   const groups = new Map<string, AdminCreditBatch[]>();
   for (const batch of batches) {
     const existing = groups.get(batch.accountId);
@@ -173,24 +179,24 @@ const groupBatchesByAccount = (
     }
   }
 
-  return [...groups.entries()].map(([accountId, accountBatches]) => ({
-    accountId,
-    batches: accountBatches,
-    userPublicIds: [...new Set(accountBatches.map((b) => b.userPublicId))],
-    refundableCount: accountBatches.filter(
+  return [...groups.entries()].map(([purchasingWalletId, walletBatches]) => ({
+    purchasingWalletId,
+    batches: walletBatches,
+    userPublicIds: [...new Set(walletBatches.map((b) => b.userPublicId))],
+    refundableCount: walletBatches.filter(
       (b) => b.expired && b.refundedAt === null,
     ).length,
-    refundedCount: accountBatches.filter((b) => b.refundedAt !== null).length,
-    totalPurchased: accountBatches.reduce(
+    refundedCount: walletBatches.filter((b) => b.refundedAt !== null).length,
+    totalPurchased: walletBatches.reduce(
       (s, b) => s + Number(BigInt(b.uploadBytesOriginal)),
       0,
     ),
-    totalRemaining: accountBatches.reduce(
+    totalRemaining: walletBatches.reduce(
       (s, b) =>
         s + (b.expired ? 0 : Number(BigInt(b.uploadBytesRemaining))),
       0,
     ),
-    totalExpiredUnused: accountBatches.reduce(
+    totalExpiredUnused: walletBatches.reduce(
       (s, b) =>
         s + (b.expired ? Number(BigInt(b.uploadBytesRemaining)) : 0),
       0,
@@ -198,19 +204,19 @@ const groupBatchesByAccount = (
   }));
 };
 
-const AccountBatchGroupSection = ({
+const PurchasingWalletBatchGroupSection = ({
   group,
   networkId,
   isExpanded,
   onToggle,
 }: {
-  group: AccountBatchGroup;
+  group: PurchasingWalletBatchGroup;
   networkId: NetworkId;
   isExpanded: boolean;
   onToggle: () => void;
 }) => (
   <div className='rounded-lg border border-border'>
-    {/* Single-line account summary — click the chevron to expand the list. */}
+    {/* Single-line purchasing wallet summary — chevron expands the list. */}
     <div
       className={`flex flex-wrap items-center justify-between gap-2 bg-muted/50 px-4 py-3 ${
         isExpanded ? 'border-b border-border' : ''
@@ -222,7 +228,9 @@ const AccountBatchGroupSection = ({
           onClick={onToggle}
           aria-expanded={isExpanded}
           aria-label={
-            isExpanded ? 'Hide batches for account' : 'Show batches for account'
+            isExpanded
+              ? 'Hide batches for purchasing wallet'
+              : 'Show batches for purchasing wallet'
           }
           className='text-muted-foreground hover:text-foreground'
         >
@@ -233,11 +241,11 @@ const AccountBatchGroupSection = ({
           )}
         </button>
         <Link
-          href={ROUTES.adminOrganization(networkId, group.accountId)}
+          href={ROUTES.adminOrganization(networkId, group.purchasingWalletId)}
           className='font-mono text-xs text-blue-500 hover:underline'
-          title={`Account ${group.accountId} — uploads and downloads`}
+          title={`Purchasing wallet ${group.purchasingWalletId} — uploads and downloads`}
         >
-          {group.accountId.slice(0, 20)}…
+          {group.purchasingWalletId.slice(0, 20)}…
         </Link>
         <span className='text-xs text-muted-foreground'>
           {group.batches.length}{' '}
@@ -275,7 +283,7 @@ const AccountBatchGroupSection = ({
       </div>
     </div>
 
-    {/* Batch rows — hidden until the admin expands the account. */}
+    {/* Batch rows — hidden until the admin expands the purchasing wallet. */}
     {isExpanded && (
     <div className='overflow-x-auto'>
       <table className='w-full text-sm'>
@@ -393,19 +401,19 @@ export const AdminCredits = () => {
   const { api, network } = useNetwork();
   const queryClient = useQueryClient();
 
-  // Accounts whose full batch list is currently expanded. Collapsed by
-  // default so the screen shows one summary line per account.
-  const [expandedAccountIds, setExpandedAccountIds] = useState<Set<string>>(
+  // Purchasing wallets whose full batch list is currently expanded.
+  // Collapsed by default so the screen shows one summary line per wallet.
+  const [expandedWalletIds, setExpandedWalletIds] = useState<Set<string>>(
     new Set(),
   );
 
-  const toggleExpanded = (accountId: string) => {
-    setExpandedAccountIds((prev) => {
+  const toggleExpanded = (purchasingWalletId: string) => {
+    setExpandedWalletIds((prev) => {
       const next = new Set(prev);
-      if (next.has(accountId)) {
-        next.delete(accountId);
+      if (next.has(purchasingWalletId)) {
+        next.delete(purchasingWalletId);
       } else {
-        next.add(accountId);
+        next.add(purchasingWalletId);
       }
       return next;
     });
@@ -446,7 +454,10 @@ export const AdminCredits = () => {
     },
   });
 
-  const groups = useMemo(() => groupBatchesByAccount(batches), [batches]);
+  const groups = useMemo(
+    () => groupBatchesByPurchasingWallet(batches),
+    [batches],
+  );
   const awaitingRefund = useMemo(
     () => groups.reduce((s, g) => s + g.refundableCount, 0),
     [groups],
@@ -467,7 +478,7 @@ export const AdminCredits = () => {
         <div>
           <h1 className='text-2xl font-bold'>Purchased Credits</h1>
           <p className='mt-0.5 text-xs text-muted-foreground'>
-            All credit batches across all users, grouped by account.
+            All credit batches across all users, grouped by purchasing wallet.
           </p>
         </div>
         {isLoading && (
@@ -533,15 +544,15 @@ export const AdminCredits = () => {
             <button
               type='button'
               onClick={() =>
-                setExpandedAccountIds(
-                  expandedAccountIds.size === groups.length
+                setExpandedWalletIds(
+                  expandedWalletIds.size === groups.length
                     ? new Set()
-                    : new Set(groups.map((g) => g.accountId)),
+                    : new Set(groups.map((g) => g.purchasingWalletId)),
                 )
               }
               className='ml-auto text-xs text-blue-500 hover:underline'
             >
-              {expandedAccountIds.size === groups.length
+              {expandedWalletIds.size === groups.length
                 ? 'Collapse all'
                 : 'Expand all'}
             </button>
@@ -556,12 +567,12 @@ export const AdminCredits = () => {
         ) : (
           <div className='space-y-3'>
             {groups.map((group) => (
-              <AccountBatchGroupSection
-                key={group.accountId}
+              <PurchasingWalletBatchGroupSection
+                key={group.purchasingWalletId}
                 group={group}
                 networkId={network.id}
-                isExpanded={expandedAccountIds.has(group.accountId)}
-                onToggle={() => toggleExpanded(group.accountId)}
+                isExpanded={expandedWalletIds.has(group.purchasingWalletId)}
+                onToggle={() => toggleExpanded(group.purchasingWalletId)}
               />
             ))}
           </div>

--- a/apps/frontend/src/components/views/AdminPanel/AdminCredits.tsx
+++ b/apps/frontend/src/components/views/AdminPanel/AdminCredits.tsx
@@ -133,17 +133,23 @@ const OverCapPanel = ({
 };
 
 // ---------------------------------------------------------------------------
-// Per-user batch group
-// Batches are grouped by account and rendered as a single collapsed summary
-// line (batch count, purchased / remaining / expired storage). The admin can
-// toggle each account open to see the full batch list, and immediately spot
-// accounts with refundable (expired, unused, not-yet-refunded) batches to
-// process together on the per-user refund screen.
+// Per-account batch group
+// Batches are grouped by accountId — credits belong to the shared
+// organization account, and several users of the same organization can each
+// purchase credits for it. Grouping by user would split one account into
+// multiple summary lines with incorrect totals.
+// Each group renders as a single collapsed summary line (batch count,
+// purchased / remaining / expired storage). The admin can toggle each
+// account open to see the full batch list (with the purchasing user per
+// row) and spot accounts with refundable (expired, unused, not-yet-refunded)
+// batches to process together on the per-user refund screen.
 // ---------------------------------------------------------------------------
 
-type UserBatchGroup = {
-  userPublicId: string;
+type AccountBatchGroup = {
+  accountId: string;
   batches: AdminCreditBatch[];
+  /** Distinct publicIds of the users who purchased for this account. */
+  userPublicIds: string[];
   refundableCount: number;
   refundedCount: number;
   /** Σ upload_bytes_original across all batches. */
@@ -154,36 +160,37 @@ type UserBatchGroup = {
   totalExpiredUnused: number;
 };
 
-const groupBatchesByUser = (
+const groupBatchesByAccount = (
   batches: AdminCreditBatch[],
-): UserBatchGroup[] => {
+): AccountBatchGroup[] => {
   const groups = new Map<string, AdminCreditBatch[]>();
   for (const batch of batches) {
-    const existing = groups.get(batch.userPublicId);
+    const existing = groups.get(batch.accountId);
     if (existing) {
       existing.push(batch);
     } else {
-      groups.set(batch.userPublicId, [batch]);
+      groups.set(batch.accountId, [batch]);
     }
   }
 
-  return [...groups.entries()].map(([userPublicId, userBatches]) => ({
-    userPublicId,
-    batches: userBatches,
-    refundableCount: userBatches.filter(
+  return [...groups.entries()].map(([accountId, accountBatches]) => ({
+    accountId,
+    batches: accountBatches,
+    userPublicIds: [...new Set(accountBatches.map((b) => b.userPublicId))],
+    refundableCount: accountBatches.filter(
       (b) => b.expired && b.refundedAt === null,
     ).length,
-    refundedCount: userBatches.filter((b) => b.refundedAt !== null).length,
-    totalPurchased: userBatches.reduce(
+    refundedCount: accountBatches.filter((b) => b.refundedAt !== null).length,
+    totalPurchased: accountBatches.reduce(
       (s, b) => s + Number(BigInt(b.uploadBytesOriginal)),
       0,
     ),
-    totalRemaining: userBatches.reduce(
+    totalRemaining: accountBatches.reduce(
       (s, b) =>
         s + (b.expired ? 0 : Number(BigInt(b.uploadBytesRemaining))),
       0,
     ),
-    totalExpiredUnused: userBatches.reduce(
+    totalExpiredUnused: accountBatches.reduce(
       (s, b) =>
         s + (b.expired ? Number(BigInt(b.uploadBytesRemaining)) : 0),
       0,
@@ -191,13 +198,13 @@ const groupBatchesByUser = (
   }));
 };
 
-const UserBatchGroupSection = ({
+const AccountBatchGroupSection = ({
   group,
   networkId,
   isExpanded,
   onToggle,
 }: {
-  group: UserBatchGroup;
+  group: AccountBatchGroup;
   networkId: NetworkId;
   isExpanded: boolean;
   onToggle: () => void;
@@ -226,16 +233,18 @@ const UserBatchGroupSection = ({
           )}
         </button>
         <Link
-          href={ROUTES.adminUserCredits(networkId, group.userPublicId)}
+          href={ROUTES.adminOrganization(networkId, group.accountId)}
           className='font-mono text-xs text-blue-500 hover:underline'
-          title={group.userPublicId}
+          title={`Account ${group.accountId} — uploads and downloads`}
         >
-          {group.userPublicId.slice(0, 20)}…
+          {group.accountId.slice(0, 20)}…
         </Link>
         <span className='text-xs text-muted-foreground'>
           {group.batches.length}{' '}
-          {group.batches.length === 1 ? 'batch' : 'batches'} ·{' '}
-          {formatBytes(group.totalPurchased, 1)} purchased ·{' '}
+          {group.batches.length === 1 ? 'batch' : 'batches'}
+          {group.userPublicIds.length > 1 &&
+            ` (${group.userPublicIds.length} users)`}{' '}
+          · {formatBytes(group.totalPurchased, 1)} purchased ·{' '}
           {formatBytes(group.totalRemaining, 1)} remaining ·{' '}
           <span
             className={group.totalExpiredUnused > 0 ? 'text-red-500' : ''}
@@ -251,19 +260,18 @@ const UserBatchGroupSection = ({
         )}
       </div>
       <div className='flex items-center gap-3'>
-        <Link
-          href={ROUTES.adminOrganization(networkId, group.batches[0].accountId)}
-          className='text-xs text-blue-500 hover:underline'
-          title={`View account ${group.batches[0].accountId} — uploads and downloads`}
-        >
-          Account →
-        </Link>
-        <Link
-          href={ROUTES.adminUserCredits(networkId, group.userPublicId)}
-          className='text-xs text-blue-500 hover:underline'
-        >
-          {group.refundableCount > 0 ? 'Process refunds →' : 'View details →'}
-        </Link>
+        {group.userPublicIds.length === 1 ? (
+          <Link
+            href={ROUTES.adminUserCredits(networkId, group.userPublicIds[0])}
+            className='text-xs text-blue-500 hover:underline'
+          >
+            {group.refundableCount > 0 ? 'Process refunds →' : 'View details →'}
+          </Link>
+        ) : (
+          <span className='text-xs text-muted-foreground'>
+            Expand to pick a user
+          </span>
+        )}
       </div>
     </div>
 
@@ -273,6 +281,7 @@ const UserBatchGroupSection = ({
       <table className='w-full text-sm'>
         <thead>
           <tr className='border-b border-border text-left text-xs text-muted-foreground'>
+            <th className='px-4 py-2 font-medium'>User</th>
             <th className='px-4 py-2 font-medium'>Status</th>
             <th className='px-4 py-2 font-medium'>Purchased</th>
             <th className='px-4 py-2 font-medium'>Original</th>
@@ -297,6 +306,18 @@ const UserBatchGroupSection = ({
                 key={batch.id}
                 className='border-b border-border last:border-0'
               >
+                <td className='px-4 py-2 font-mono text-xs'>
+                  <Link
+                    href={ROUTES.adminUserCredits(
+                      networkId,
+                      batch.userPublicId,
+                    )}
+                    className='text-blue-500 hover:underline'
+                    title={batch.userPublicId}
+                  >
+                    {batch.userPublicId.slice(0, 12)}…
+                  </Link>
+                </td>
                 <td className='px-4 py-2'>
                   <span
                     className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_CLASSES[status]}`}
@@ -374,17 +395,17 @@ export const AdminCredits = () => {
 
   // Accounts whose full batch list is currently expanded. Collapsed by
   // default so the screen shows one summary line per account.
-  const [expandedUserIds, setExpandedUserIds] = useState<Set<string>>(
+  const [expandedAccountIds, setExpandedAccountIds] = useState<Set<string>>(
     new Set(),
   );
 
-  const toggleExpanded = (userPublicId: string) => {
-    setExpandedUserIds((prev) => {
+  const toggleExpanded = (accountId: string) => {
+    setExpandedAccountIds((prev) => {
       const next = new Set(prev);
-      if (next.has(userPublicId)) {
-        next.delete(userPublicId);
+      if (next.has(accountId)) {
+        next.delete(accountId);
       } else {
-        next.add(userPublicId);
+        next.add(accountId);
       }
       return next;
     });
@@ -425,7 +446,7 @@ export const AdminCredits = () => {
     },
   });
 
-  const groups = useMemo(() => groupBatchesByUser(batches), [batches]);
+  const groups = useMemo(() => groupBatchesByAccount(batches), [batches]);
   const awaitingRefund = useMemo(
     () => groups.reduce((s, g) => s + g.refundableCount, 0),
     [groups],
@@ -512,15 +533,15 @@ export const AdminCredits = () => {
             <button
               type='button'
               onClick={() =>
-                setExpandedUserIds(
-                  expandedUserIds.size === groups.length
+                setExpandedAccountIds(
+                  expandedAccountIds.size === groups.length
                     ? new Set()
-                    : new Set(groups.map((g) => g.userPublicId)),
+                    : new Set(groups.map((g) => g.accountId)),
                 )
               }
               className='ml-auto text-xs text-blue-500 hover:underline'
             >
-              {expandedUserIds.size === groups.length
+              {expandedAccountIds.size === groups.length
                 ? 'Collapse all'
                 : 'Expand all'}
             </button>
@@ -535,12 +556,12 @@ export const AdminCredits = () => {
         ) : (
           <div className='space-y-3'>
             {groups.map((group) => (
-              <UserBatchGroupSection
-                key={group.userPublicId}
+              <AccountBatchGroupSection
+                key={group.accountId}
                 group={group}
                 networkId={network.id}
-                isExpanded={expandedUserIds.has(group.userPublicId)}
-                onToggle={() => toggleExpanded(group.userPublicId)}
+                isExpanded={expandedAccountIds.has(group.accountId)}
+                onToggle={() => toggleExpanded(group.accountId)}
               />
             ))}
           </div>

--- a/apps/frontend/src/components/views/AdminPanel/AdminCredits.tsx
+++ b/apps/frontend/src/components/views/AdminPanel/AdminCredits.tsx
@@ -133,29 +133,29 @@ const OverCapPanel = ({
 };
 
 // ---------------------------------------------------------------------------
-// Per-purchasing-wallet batch group
-// Batches are grouped by `batch.accountId`, the org-level storage account
-// referred to as the "purchasing wallet" in the admin UI — credits belong
-// to the shared organization account, and several users of the same
-// organization can each purchase credits for it. Grouping by user would
-// split one purchasing wallet into multiple summary lines with incorrect
-// totals; grouping by the paying EVM address would be wrong too, since it
-// varies per batch and the combined-refund constraint is per purchasing
-// wallet, not per address.
+// Per-account batch group
+// Top-level grouping is by `batch.accountId` — the org-level storage
+// account that credits belong to; several users of the same organization
+// can each purchase credits for it, so grouping by user would split one
+// account into multiple summary lines with incorrect totals.
+// Within an account, batches can have been paid from different purchasing
+// wallets (the intent's fromAddress). Refunds are batched per
+// (account, purchasing wallet) pair — one refund transfer goes back to one
+// wallet — so the expanded list is sorted by purchasing wallet and shows it
+// per row; the actual refund selection happens on the per-user screen,
+// which enforces the same pairing.
 // Each group renders as a single collapsed summary line (batch count,
-// purchased / remaining / expired storage). The admin can toggle each
-// purchasing wallet open to see the full batch list (with the purchasing
-// user per row) and spot wallets with refundable (expired, unused,
-// not-yet-refunded) batches to process together on the per-user refund
-// screen.
+// users / wallets involved, purchased / remaining / expired storage).
 // ---------------------------------------------------------------------------
 
-type PurchasingWalletBatchGroup = {
+type AccountBatchGroup = {
   /** batch.accountId — the org-level storage account. */
-  purchasingWalletId: string;
+  accountId: string;
   batches: AdminCreditBatch[];
-  /** Distinct publicIds of the users who purchased for this wallet. */
+  /** Distinct publicIds of the users who purchased for this account. */
   userPublicIds: string[];
+  /** Distinct purchasing wallets (fromAddress) across the batches. */
+  walletCount: number;
   refundableCount: number;
   refundedCount: number;
   /** Σ upload_bytes_original across all batches. */
@@ -166,9 +166,9 @@ type PurchasingWalletBatchGroup = {
   totalExpiredUnused: number;
 };
 
-const groupBatchesByPurchasingWallet = (
+const groupBatchesByAccount = (
   batches: AdminCreditBatch[],
-): PurchasingWalletBatchGroup[] => {
+): AccountBatchGroup[] => {
   const groups = new Map<string, AdminCreditBatch[]>();
   for (const batch of batches) {
     const existing = groups.get(batch.accountId);
@@ -179,24 +179,31 @@ const groupBatchesByPurchasingWallet = (
     }
   }
 
-  return [...groups.entries()].map(([purchasingWalletId, walletBatches]) => ({
-    purchasingWalletId,
-    batches: walletBatches,
-    userPublicIds: [...new Set(walletBatches.map((b) => b.userPublicId))],
-    refundableCount: walletBatches.filter(
+  return [...groups.entries()].map(([accountId, accountBatches]) => ({
+    accountId,
+    // Sort by purchasing wallet so batches that can be refunded together
+    // (same account + same wallet) are adjacent, newest first within each.
+    batches: [...accountBatches].sort(
+      (a, b) =>
+        (a.fromAddress ?? '').localeCompare(b.fromAddress ?? '') ||
+        new Date(b.purchasedAt).getTime() - new Date(a.purchasedAt).getTime(),
+    ),
+    userPublicIds: [...new Set(accountBatches.map((b) => b.userPublicId))],
+    walletCount: new Set(accountBatches.map((b) => b.fromAddress ?? '—')).size,
+    refundableCount: accountBatches.filter(
       (b) => b.expired && b.refundedAt === null,
     ).length,
-    refundedCount: walletBatches.filter((b) => b.refundedAt !== null).length,
-    totalPurchased: walletBatches.reduce(
+    refundedCount: accountBatches.filter((b) => b.refundedAt !== null).length,
+    totalPurchased: accountBatches.reduce(
       (s, b) => s + Number(BigInt(b.uploadBytesOriginal)),
       0,
     ),
-    totalRemaining: walletBatches.reduce(
+    totalRemaining: accountBatches.reduce(
       (s, b) =>
         s + (b.expired ? 0 : Number(BigInt(b.uploadBytesRemaining))),
       0,
     ),
-    totalExpiredUnused: walletBatches.reduce(
+    totalExpiredUnused: accountBatches.reduce(
       (s, b) =>
         s + (b.expired ? Number(BigInt(b.uploadBytesRemaining)) : 0),
       0,
@@ -204,13 +211,13 @@ const groupBatchesByPurchasingWallet = (
   }));
 };
 
-const PurchasingWalletBatchGroupSection = ({
+const AccountBatchGroupSection = ({
   group,
   networkId,
   isExpanded,
   onToggle,
 }: {
-  group: PurchasingWalletBatchGroup;
+  group: AccountBatchGroup;
   networkId: NetworkId;
   isExpanded: boolean;
   onToggle: () => void;
@@ -228,9 +235,7 @@ const PurchasingWalletBatchGroupSection = ({
           onClick={onToggle}
           aria-expanded={isExpanded}
           aria-label={
-            isExpanded
-              ? 'Hide batches for purchasing wallet'
-              : 'Show batches for purchasing wallet'
+            isExpanded ? 'Hide batches for account' : 'Show batches for account'
           }
           className='text-muted-foreground hover:text-foreground'
         >
@@ -241,17 +246,18 @@ const PurchasingWalletBatchGroupSection = ({
           )}
         </button>
         <Link
-          href={ROUTES.adminOrganization(networkId, group.purchasingWalletId)}
+          href={ROUTES.adminOrganization(networkId, group.accountId)}
           className='font-mono text-xs text-blue-500 hover:underline'
-          title={`Purchasing wallet ${group.purchasingWalletId} — uploads and downloads`}
+          title={`Account ${group.accountId} — uploads and downloads`}
         >
-          {group.purchasingWalletId.slice(0, 20)}…
+          {group.accountId.slice(0, 20)}…
         </Link>
         <span className='text-xs text-muted-foreground'>
           {group.batches.length}{' '}
           {group.batches.length === 1 ? 'batch' : 'batches'}
           {group.userPublicIds.length > 1 &&
-            ` (${group.userPublicIds.length} users)`}{' '}
+            ` (${group.userPublicIds.length} users)`}
+          {group.walletCount > 1 && ` (${group.walletCount} wallets)`}{' '}
           · {formatBytes(group.totalPurchased, 1)} purchased ·{' '}
           {formatBytes(group.totalRemaining, 1)} remaining ·{' '}
           <span
@@ -283,13 +289,15 @@ const PurchasingWalletBatchGroupSection = ({
       </div>
     </div>
 
-    {/* Batch rows — hidden until the admin expands the purchasing wallet. */}
+    {/* Batch rows — hidden until the admin expands the account. Sorted by
+        purchasing wallet so refundable-together batches are adjacent. */}
     {isExpanded && (
     <div className='overflow-x-auto'>
       <table className='w-full text-sm'>
         <thead>
           <tr className='border-b border-border text-left text-xs text-muted-foreground'>
             <th className='px-4 py-2 font-medium'>User</th>
+            <th className='px-4 py-2 font-medium'>Purchasing Wallet</th>
             <th className='px-4 py-2 font-medium'>Status</th>
             <th className='px-4 py-2 font-medium'>Purchased</th>
             <th className='px-4 py-2 font-medium'>Original</th>
@@ -325,6 +333,16 @@ const PurchasingWalletBatchGroupSection = ({
                   >
                     {batch.userPublicId.slice(0, 12)}…
                   </Link>
+                </td>
+                <td className='px-4 py-2 font-mono text-xs'>
+                  {batch.fromAddress ? (
+                    <span title={batch.fromAddress}>
+                      {batch.fromAddress.slice(0, 8)}…
+                      {batch.fromAddress.slice(-6)}
+                    </span>
+                  ) : (
+                    <span className='text-muted-foreground'>—</span>
+                  )}
                 </td>
                 <td className='px-4 py-2'>
                   <span
@@ -401,19 +419,19 @@ export const AdminCredits = () => {
   const { api, network } = useNetwork();
   const queryClient = useQueryClient();
 
-  // Purchasing wallets whose full batch list is currently expanded.
-  // Collapsed by default so the screen shows one summary line per wallet.
-  const [expandedWalletIds, setExpandedWalletIds] = useState<Set<string>>(
+  // Accounts whose full batch list is currently expanded. Collapsed by
+  // default so the screen shows one summary line per account.
+  const [expandedAccountIds, setExpandedAccountIds] = useState<Set<string>>(
     new Set(),
   );
 
-  const toggleExpanded = (purchasingWalletId: string) => {
-    setExpandedWalletIds((prev) => {
+  const toggleExpanded = (accountId: string) => {
+    setExpandedAccountIds((prev) => {
       const next = new Set(prev);
-      if (next.has(purchasingWalletId)) {
-        next.delete(purchasingWalletId);
+      if (next.has(accountId)) {
+        next.delete(accountId);
       } else {
-        next.add(purchasingWalletId);
+        next.add(accountId);
       }
       return next;
     });
@@ -455,7 +473,7 @@ export const AdminCredits = () => {
   });
 
   const groups = useMemo(
-    () => groupBatchesByPurchasingWallet(batches),
+    () => groupBatchesByAccount(batches),
     [batches],
   );
   const awaitingRefund = useMemo(
@@ -478,7 +496,8 @@ export const AdminCredits = () => {
         <div>
           <h1 className='text-2xl font-bold'>Purchased Credits</h1>
           <p className='mt-0.5 text-xs text-muted-foreground'>
-            All credit batches across all users, grouped by purchasing wallet.
+            All credit batches across all users, grouped by account. Refunds
+            are processed per account and purchasing wallet.
           </p>
         </div>
         {isLoading && (
@@ -544,15 +563,15 @@ export const AdminCredits = () => {
             <button
               type='button'
               onClick={() =>
-                setExpandedWalletIds(
-                  expandedWalletIds.size === groups.length
+                setExpandedAccountIds(
+                  expandedAccountIds.size === groups.length
                     ? new Set()
-                    : new Set(groups.map((g) => g.purchasingWalletId)),
+                    : new Set(groups.map((g) => g.accountId)),
                 )
               }
               className='ml-auto text-xs text-blue-500 hover:underline'
             >
-              {expandedWalletIds.size === groups.length
+              {expandedAccountIds.size === groups.length
                 ? 'Collapse all'
                 : 'Expand all'}
             </button>
@@ -567,12 +586,12 @@ export const AdminCredits = () => {
         ) : (
           <div className='space-y-3'>
             {groups.map((group) => (
-              <PurchasingWalletBatchGroupSection
-                key={group.purchasingWalletId}
+              <AccountBatchGroupSection
+                key={group.accountId}
                 group={group}
                 networkId={network.id}
-                isExpanded={expandedWalletIds.has(group.purchasingWalletId)}
-                onToggle={() => toggleExpanded(group.purchasingWalletId)}
+                isExpanded={expandedAccountIds.has(group.accountId)}
+                onToggle={() => toggleExpanded(group.accountId)}
               />
             ))}
           </div>

--- a/apps/frontend/src/components/views/AdminPanel/AdminCredits.tsx
+++ b/apps/frontend/src/components/views/AdminPanel/AdminCredits.tsx
@@ -1,12 +1,23 @@
 'use client';
 
+import { useMemo } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNetwork } from '../../../contexts/network';
 import { formatBytes } from '../../../utils/number';
 import { formatDate } from '../../../utils/time';
-import { RefreshCw, AlertTriangle, RotateCcw } from 'lucide-react';
+import {
+  ArrowLeft,
+  RefreshCw,
+  AlertTriangle,
+  RotateCcw,
+  CheckCircle2,
+} from 'lucide-react';
 import { Button, ROUTES, type NetworkId } from '@auto-drive/ui';
-import { getBatchStatus, STATUS_CLASSES, STATUS_LABEL } from '../../../utils/credits';
+import {
+  getBatchStatus,
+  STATUS_CLASSES,
+  STATUS_LABEL,
+} from '../../../utils/credits';
 import type {
   AdminCreditBatch,
   CreditEconomicsResponse,
@@ -120,40 +131,101 @@ const OverCapPanel = ({
 };
 
 // ---------------------------------------------------------------------------
-// All credit batches table
+// Per-user batch group
+// Batches are grouped by account so an admin can immediately see when one
+// user has several refundable (expired, unused, not-yet-refunded) batches
+// and process them together on the per-user refund screen.
 // ---------------------------------------------------------------------------
 
-const AllBatchesTable = ({
-  batches,
-  networkId,
-}: {
+type UserBatchGroup = {
+  userPublicId: string;
   batches: AdminCreditBatch[];
-  networkId: NetworkId;
-}) => {
-  if (batches.length === 0) {
-    return (
-      <p className='text-sm text-muted-foreground'>
-        No credit batches have been purchased yet.
-      </p>
-    );
+  refundableCount: number;
+  refundedCount: number;
+  totalRemaining: number;
+};
+
+const groupBatchesByUser = (
+  batches: AdminCreditBatch[],
+): UserBatchGroup[] => {
+  const groups = new Map<string, AdminCreditBatch[]>();
+  for (const batch of batches) {
+    const existing = groups.get(batch.userPublicId);
+    if (existing) {
+      existing.push(batch);
+    } else {
+      groups.set(batch.userPublicId, [batch]);
+    }
   }
 
-  return (
+  return [...groups.entries()].map(([userPublicId, userBatches]) => ({
+    userPublicId,
+    batches: userBatches,
+    refundableCount: userBatches.filter(
+      (b) => b.expired && b.refundedAt === null,
+    ).length,
+    refundedCount: userBatches.filter((b) => b.refundedAt !== null).length,
+    totalRemaining: userBatches.reduce(
+      (s, b) => s + Number(BigInt(b.uploadBytesRemaining)),
+      0,
+    ),
+  }));
+};
+
+const UserBatchGroupSection = ({
+  group,
+  networkId,
+}: {
+  group: UserBatchGroup;
+  networkId: NetworkId;
+}) => (
+  <div className='rounded-lg border border-border'>
+    {/* Group header */}
+    <div className='flex flex-wrap items-center justify-between gap-2 border-b border-border bg-muted/50 px-4 py-3'>
+      <div className='flex items-center gap-3'>
+        <Link
+          href={ROUTES.adminUserCredits(networkId, group.userPublicId)}
+          className='font-mono text-xs text-blue-500 hover:underline'
+          title={group.userPublicId}
+        >
+          {group.userPublicId.slice(0, 20)}…
+        </Link>
+        <span className='text-xs text-muted-foreground'>
+          {group.batches.length}{' '}
+          {group.batches.length === 1 ? 'batch' : 'batches'} ·{' '}
+          {formatBytes(group.totalRemaining, 1)} remaining
+        </span>
+        {group.refundableCount > 0 && (
+          <span className='inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900/30 dark:text-amber-400'>
+            <AlertTriangle className='h-3 w-3' />
+            {group.refundableCount} awaiting refund
+          </span>
+        )}
+      </div>
+      <Link
+        href={ROUTES.adminUserCredits(networkId, group.userPublicId)}
+        className='text-xs text-blue-500 hover:underline'
+      >
+        {group.refundableCount > 0 ? 'Process refunds →' : 'View details →'}
+      </Link>
+    </div>
+
+    {/* Batch rows */}
     <div className='overflow-x-auto'>
       <table className='w-full text-sm'>
         <thead>
           <tr className='border-b border-border text-left text-xs text-muted-foreground'>
-            <th className='pb-2 pr-4 font-medium'>User</th>
-            <th className='pb-2 pr-4 font-medium'>Status</th>
-            <th className='pb-2 pr-4 font-medium'>Purchased</th>
-            <th className='pb-2 pr-4 font-medium'>Original</th>
-            <th className='pb-2 pr-4 font-medium'>Remaining</th>
-            <th className='pb-2 pr-4 font-medium'>Used %</th>
-            <th className='pb-2 font-medium'>Expires</th>
+            <th className='px-4 py-2 font-medium'>Status</th>
+            <th className='px-4 py-2 font-medium'>Purchased</th>
+            <th className='px-4 py-2 font-medium'>Original</th>
+            <th className='px-4 py-2 font-medium'>Remaining</th>
+            <th className='px-4 py-2 font-medium'>Used %</th>
+            <th className='px-4 py-2 font-medium'>Expires</th>
+            <th className='px-4 py-2 font-medium'>Refund</th>
           </tr>
         </thead>
         <tbody>
-          {batches.map((batch) => {
+          {group.batches.map((batch) => {
             const status = getBatchStatus(batch);
             const original = Number(BigInt(batch.uploadBytesOriginal));
             const remaining = Number(BigInt(batch.uploadBytesRemaining));
@@ -167,32 +239,23 @@ const AllBatchesTable = ({
                 key={batch.id}
                 className='border-b border-border last:border-0'
               >
-                <td className='py-2 pr-4 font-mono text-xs'>
-                  <Link
-                    href={ROUTES.adminUserCredits(networkId, batch.userPublicId)}
-                    className='text-blue-500 hover:underline'
-                    title={batch.userPublicId}
-                  >
-                    {batch.userPublicId.slice(0, 14)}…
-                  </Link>
-                </td>
-                <td className='py-2 pr-4'>
+                <td className='px-4 py-2'>
                   <span
                     className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_CLASSES[status]}`}
                   >
                     {STATUS_LABEL[status]}
                   </span>
                 </td>
-                <td className='py-2 pr-4 text-xs'>
+                <td className='px-4 py-2 text-xs'>
                   {formatDate(batch.purchasedAt)}
                 </td>
-                <td className='py-2 pr-4 text-xs'>
+                <td className='px-4 py-2 text-xs'>
                   {formatBytes(original, 1)}
                 </td>
-                <td className='py-2 pr-4 text-xs'>
+                <td className='px-4 py-2 text-xs'>
                   {formatBytes(remaining, 1)}
                 </td>
-                <td className='py-2 pr-4'>
+                <td className='px-4 py-2'>
                   <div className='flex items-center gap-2'>
                     <div className='h-1.5 w-16 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700'>
                       <div
@@ -205,7 +268,7 @@ const AllBatchesTable = ({
                     </span>
                   </div>
                 </td>
-                <td className='py-2 text-xs'>
+                <td className='px-4 py-2 text-xs'>
                   {batch.expired ? (
                     <span className='text-red-500'>
                       Expired {formatDate(batch.expiresAt)}
@@ -214,17 +277,36 @@ const AllBatchesTable = ({
                     formatDate(batch.expiresAt)
                   )}
                 </td>
+                <td className='px-4 py-2 text-xs'>
+                  {batch.refundedAt !== null ? (
+                    <span
+                      className='inline-flex items-center gap-1 text-muted-foreground'
+                      title={batch.refundTxHash ?? undefined}
+                    >
+                      <CheckCircle2 className='h-3 w-3 text-green-500' />
+                      {formatDate(batch.refundedAt)}
+                      {batch.refundTxHash && (
+                        <span className='font-mono'>
+                          · {batch.refundTxHash.slice(0, 10)}…
+                        </span>
+                      )}
+                    </span>
+                  ) : (
+                    <span className='text-muted-foreground'>—</span>
+                  )}
+                </td>
               </tr>
             );
           })}
         </tbody>
       </table>
     </div>
-  );
-};
+  </div>
+);
 
 // ---------------------------------------------------------------------------
-// Main component
+// Main component — dedicated admin screen for all purchased credits.
+// Rendered at /{chainId}/drive/admin/credits.
 // ---------------------------------------------------------------------------
 
 export const AdminCredits = () => {
@@ -266,14 +348,32 @@ export const AdminCredits = () => {
     },
   });
 
+  const groups = useMemo(() => groupBatchesByUser(batches), [batches]);
+  const awaitingRefund = useMemo(
+    () => groups.reduce((s, g) => s + g.refundableCount, 0),
+    [groups],
+  );
+
   const isLoading = economicsLoading || batchesLoading || overCapLoading;
 
   return (
-    <div className='space-y-8'>
-      <div className='flex items-center gap-2'>
-        <h2 className='text-xl font-semibold'>Purchased Credits</h2>
+    <div className='space-y-8 p-6'>
+      {/* Header */}
+      <div className='flex items-center gap-3'>
+        <Link
+          href={ROUTES.admin(network.id)}
+          className='text-muted-foreground hover:text-foreground'
+        >
+          <ArrowLeft className='h-5 w-5' />
+        </Link>
+        <div>
+          <h1 className='text-2xl font-bold'>Purchased Credits</h1>
+          <p className='mt-0.5 text-xs text-muted-foreground'>
+            All credit batches across all users, grouped by account.
+          </p>
+        </div>
         {isLoading && (
-          <RefreshCw className='h-4 w-4 animate-spin text-muted-foreground' />
+          <RefreshCw className='ml-auto h-4 w-4 animate-spin text-muted-foreground' />
         )}
       </div>
 
@@ -319,12 +419,36 @@ export const AdminCredits = () => {
         />
       </div>
 
-      {/* All batches table */}
+      {/* All batches grouped by user */}
       <div>
-        <h3 className='mb-3 text-sm font-medium text-muted-foreground uppercase tracking-wide'>
-          All Purchase Batches ({batches.length})
-        </h3>
-        <AllBatchesTable batches={batches} networkId={network.id} />
+        <div className='mb-3 flex items-center gap-2'>
+          <h3 className='text-sm font-medium text-muted-foreground uppercase tracking-wide'>
+            All Purchase Batches ({batches.length})
+          </h3>
+          {awaitingRefund > 0 && (
+            <span className='inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900/30 dark:text-amber-400'>
+              <AlertTriangle className='h-3 w-3' />
+              {awaitingRefund} expired awaiting refund
+            </span>
+          )}
+        </div>
+        {groups.length === 0 ? (
+          !batchesLoading && (
+            <p className='text-sm text-muted-foreground'>
+              No credit batches have been purchased yet.
+            </p>
+          )
+        ) : (
+          <div className='space-y-4'>
+            {groups.map((group) => (
+              <UserBatchGroupSection
+                key={group.userPublicId}
+                group={group}
+                networkId={network.id}
+              />
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/frontend/src/components/views/AdminPanel/AdminCredits.tsx
+++ b/apps/frontend/src/components/views/AdminPanel/AdminCredits.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNetwork } from '../../../contexts/network';
 import { formatBytes } from '../../../utils/number';
@@ -11,6 +11,8 @@ import {
   AlertTriangle,
   RotateCcw,
   CheckCircle2,
+  ChevronDown,
+  ChevronRight,
 } from 'lucide-react';
 import { Button, ROUTES, type NetworkId } from '@auto-drive/ui';
 import {
@@ -132,9 +134,11 @@ const OverCapPanel = ({
 
 // ---------------------------------------------------------------------------
 // Per-user batch group
-// Batches are grouped by account so an admin can immediately see when one
-// user has several refundable (expired, unused, not-yet-refunded) batches
-// and process them together on the per-user refund screen.
+// Batches are grouped by account and rendered as a single collapsed summary
+// line (batch count, purchased / remaining / expired storage). The admin can
+// toggle each account open to see the full batch list, and immediately spot
+// accounts with refundable (expired, unused, not-yet-refunded) batches to
+// process together on the per-user refund screen.
 // ---------------------------------------------------------------------------
 
 type UserBatchGroup = {
@@ -142,7 +146,12 @@ type UserBatchGroup = {
   batches: AdminCreditBatch[];
   refundableCount: number;
   refundedCount: number;
+  /** Σ upload_bytes_original across all batches. */
+  totalPurchased: number;
+  /** Σ upload_bytes_remaining across non-expired batches (still usable). */
   totalRemaining: number;
+  /** Σ upload_bytes_remaining across expired batches (forfeited unused). */
+  totalExpiredUnused: number;
 };
 
 const groupBatchesByUser = (
@@ -165,8 +174,18 @@ const groupBatchesByUser = (
       (b) => b.expired && b.refundedAt === null,
     ).length,
     refundedCount: userBatches.filter((b) => b.refundedAt !== null).length,
+    totalPurchased: userBatches.reduce(
+      (s, b) => s + Number(BigInt(b.uploadBytesOriginal)),
+      0,
+    ),
     totalRemaining: userBatches.reduce(
-      (s, b) => s + Number(BigInt(b.uploadBytesRemaining)),
+      (s, b) =>
+        s + (b.expired ? 0 : Number(BigInt(b.uploadBytesRemaining))),
+      0,
+    ),
+    totalExpiredUnused: userBatches.reduce(
+      (s, b) =>
+        s + (b.expired ? Number(BigInt(b.uploadBytesRemaining)) : 0),
       0,
     ),
   }));
@@ -175,14 +194,37 @@ const groupBatchesByUser = (
 const UserBatchGroupSection = ({
   group,
   networkId,
+  isExpanded,
+  onToggle,
 }: {
   group: UserBatchGroup;
   networkId: NetworkId;
+  isExpanded: boolean;
+  onToggle: () => void;
 }) => (
   <div className='rounded-lg border border-border'>
-    {/* Group header */}
-    <div className='flex flex-wrap items-center justify-between gap-2 border-b border-border bg-muted/50 px-4 py-3'>
-      <div className='flex items-center gap-3'>
+    {/* Single-line account summary — click the chevron to expand the list. */}
+    <div
+      className={`flex flex-wrap items-center justify-between gap-2 bg-muted/50 px-4 py-3 ${
+        isExpanded ? 'border-b border-border' : ''
+      }`}
+    >
+      <div className='flex flex-wrap items-center gap-3'>
+        <button
+          type='button'
+          onClick={onToggle}
+          aria-expanded={isExpanded}
+          aria-label={
+            isExpanded ? 'Hide batches for account' : 'Show batches for account'
+          }
+          className='text-muted-foreground hover:text-foreground'
+        >
+          {isExpanded ? (
+            <ChevronDown className='h-4 w-4' />
+          ) : (
+            <ChevronRight className='h-4 w-4' />
+          )}
+        </button>
         <Link
           href={ROUTES.adminUserCredits(networkId, group.userPublicId)}
           className='font-mono text-xs text-blue-500 hover:underline'
@@ -193,7 +235,13 @@ const UserBatchGroupSection = ({
         <span className='text-xs text-muted-foreground'>
           {group.batches.length}{' '}
           {group.batches.length === 1 ? 'batch' : 'batches'} ·{' '}
-          {formatBytes(group.totalRemaining, 1)} remaining
+          {formatBytes(group.totalPurchased, 1)} purchased ·{' '}
+          {formatBytes(group.totalRemaining, 1)} remaining ·{' '}
+          <span
+            className={group.totalExpiredUnused > 0 ? 'text-red-500' : ''}
+          >
+            {formatBytes(group.totalExpiredUnused, 1)} expired
+          </span>
         </span>
         {group.refundableCount > 0 && (
           <span className='inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900/30 dark:text-amber-400'>
@@ -210,7 +258,8 @@ const UserBatchGroupSection = ({
       </Link>
     </div>
 
-    {/* Batch rows */}
+    {/* Batch rows — hidden until the admin expands the account. */}
+    {isExpanded && (
     <div className='overflow-x-auto'>
       <table className='w-full text-sm'>
         <thead>
@@ -301,6 +350,7 @@ const UserBatchGroupSection = ({
         </tbody>
       </table>
     </div>
+    )}
   </div>
 );
 
@@ -312,6 +362,24 @@ const UserBatchGroupSection = ({
 export const AdminCredits = () => {
   const { api, network } = useNetwork();
   const queryClient = useQueryClient();
+
+  // Accounts whose full batch list is currently expanded. Collapsed by
+  // default so the screen shows one summary line per account.
+  const [expandedUserIds, setExpandedUserIds] = useState<Set<string>>(
+    new Set(),
+  );
+
+  const toggleExpanded = (userPublicId: string) => {
+    setExpandedUserIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(userPublicId)) {
+        next.delete(userPublicId);
+      } else {
+        next.add(userPublicId);
+      }
+      return next;
+    });
+  };
 
   const { data: economics, isLoading: economicsLoading } =
     useQuery<CreditEconomicsResponse>({
@@ -431,6 +499,23 @@ export const AdminCredits = () => {
               {awaitingRefund} expired awaiting refund
             </span>
           )}
+          {groups.length > 0 && (
+            <button
+              type='button'
+              onClick={() =>
+                setExpandedUserIds(
+                  expandedUserIds.size === groups.length
+                    ? new Set()
+                    : new Set(groups.map((g) => g.userPublicId)),
+                )
+              }
+              className='ml-auto text-xs text-blue-500 hover:underline'
+            >
+              {expandedUserIds.size === groups.length
+                ? 'Collapse all'
+                : 'Expand all'}
+            </button>
+          )}
         </div>
         {groups.length === 0 ? (
           !batchesLoading && (
@@ -439,12 +524,14 @@ export const AdminCredits = () => {
             </p>
           )
         ) : (
-          <div className='space-y-4'>
+          <div className='space-y-3'>
             {groups.map((group) => (
               <UserBatchGroupSection
                 key={group.userPublicId}
                 group={group}
                 networkId={network.id}
+                isExpanded={expandedUserIds.has(group.userPublicId)}
+                onToggle={() => toggleExpanded(group.userPublicId)}
               />
             ))}
           </div>

--- a/apps/frontend/src/components/views/AdminPanel/AdminUserCredits.tsx
+++ b/apps/frontend/src/components/views/AdminPanel/AdminUserCredits.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNetwork } from '../../../contexts/network';
 import { formatBytes } from '../../../utils/number';
@@ -16,6 +16,7 @@ import { getBatchStatus, STATUS_CLASSES, STATUS_LABEL } from '../../../utils/cre
 import type { AdminUserCreditBatch } from '../../../services/api';
 import Link from 'next/link';
 import { shannonsToAi3 } from '@autonomys/auto-utils';
+import { RefundTxHashModal } from './RefundTxHashModal';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -46,7 +47,12 @@ export const AdminUserCredits = ({
 }) => {
   const { api, network } = useNetwork();
   const queryClient = useQueryClient();
-  const [refundingId, setRefundingId] = useState<string | null>(null);
+
+  // Ids of the batches the admin has ticked for a combined refund.
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  // Batches currently being confirmed in the tx-hash modal (null = closed).
+  const [refundTarget, setRefundTarget] = useState<string[] | null>(null);
+  const [refundError, setRefundError] = useState<string | null>(null);
 
   const queryKey = ['adminUserCreditBatches', userPublicId];
 
@@ -56,29 +62,68 @@ export const AdminUserCredits = ({
     staleTime: 30_000,
   });
 
+  // A batch can be selected for refund as long as it has not been refunded
+  // yet. Several unused batches of the same account can be ticked and
+  // processed together with a single on-chain transaction hash.
+  const refundableIds = useMemo(
+    () => new Set(batches.filter((b) => b.refundedAt === null).map((b) => b.id)),
+    [batches],
+  );
+
+  const selectedRefundableIds = useMemo(
+    () => [...selectedIds].filter((id) => refundableIds.has(id)),
+    [selectedIds, refundableIds],
+  );
+
+  const allSelected =
+    refundableIds.size > 0 && selectedRefundableIds.length === refundableIds.size;
+
+  const toggleSelected = (batchId: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(batchId)) {
+        next.delete(batchId);
+      } else {
+        next.add(batchId);
+      }
+      return next;
+    });
+  };
+
+  const toggleSelectAll = () => {
+    setSelectedIds(allSelected ? new Set() : new Set(refundableIds));
+  };
+
   const { mutate: refund, isPending: isRefunding } = useMutation<
-    void,
+    unknown,
     Error,
-    string
+    { batchIds: string[]; refundTxHash: string }
   >({
-    mutationFn: async (batchId: string) => {
-      setRefundingId(batchId);
-      return api.refundCreditBatch(batchId);
-    },
-    onSettled: () => {
-      setRefundingId(null);
-    },
+    mutationFn: ({ batchIds, refundTxHash }) =>
+      api.refundCreditBatches(batchIds, refundTxHash),
     onSuccess: () => {
+      setRefundTarget(null);
+      setRefundError(null);
+      setSelectedIds(new Set());
       void queryClient.invalidateQueries({ queryKey });
+      void queryClient.invalidateQueries({ queryKey: ['adminCreditBatches'] });
+    },
+    onError: (error) => {
+      setRefundError(error.message);
     },
   });
+
+  const openRefundModal = (batchIds: string[]) => {
+    setRefundError(null);
+    setRefundTarget(batchIds);
+  };
 
   return (
     <div className='space-y-6 p-6'>
       {/* Header */}
       <div className='flex items-center gap-3'>
         <Link
-          href={ROUTES.admin(network.id)}
+          href={ROUTES.adminCredits(network.id)}
           className='text-muted-foreground hover:text-foreground'
         >
           <ArrowLeft className='h-5 w-5' />
@@ -137,6 +182,34 @@ export const AdminUserCredits = ({
         </div>
       )}
 
+      {/* Combined refund action bar */}
+      {selectedRefundableIds.length > 0 && (
+        <div className='flex flex-wrap items-center justify-between gap-3 rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 dark:border-amber-700 dark:bg-amber-900/20'>
+          <p className='text-sm text-amber-800 dark:text-amber-300'>
+            {selectedRefundableIds.length}{' '}
+            {selectedRefundableIds.length === 1 ? 'batch' : 'batches'} selected
+            — one transaction hash will be recorded on all of them.
+          </p>
+          <div className='flex items-center gap-2'>
+            <Button
+              variant='outline'
+              onClick={() => setSelectedIds(new Set())}
+              className='text-xs'
+            >
+              Clear
+            </Button>
+            <Button
+              variant='primary'
+              onClick={() => openRefundModal(selectedRefundableIds)}
+              className='flex items-center gap-1 text-xs'
+            >
+              <AlertTriangle className='h-3 w-3' />
+              Mark {selectedRefundableIds.length} Refunded
+            </Button>
+          </div>
+        </div>
+      )}
+
       {/* Batches table */}
       {batches.length === 0 && !isLoading ? (
         <p className='text-sm text-muted-foreground'>
@@ -147,6 +220,15 @@ export const AdminUserCredits = ({
           <table className='w-full text-sm'>
             <thead>
               <tr className='border-b border-border bg-muted/50 text-left text-xs text-muted-foreground'>
+                <th className='px-4 py-3 font-medium'>
+                  <input
+                    type='checkbox'
+                    aria-label='Select all refundable batches'
+                    checked={allSelected}
+                    disabled={refundableIds.size === 0}
+                    onChange={toggleSelectAll}
+                  />
+                </th>
                 <th className='px-4 py-3 font-medium'>Date</th>
                 <th className='px-4 py-3 font-medium'>Status</th>
                 <th className='px-4 py-3 font-medium'>Expires</th>
@@ -164,12 +246,24 @@ export const AdminUserCredits = ({
                 const original = Number(BigInt(batch.uploadBytesOriginal));
                 const remaining = Number(BigInt(batch.uploadBytesRemaining));
                 const consumed = original - remaining;
+                const isRefundable = batch.refundedAt === null;
 
                 return (
                   <tr
                     key={batch.id}
                     className='border-b border-border last:border-0 hover:bg-muted/30'
                   >
+                    {/* Selection */}
+                    <td className='px-4 py-3'>
+                      <input
+                        type='checkbox'
+                        aria-label='Select batch for refund'
+                        checked={selectedIds.has(batch.id)}
+                        disabled={!isRefundable}
+                        onChange={() => toggleSelected(batch.id)}
+                      />
+                    </td>
+
                     {/* Date */}
                     <td className='px-4 py-3 text-xs'>
                       {formatDate(batch.purchasedAt)}
@@ -235,23 +329,30 @@ export const AdminUserCredits = ({
                       )}
                     </td>
 
-                    {/* Refund action */}
+                    {/* Refund action / record */}
                     <td className='px-4 py-3'>
                       {batch.refundedAt !== null ? (
-                        <span className='text-xs text-muted-foreground'>
-                          {formatDate(batch.refundedAt)}
-                        </span>
+                        <div className='flex flex-col gap-0.5 text-xs text-muted-foreground'>
+                          <span>{formatDate(batch.refundedAt)}</span>
+                          {batch.refundTxHash && (
+                            <span
+                              className='font-mono'
+                              title={batch.refundTxHash}
+                            >
+                              {batch.refundTxHash.slice(0, 10)}…
+                              {batch.refundTxHash.slice(-6)}
+                            </span>
+                          )}
+                        </div>
                       ) : (
                         <Button
                           variant='outline'
-                          disabled={isRefunding && refundingId === batch.id}
-                          onClick={() => refund(batch.id)}
+                          disabled={isRefunding}
+                          onClick={() => openRefundModal([batch.id])}
                           className='flex items-center gap-1 text-xs'
                         >
                           <AlertTriangle className='h-3 w-3 text-orange-500' />
-                          {isRefunding && refundingId === batch.id
-                            ? 'Marking…'
-                            : 'Mark Refunded'}
+                          Mark Refunded
                         </Button>
                       )}
                     </td>
@@ -261,6 +362,24 @@ export const AdminUserCredits = ({
             </tbody>
           </table>
         </div>
+      )}
+
+      {/* Refund confirmation modal — the transaction hash is mandatory. */}
+      {refundTarget !== null && (
+        <RefundTxHashModal
+          batchCount={refundTarget.length}
+          isSubmitting={isRefunding}
+          errorMessage={refundError}
+          onConfirm={(refundTxHash) =>
+            refund({ batchIds: refundTarget, refundTxHash })
+          }
+          onClose={() => {
+            if (!isRefunding) {
+              setRefundTarget(null);
+              setRefundError(null);
+            }
+          }}
+        />
       )}
     </div>
   );

--- a/apps/frontend/src/components/views/AdminPanel/AdminUserCredits.tsx
+++ b/apps/frontend/src/components/views/AdminPanel/AdminUserCredits.tsx
@@ -63,9 +63,15 @@ export const AdminUserCredits = ({
     staleTime: 30_000,
   });
 
+  // Terminology: an "account" here is the org-level STORAGE account
+  // (backend `accounts` table) that credits, uploads and downloads are
+  // recorded against — not the EVM wallet that paid. The purchasing wallet
+  // is a separate concept, exposed per batch as `fromAddress` and shown in
+  // the "Purchasing Wallet" column: one storage account can be funded from many
+  // wallets, and one wallet can fund batches on different accounts.
   // Batches are loaded by userPublicId, so they can span more than one
-  // account when the user purchased credits under different org accounts
-  // over time. Each distinct account links to the existing account
+  // storage account when the user purchased credits under different org
+  // accounts over time. Each distinct account links to the existing account
   // (organization) page with the uploads/downloads history.
   const accountIds = useMemo(
     () => [...new Set(batches.map((b) => b.accountId))],
@@ -207,9 +213,9 @@ export const AdminUserCredits = ({
               key={accountId}
               href={ROUTES.adminOrganization(network.id, accountId)}
               className='mt-1 flex w-fit items-center gap-1 font-mono text-xs text-blue-500 hover:underline'
-              title={`View account ${accountId} — uploads and downloads`}
+              title={`View storage account ${accountId} — uploads and downloads`}
             >
-              Account: {accountId}
+              Storage account: {accountId}
               <ExternalLink className='h-3 w-3' />
             </Link>
           ))}
@@ -327,7 +333,7 @@ export const AdminUserCredits = ({
                 <th className='px-4 py-3 font-medium'>Consumed</th>
                 <th className='px-4 py-3 font-medium'>Remaining</th>
                 <th className='px-4 py-3 font-medium'>AI3 Paid</th>
-                <th className='px-4 py-3 font-medium'>EVM Wallet</th>
+                <th className='px-4 py-3 font-medium'>Purchasing Wallet</th>
                 <th className='px-4 py-3 font-medium'>Refund</th>
               </tr>
             </thead>

--- a/apps/frontend/src/components/views/AdminPanel/AdminUserCredits.tsx
+++ b/apps/frontend/src/components/views/AdminPanel/AdminUserCredits.tsx
@@ -37,6 +37,16 @@ const formatAI3Paid = (paymentAmount: string | null): string => {
   }
 };
 
+/**
+ * A combined refund is one on-chain transfer back to one wallet, so it can
+ * only cover batches of the SAME account paid from the SAME purchasing
+ * wallet (enforced by the backend). Batches are grouped by this composite
+ * key; batches without a recorded wallet (legacy intents) only group with
+ * each other.
+ */
+const refundGroupKey = (batch: AdminUserCreditBatch): string =>
+  `${batch.accountId}::${batch.fromAddress ?? 'unknown-wallet'}`;
+
 // ---------------------------------------------------------------------------
 // Main component
 // ---------------------------------------------------------------------------
@@ -63,27 +73,26 @@ export const AdminUserCredits = ({
     staleTime: 30_000,
   });
 
-  // Terminology: a "purchasing wallet" here groups batches by
-  // `batch.accountId` — the org-level storage account (backend `accounts`
-  // table) that credits, uploads and downloads are recorded against, and the
-  // unit a combined refund must stay within. Batches are loaded by
-  // userPublicId, so they can span more than one purchasing wallet when the
-  // user purchased credits under different org accounts over time. Each
-  // distinct one links to the existing account (organization) page with the
-  // uploads/downloads history. The EVM address that paid is a separate
-  // per-batch field (`fromAddress`, shown in the "EVM Wallet" column).
-  const purchasingWalletIds = useMemo(
+  // Terminology: the "account" is the org-level storage account (backend
+  // `accounts` table, batch.accountId) that credits, uploads and downloads
+  // are recorded against; the "purchasing wallet" is the EVM address that
+  // paid for the batch (intent's fromAddress). Batches are loaded by
+  // userPublicId, so they can span more than one account, and within one
+  // account they can have been paid from different purchasing wallets.
+  // Each distinct account links to the existing account (organization) page
+  // with the uploads/downloads history.
+  const accountIds = useMemo(
     () => [...new Set(batches.map((b) => b.accountId))],
     [batches],
   );
-  const hasMultiplePurchasingWallets = purchasingWalletIds.length > 1;
+  const hasMultipleAccounts = accountIds.length > 1;
 
-  // A batch can be selected for refund as long as it has not been refunded
-  // yet. Several unused batches of the SAME purchasing wallet can be ticked
-  // and processed together with a single on-chain transaction hash — the
-  // backend rejects combined refunds that span purchasing wallets, so the
-  // first selected batch anchors the wallet and batches of other wallets
-  // are disabled until the selection is cleared.
+  const refundGroupKeys = useMemo(
+    () => [...new Set(batches.map(refundGroupKey))],
+    [batches],
+  );
+  const hasMultipleRefundGroups = refundGroupKeys.length > 1;
+
   const refundableIds = useMemo(
     () => new Set(batches.filter((b) => b.refundedAt === null).map((b) => b.id)),
     [batches],
@@ -94,36 +103,36 @@ export const AdminUserCredits = ({
     [selectedIds, refundableIds],
   );
 
-  // Purchasing wallet of the current selection (all selected batches share it).
-  const selectedPurchasingWalletId = useMemo(() => {
-    const firstSelected = batches.find((b) => selectedIds.has(b.id));
-    return firstSelected?.accountId ?? null;
-  }, [batches, selectedIds]);
+  // (account, purchasing wallet) anchor of the current selection — all
+  // selected batches share it.
+  const selectedBatch = useMemo(
+    () => batches.find((b) => selectedIds.has(b.id)) ?? null,
+    [batches, selectedIds],
+  );
+  const selectedGroupKey = selectedBatch ? refundGroupKey(selectedBatch) : null;
 
   const isSelectable = (batch: AdminUserCreditBatch): boolean =>
     batch.refundedAt === null &&
-    (selectedPurchasingWalletId === null ||
-      batch.accountId === selectedPurchasingWalletId);
+    (selectedGroupKey === null || refundGroupKey(batch) === selectedGroupKey);
 
-  // Select-all targets a single purchasing wallet: the selection's wallet,
-  // or — when nothing is selected — the first one with refundable batches.
-  const selectAllPurchasingWalletId = useMemo(() => {
-    if (selectedPurchasingWalletId) return selectedPurchasingWalletId;
-    return (
-      batches.find((b) => refundableIds.has(b.id))?.accountId ?? null
-    );
-  }, [selectedPurchasingWalletId, batches, refundableIds]);
+  // Select-all targets a single (account, purchasing wallet) group: the
+  // selection's group, or — when nothing is selected — the first group with
+  // refundable batches.
+  const selectAllGroupKey = useMemo(() => {
+    if (selectedGroupKey) return selectedGroupKey;
+    const firstRefundable = batches.find((b) => refundableIds.has(b.id));
+    return firstRefundable ? refundGroupKey(firstRefundable) : null;
+  }, [selectedGroupKey, batches, refundableIds]);
 
   const selectAllTargetIds = useMemo(
     () =>
       batches
         .filter(
           (b) =>
-            refundableIds.has(b.id) &&
-            b.accountId === selectAllPurchasingWalletId,
+            refundableIds.has(b.id) && refundGroupKey(b) === selectAllGroupKey,
         )
         .map((b) => b.id),
-    [batches, refundableIds, selectAllPurchasingWalletId],
+    [batches, refundableIds, selectAllGroupKey],
   );
 
   const allSelected =
@@ -210,14 +219,14 @@ export const AdminUserCredits = ({
           >
             {userPublicId}
           </p>
-          {purchasingWalletIds.map((walletId) => (
+          {accountIds.map((accountId) => (
             <Link
-              key={walletId}
-              href={ROUTES.adminOrganization(network.id, walletId)}
+              key={accountId}
+              href={ROUTES.adminOrganization(network.id, accountId)}
               className='mt-1 flex w-fit items-center gap-1 font-mono text-xs text-blue-500 hover:underline'
-              title={`View purchasing wallet ${walletId} — uploads and downloads`}
+              title={`View account ${accountId} — uploads and downloads`}
             >
-              Purchasing wallet: {walletId}
+              Account: {accountId}
               <ExternalLink className='h-3 w-3' />
             </Link>
           ))}
@@ -273,10 +282,14 @@ export const AdminUserCredits = ({
           <p className='text-sm text-amber-800 dark:text-amber-300'>
             {selectedRefundableIds.length}{' '}
             {selectedRefundableIds.length === 1 ? 'batch' : 'batches'} selected
-            {hasMultiplePurchasingWallets && selectedPurchasingWalletId && (
+            {hasMultipleRefundGroups && selectedBatch && (
               <span className='font-mono'>
                 {' '}
-                (purchasing wallet {selectedPurchasingWalletId.slice(0, 8)}…)
+                (account {selectedBatch.accountId.slice(0, 8)}…, wallet{' '}
+                {selectedBatch.fromAddress
+                  ? `${selectedBatch.fromAddress.slice(0, 8)}…`
+                  : 'unknown'}
+                )
               </span>
             )}{' '}
             — one transaction hash will be recorded on all of them.
@@ -314,10 +327,10 @@ export const AdminUserCredits = ({
                 <th className='px-4 py-3 font-medium'>
                   <input
                     type='checkbox'
-                    aria-label='Select all refundable batches of the purchasing wallet'
+                    aria-label='Select all refundable batches of the same account and purchasing wallet'
                     title={
-                      hasMultiplePurchasingWallets && selectAllPurchasingWalletId
-                        ? `Selects refundable batches of purchasing wallet ${selectAllPurchasingWalletId} only — combined refunds cannot span purchasing wallets`
+                      hasMultipleRefundGroups
+                        ? 'Selects refundable batches of one account/purchasing-wallet pair only — combined refunds cannot span accounts or paying wallets'
                         : undefined
                     }
                     checked={allSelected}
@@ -325,8 +338,8 @@ export const AdminUserCredits = ({
                     onChange={toggleSelectAll}
                   />
                 </th>
-                {hasMultiplePurchasingWallets && (
-                  <th className='px-4 py-3 font-medium'>Purchasing Wallet</th>
+                {hasMultipleAccounts && (
+                  <th className='px-4 py-3 font-medium'>Account</th>
                 )}
                 <th className='px-4 py-3 font-medium'>Date</th>
                 <th className='px-4 py-3 font-medium'>Status</th>
@@ -335,7 +348,7 @@ export const AdminUserCredits = ({
                 <th className='px-4 py-3 font-medium'>Consumed</th>
                 <th className='px-4 py-3 font-medium'>Remaining</th>
                 <th className='px-4 py-3 font-medium'>AI3 Paid</th>
-                <th className='px-4 py-3 font-medium'>EVM Wallet</th>
+                <th className='px-4 py-3 font-medium'>Purchasing Wallet</th>
                 <th className='px-4 py-3 font-medium'>Refund</th>
               </tr>
             </thead>
@@ -346,7 +359,7 @@ export const AdminUserCredits = ({
                 const remaining = Number(BigInt(batch.uploadBytesRemaining));
                 const consumed = original - remaining;
                 const isRefundable = batch.refundedAt === null;
-                const isOtherPurchasingWallet =
+                const isOtherRefundGroup =
                   isRefundable && !isSelectable(batch);
 
                 return (
@@ -360,8 +373,8 @@ export const AdminUserCredits = ({
                         type='checkbox'
                         aria-label='Select batch for refund'
                         title={
-                          isOtherPurchasingWallet
-                            ? 'Belongs to a different purchasing wallet than the current selection — combined refunds cannot span purchasing wallets'
+                          isOtherRefundGroup
+                            ? 'Belongs to a different account or purchasing wallet than the current selection — combined refunds cannot span accounts or paying wallets'
                             : undefined
                         }
                         checked={selectedIds.has(batch.id)}
@@ -370,8 +383,8 @@ export const AdminUserCredits = ({
                       />
                     </td>
 
-                    {/* Purchasing wallet (only when batches span several) */}
-                    {hasMultiplePurchasingWallets && (
+                    {/* Account (only when batches span several accounts) */}
+                    {hasMultipleAccounts && (
                       <td className='px-4 py-3 font-mono text-xs'>
                         <Link
                           href={ROUTES.adminOrganization(

--- a/apps/frontend/src/components/views/AdminPanel/AdminUserCredits.tsx
+++ b/apps/frontend/src/components/views/AdminPanel/AdminUserCredits.tsx
@@ -162,6 +162,28 @@ export const AdminUserCredits = ({
     setRefundTarget(batchIds);
   };
 
+  // Informational pro-rated refund suggestion for the modal: unused bytes ×
+  // the shannons/byte rate locked at purchase, summed over the target
+  // batches. The actual AI3 transfer happens out-of-band and the amount is
+  // not enforced by the system.
+  const suggestedRefundAi3 = useMemo(() => {
+    if (!refundTarget) return null;
+    try {
+      const totalShannons = refundTarget.reduce((sum, id) => {
+        const batch = batches.find((b) => b.id === id);
+        if (!batch || batch.refundedAt !== null) return sum;
+        return (
+          sum +
+          BigInt(batch.uploadBytesRemaining) * BigInt(batch.shannonsPerByte)
+        );
+      }, BigInt(0));
+      if (totalShannons === BigInt(0)) return null;
+      return `${shannonsToAi3(totalShannons, { trimTrailingZeros: true })} AI3`;
+    } catch {
+      return null;
+    }
+  }, [refundTarget, batches]);
+
   return (
     <div className='space-y-6 p-6'>
       {/* Header */}
@@ -460,6 +482,7 @@ export const AdminUserCredits = ({
       {refundTarget !== null && (
         <RefundTxHashModal
           batchCount={refundTarget.length}
+          suggestedRefundAi3={suggestedRefundAi3}
           isSubmitting={isRefunding}
           errorMessage={refundError}
           onConfirm={(refundTxHash) =>

--- a/apps/frontend/src/components/views/AdminPanel/AdminUserCredits.tsx
+++ b/apps/frontend/src/components/views/AdminPanel/AdminUserCredits.tsx
@@ -63,28 +63,27 @@ export const AdminUserCredits = ({
     staleTime: 30_000,
   });
 
-  // Terminology: an "account" here is the org-level STORAGE account
-  // (backend `accounts` table) that credits, uploads and downloads are
-  // recorded against — not the EVM wallet that paid. The purchasing wallet
-  // is a separate concept, exposed per batch as `fromAddress` and shown in
-  // the "Purchasing Wallet" column: one storage account can be funded from many
-  // wallets, and one wallet can fund batches on different accounts.
-  // Batches are loaded by userPublicId, so they can span more than one
-  // storage account when the user purchased credits under different org
-  // accounts over time. Each distinct account links to the existing account
-  // (organization) page with the uploads/downloads history.
-  const accountIds = useMemo(
+  // Terminology: a "purchasing wallet" here groups batches by
+  // `batch.accountId` — the org-level storage account (backend `accounts`
+  // table) that credits, uploads and downloads are recorded against, and the
+  // unit a combined refund must stay within. Batches are loaded by
+  // userPublicId, so they can span more than one purchasing wallet when the
+  // user purchased credits under different org accounts over time. Each
+  // distinct one links to the existing account (organization) page with the
+  // uploads/downloads history. The EVM address that paid is a separate
+  // per-batch field (`fromAddress`, shown in the "EVM Wallet" column).
+  const purchasingWalletIds = useMemo(
     () => [...new Set(batches.map((b) => b.accountId))],
     [batches],
   );
-  const hasMultipleAccounts = accountIds.length > 1;
+  const hasMultiplePurchasingWallets = purchasingWalletIds.length > 1;
 
   // A batch can be selected for refund as long as it has not been refunded
-  // yet. Several unused batches of the SAME account can be ticked and
-  // processed together with a single on-chain transaction hash — the
-  // backend rejects combined refunds that span accounts, so the first
-  // selected batch anchors the account and batches of other accounts are
-  // disabled until the selection is cleared.
+  // yet. Several unused batches of the SAME purchasing wallet can be ticked
+  // and processed together with a single on-chain transaction hash — the
+  // backend rejects combined refunds that span purchasing wallets, so the
+  // first selected batch anchors the wallet and batches of other wallets
+  // are disabled until the selection is cleared.
   const refundableIds = useMemo(
     () => new Set(batches.filter((b) => b.refundedAt === null).map((b) => b.id)),
     [batches],
@@ -95,33 +94,36 @@ export const AdminUserCredits = ({
     [selectedIds, refundableIds],
   );
 
-  // Account of the current selection (all selected batches share it).
-  const selectedAccountId = useMemo(() => {
+  // Purchasing wallet of the current selection (all selected batches share it).
+  const selectedPurchasingWalletId = useMemo(() => {
     const firstSelected = batches.find((b) => selectedIds.has(b.id));
     return firstSelected?.accountId ?? null;
   }, [batches, selectedIds]);
 
   const isSelectable = (batch: AdminUserCreditBatch): boolean =>
     batch.refundedAt === null &&
-    (selectedAccountId === null || batch.accountId === selectedAccountId);
+    (selectedPurchasingWalletId === null ||
+      batch.accountId === selectedPurchasingWalletId);
 
-  // Select-all targets a single account: the selection's account, or — when
-  // nothing is selected — the first account that has refundable batches.
-  const selectAllAccountId = useMemo(() => {
-    if (selectedAccountId) return selectedAccountId;
+  // Select-all targets a single purchasing wallet: the selection's wallet,
+  // or — when nothing is selected — the first one with refundable batches.
+  const selectAllPurchasingWalletId = useMemo(() => {
+    if (selectedPurchasingWalletId) return selectedPurchasingWalletId;
     return (
       batches.find((b) => refundableIds.has(b.id))?.accountId ?? null
     );
-  }, [selectedAccountId, batches, refundableIds]);
+  }, [selectedPurchasingWalletId, batches, refundableIds]);
 
   const selectAllTargetIds = useMemo(
     () =>
       batches
         .filter(
-          (b) => refundableIds.has(b.id) && b.accountId === selectAllAccountId,
+          (b) =>
+            refundableIds.has(b.id) &&
+            b.accountId === selectAllPurchasingWalletId,
         )
         .map((b) => b.id),
-    [batches, refundableIds, selectAllAccountId],
+    [batches, refundableIds, selectAllPurchasingWalletId],
   );
 
   const allSelected =
@@ -208,14 +210,14 @@ export const AdminUserCredits = ({
           >
             {userPublicId}
           </p>
-          {accountIds.map((accountId) => (
+          {purchasingWalletIds.map((walletId) => (
             <Link
-              key={accountId}
-              href={ROUTES.adminOrganization(network.id, accountId)}
+              key={walletId}
+              href={ROUTES.adminOrganization(network.id, walletId)}
               className='mt-1 flex w-fit items-center gap-1 font-mono text-xs text-blue-500 hover:underline'
-              title={`View storage account ${accountId} — uploads and downloads`}
+              title={`View purchasing wallet ${walletId} — uploads and downloads`}
             >
-              Storage account: {accountId}
+              Purchasing wallet: {walletId}
               <ExternalLink className='h-3 w-3' />
             </Link>
           ))}
@@ -271,10 +273,10 @@ export const AdminUserCredits = ({
           <p className='text-sm text-amber-800 dark:text-amber-300'>
             {selectedRefundableIds.length}{' '}
             {selectedRefundableIds.length === 1 ? 'batch' : 'batches'} selected
-            {hasMultipleAccounts && selectedAccountId && (
+            {hasMultiplePurchasingWallets && selectedPurchasingWalletId && (
               <span className='font-mono'>
                 {' '}
-                (account {selectedAccountId.slice(0, 8)}…)
+                (purchasing wallet {selectedPurchasingWalletId.slice(0, 8)}…)
               </span>
             )}{' '}
             — one transaction hash will be recorded on all of them.
@@ -312,10 +314,10 @@ export const AdminUserCredits = ({
                 <th className='px-4 py-3 font-medium'>
                   <input
                     type='checkbox'
-                    aria-label='Select all refundable batches of the account'
+                    aria-label='Select all refundable batches of the purchasing wallet'
                     title={
-                      hasMultipleAccounts && selectAllAccountId
-                        ? `Selects refundable batches of account ${selectAllAccountId} only — combined refunds cannot span accounts`
+                      hasMultiplePurchasingWallets && selectAllPurchasingWalletId
+                        ? `Selects refundable batches of purchasing wallet ${selectAllPurchasingWalletId} only — combined refunds cannot span purchasing wallets`
                         : undefined
                     }
                     checked={allSelected}
@@ -323,8 +325,8 @@ export const AdminUserCredits = ({
                     onChange={toggleSelectAll}
                   />
                 </th>
-                {hasMultipleAccounts && (
-                  <th className='px-4 py-3 font-medium'>Account</th>
+                {hasMultiplePurchasingWallets && (
+                  <th className='px-4 py-3 font-medium'>Purchasing Wallet</th>
                 )}
                 <th className='px-4 py-3 font-medium'>Date</th>
                 <th className='px-4 py-3 font-medium'>Status</th>
@@ -333,7 +335,7 @@ export const AdminUserCredits = ({
                 <th className='px-4 py-3 font-medium'>Consumed</th>
                 <th className='px-4 py-3 font-medium'>Remaining</th>
                 <th className='px-4 py-3 font-medium'>AI3 Paid</th>
-                <th className='px-4 py-3 font-medium'>Purchasing Wallet</th>
+                <th className='px-4 py-3 font-medium'>EVM Wallet</th>
                 <th className='px-4 py-3 font-medium'>Refund</th>
               </tr>
             </thead>
@@ -344,7 +346,7 @@ export const AdminUserCredits = ({
                 const remaining = Number(BigInt(batch.uploadBytesRemaining));
                 const consumed = original - remaining;
                 const isRefundable = batch.refundedAt === null;
-                const isOtherAccount =
+                const isOtherPurchasingWallet =
                   isRefundable && !isSelectable(batch);
 
                 return (
@@ -358,8 +360,8 @@ export const AdminUserCredits = ({
                         type='checkbox'
                         aria-label='Select batch for refund'
                         title={
-                          isOtherAccount
-                            ? 'Belongs to a different account than the current selection — combined refunds cannot span accounts'
+                          isOtherPurchasingWallet
+                            ? 'Belongs to a different purchasing wallet than the current selection — combined refunds cannot span purchasing wallets'
                             : undefined
                         }
                         checked={selectedIds.has(batch.id)}
@@ -368,8 +370,8 @@ export const AdminUserCredits = ({
                       />
                     </td>
 
-                    {/* Account (only when batches span several accounts) */}
-                    {hasMultipleAccounts && (
+                    {/* Purchasing wallet (only when batches span several) */}
+                    {hasMultiplePurchasingWallets && (
                       <td className='px-4 py-3 font-mono text-xs'>
                         <Link
                           href={ROUTES.adminOrganization(

--- a/apps/frontend/src/components/views/AdminPanel/AdminUserCredits.tsx
+++ b/apps/frontend/src/components/views/AdminPanel/AdminUserCredits.tsx
@@ -10,6 +10,7 @@ import {
   RefreshCw,
   CheckCircle2,
   AlertTriangle,
+  ExternalLink,
 } from 'lucide-react';
 import { Button, ROUTES } from '@auto-drive/ui';
 import { getBatchStatus, STATUS_CLASSES, STATUS_LABEL } from '../../../utils/credits';
@@ -61,6 +62,10 @@ export const AdminUserCredits = ({
     queryFn: () => api.getUserCreditBatches(userPublicId),
     staleTime: 30_000,
   });
+
+  // All batches on this page belong to the same account; its id links to the
+  // existing account (organization) page with the uploads/downloads history.
+  const accountId = batches[0]?.accountId ?? null;
 
   // A batch can be selected for refund as long as it has not been refunded
   // yet. Several unused batches of the same account can be ticked and
@@ -136,6 +141,16 @@ export const AdminUserCredits = ({
           >
             {userPublicId}
           </p>
+          {accountId && (
+            <Link
+              href={ROUTES.adminOrganization(network.id, accountId)}
+              className='mt-1 inline-flex items-center gap-1 font-mono text-xs text-blue-500 hover:underline'
+              title={`View account ${accountId} — uploads and downloads`}
+            >
+              Account: {accountId}
+              <ExternalLink className='h-3 w-3' />
+            </Link>
+          )}
         </div>
         {isLoading && (
           <RefreshCw className='ml-auto h-4 w-4 animate-spin text-muted-foreground' />

--- a/apps/frontend/src/components/views/AdminPanel/AdminUserCredits.tsx
+++ b/apps/frontend/src/components/views/AdminPanel/AdminUserCredits.tsx
@@ -63,13 +63,22 @@ export const AdminUserCredits = ({
     staleTime: 30_000,
   });
 
-  // All batches on this page belong to the same account; its id links to the
-  // existing account (organization) page with the uploads/downloads history.
-  const accountId = batches[0]?.accountId ?? null;
+  // Batches are loaded by userPublicId, so they can span more than one
+  // account when the user purchased credits under different org accounts
+  // over time. Each distinct account links to the existing account
+  // (organization) page with the uploads/downloads history.
+  const accountIds = useMemo(
+    () => [...new Set(batches.map((b) => b.accountId))],
+    [batches],
+  );
+  const hasMultipleAccounts = accountIds.length > 1;
 
   // A batch can be selected for refund as long as it has not been refunded
-  // yet. Several unused batches of the same account can be ticked and
-  // processed together with a single on-chain transaction hash.
+  // yet. Several unused batches of the SAME account can be ticked and
+  // processed together with a single on-chain transaction hash — the
+  // backend rejects combined refunds that span accounts, so the first
+  // selected batch anchors the account and batches of other accounts are
+  // disabled until the selection is cleared.
   const refundableIds = useMemo(
     () => new Set(batches.filter((b) => b.refundedAt === null).map((b) => b.id)),
     [batches],
@@ -80,8 +89,38 @@ export const AdminUserCredits = ({
     [selectedIds, refundableIds],
   );
 
+  // Account of the current selection (all selected batches share it).
+  const selectedAccountId = useMemo(() => {
+    const firstSelected = batches.find((b) => selectedIds.has(b.id));
+    return firstSelected?.accountId ?? null;
+  }, [batches, selectedIds]);
+
+  const isSelectable = (batch: AdminUserCreditBatch): boolean =>
+    batch.refundedAt === null &&
+    (selectedAccountId === null || batch.accountId === selectedAccountId);
+
+  // Select-all targets a single account: the selection's account, or — when
+  // nothing is selected — the first account that has refundable batches.
+  const selectAllAccountId = useMemo(() => {
+    if (selectedAccountId) return selectedAccountId;
+    return (
+      batches.find((b) => refundableIds.has(b.id))?.accountId ?? null
+    );
+  }, [selectedAccountId, batches, refundableIds]);
+
+  const selectAllTargetIds = useMemo(
+    () =>
+      batches
+        .filter(
+          (b) => refundableIds.has(b.id) && b.accountId === selectAllAccountId,
+        )
+        .map((b) => b.id),
+    [batches, refundableIds, selectAllAccountId],
+  );
+
   const allSelected =
-    refundableIds.size > 0 && selectedRefundableIds.length === refundableIds.size;
+    selectAllTargetIds.length > 0 &&
+    selectAllTargetIds.every((id) => selectedIds.has(id));
 
   const toggleSelected = (batchId: string) => {
     setSelectedIds((prev) => {
@@ -96,7 +135,7 @@ export const AdminUserCredits = ({
   };
 
   const toggleSelectAll = () => {
-    setSelectedIds(allSelected ? new Set() : new Set(refundableIds));
+    setSelectedIds(allSelected ? new Set() : new Set(selectAllTargetIds));
   };
 
   const { mutate: refund, isPending: isRefunding } = useMutation<
@@ -141,16 +180,17 @@ export const AdminUserCredits = ({
           >
             {userPublicId}
           </p>
-          {accountId && (
+          {accountIds.map((accountId) => (
             <Link
+              key={accountId}
               href={ROUTES.adminOrganization(network.id, accountId)}
-              className='mt-1 inline-flex items-center gap-1 font-mono text-xs text-blue-500 hover:underline'
+              className='mt-1 flex w-fit items-center gap-1 font-mono text-xs text-blue-500 hover:underline'
               title={`View account ${accountId} — uploads and downloads`}
             >
               Account: {accountId}
               <ExternalLink className='h-3 w-3' />
             </Link>
-          )}
+          ))}
         </div>
         {isLoading && (
           <RefreshCw className='ml-auto h-4 w-4 animate-spin text-muted-foreground' />
@@ -203,6 +243,12 @@ export const AdminUserCredits = ({
           <p className='text-sm text-amber-800 dark:text-amber-300'>
             {selectedRefundableIds.length}{' '}
             {selectedRefundableIds.length === 1 ? 'batch' : 'batches'} selected
+            {hasMultipleAccounts && selectedAccountId && (
+              <span className='font-mono'>
+                {' '}
+                (account {selectedAccountId.slice(0, 8)}…)
+              </span>
+            )}{' '}
             — one transaction hash will be recorded on all of them.
           </p>
           <div className='flex items-center gap-2'>
@@ -238,12 +284,20 @@ export const AdminUserCredits = ({
                 <th className='px-4 py-3 font-medium'>
                   <input
                     type='checkbox'
-                    aria-label='Select all refundable batches'
+                    aria-label='Select all refundable batches of the account'
+                    title={
+                      hasMultipleAccounts && selectAllAccountId
+                        ? `Selects refundable batches of account ${selectAllAccountId} only — combined refunds cannot span accounts`
+                        : undefined
+                    }
                     checked={allSelected}
-                    disabled={refundableIds.size === 0}
+                    disabled={selectAllTargetIds.length === 0}
                     onChange={toggleSelectAll}
                   />
                 </th>
+                {hasMultipleAccounts && (
+                  <th className='px-4 py-3 font-medium'>Account</th>
+                )}
                 <th className='px-4 py-3 font-medium'>Date</th>
                 <th className='px-4 py-3 font-medium'>Status</th>
                 <th className='px-4 py-3 font-medium'>Expires</th>
@@ -262,6 +316,8 @@ export const AdminUserCredits = ({
                 const remaining = Number(BigInt(batch.uploadBytesRemaining));
                 const consumed = original - remaining;
                 const isRefundable = batch.refundedAt === null;
+                const isOtherAccount =
+                  isRefundable && !isSelectable(batch);
 
                 return (
                   <tr
@@ -273,11 +329,32 @@ export const AdminUserCredits = ({
                       <input
                         type='checkbox'
                         aria-label='Select batch for refund'
+                        title={
+                          isOtherAccount
+                            ? 'Belongs to a different account than the current selection — combined refunds cannot span accounts'
+                            : undefined
+                        }
                         checked={selectedIds.has(batch.id)}
-                        disabled={!isRefundable}
+                        disabled={!isSelectable(batch)}
                         onChange={() => toggleSelected(batch.id)}
                       />
                     </td>
+
+                    {/* Account (only when batches span several accounts) */}
+                    {hasMultipleAccounts && (
+                      <td className='px-4 py-3 font-mono text-xs'>
+                        <Link
+                          href={ROUTES.adminOrganization(
+                            network.id,
+                            batch.accountId,
+                          )}
+                          className='text-blue-500 hover:underline'
+                          title={batch.accountId}
+                        >
+                          {batch.accountId.slice(0, 8)}…
+                        </Link>
+                      </td>
+                    )}
 
                     {/* Date */}
                     <td className='px-4 py-3 text-xs'>

--- a/apps/frontend/src/components/views/AdminPanel/RefundTxHashModal.tsx
+++ b/apps/frontend/src/components/views/AdminPanel/RefundTxHashModal.tsx
@@ -20,12 +20,19 @@ export const REFUND_TX_HASH_REGEX = /^0x[0-9a-fA-F]{64}$/;
  */
 export const RefundTxHashModal = ({
   batchCount,
+  suggestedRefundAi3,
   isSubmitting,
   errorMessage,
   onConfirm,
   onClose,
 }: {
   batchCount: number;
+  /**
+   * Informational pro-rated refund suggestion (unused bytes × locked
+   * price), pre-formatted as an AI3 amount. The system does not enforce
+   * the transferred amount — the transfer happens out-of-band.
+   */
+  suggestedRefundAi3?: string | null;
   isSubmitting: boolean;
   errorMessage: string | null;
   onConfirm: (refundTxHash: string) => void;
@@ -78,8 +85,21 @@ export const RefundTxHashModal = ({
           Enter the transaction hash of the on-chain AI3 refund transfer.
           {batchCount > 1 &&
             ' The same hash will be recorded on every selected batch.'}{' '}
-          A refund cannot be recorded without it.
+          A refund cannot be recorded without it. Marking as refunded voids
+          the entire remaining balance of the selected{' '}
+          {batchCount === 1 ? 'batch' : 'batches'}.
         </p>
+
+        {suggestedRefundAi3 && (
+          <p className='mb-4 rounded border border-border bg-muted/50 px-3 py-2 text-xs text-muted-foreground'>
+            Suggested pro-rated refund:{' '}
+            <span className='font-mono font-medium text-foreground'>
+              {suggestedRefundAi3}
+            </span>{' '}
+            (unused storage × locked purchase price). Informational only —
+            the transferred amount is not verified.
+          </p>
+        )}
 
         <label htmlFor='refundTxHash' className='mb-1 block text-sm'>
           Refund transaction hash

--- a/apps/frontend/src/components/views/AdminPanel/RefundTxHashModal.tsx
+++ b/apps/frontend/src/components/views/AdminPanel/RefundTxHashModal.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Button } from '@auto-drive/ui';
+import { AlertTriangle, X } from 'lucide-react';
+
+/**
+ * Strict EVM transaction hash format: 0x followed by 64 hex characters.
+ * Mirrors the backend validation — the backend rejects anything else and
+ * the batch is NOT marked as refunded.
+ */
+export const REFUND_TX_HASH_REGEX = /^0x[0-9a-fA-F]{64}$/;
+
+/**
+ * Modal that collects the mandatory on-chain refund transaction hash before
+ * marking one or more credit batches as refunded. The confirm button stays
+ * disabled until a validly-formatted hash is entered, so a refund can never
+ * be recorded without one. When several batches are refunded together the
+ * same hash is recorded on each (one AI3 transfer covers them all).
+ */
+export const RefundTxHashModal = ({
+  batchCount,
+  isSubmitting,
+  errorMessage,
+  onConfirm,
+  onClose,
+}: {
+  batchCount: number;
+  isSubmitting: boolean;
+  errorMessage: string | null;
+  onConfirm: (refundTxHash: string) => void;
+  onClose: () => void;
+}) => {
+  const [txHash, setTxHash] = useState('');
+  const trimmed = txHash.trim();
+  const isValid = REFUND_TX_HASH_REGEX.test(trimmed);
+  const showFormatHint = trimmed.length > 0 && !isValid;
+
+  // Close on Escape (unless a submission is in flight).
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && !isSubmitting) {
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isSubmitting, onClose]);
+
+  return (
+    <div
+      className='fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4'
+      role='dialog'
+      aria-modal='true'
+    >
+      <div className='w-full max-w-md rounded-lg border border-border bg-background p-6 shadow-xl'>
+        <div className='mb-4 flex items-start justify-between'>
+          <div className='flex items-center gap-2'>
+            <AlertTriangle className='h-5 w-5 text-orange-500' />
+            <h3 className='text-lg font-semibold'>
+              {batchCount === 1
+                ? 'Mark batch as refunded'
+                : `Mark ${batchCount} batches as refunded`}
+            </h3>
+          </div>
+          <button
+            type='button'
+            onClick={onClose}
+            disabled={isSubmitting}
+            className='text-muted-foreground hover:text-foreground disabled:opacity-50'
+            aria-label='Close'
+          >
+            <X className='h-5 w-5' />
+          </button>
+        </div>
+
+        <p className='mb-4 text-sm text-muted-foreground'>
+          Enter the transaction hash of the on-chain AI3 refund transfer.
+          {batchCount > 1 &&
+            ' The same hash will be recorded on every selected batch.'}{' '}
+          A refund cannot be recorded without it.
+        </p>
+
+        <label htmlFor='refundTxHash' className='mb-1 block text-sm'>
+          Refund transaction hash
+        </label>
+        <input
+          id='refundTxHash'
+          type='text'
+          value={txHash}
+          onChange={(e) => setTxHash(e.target.value)}
+          placeholder='0x…'
+          spellCheck={false}
+          className='bg-background-hover text-foreground-hover w-full rounded border px-3 py-2 font-mono text-xs'
+        />
+        {showFormatHint && (
+          <p className='mt-1 text-xs text-red-500'>
+            Expected format: 0x followed by 64 hex characters.
+          </p>
+        )}
+        {errorMessage && (
+          <p className='mt-2 text-sm text-red-500'>{errorMessage}</p>
+        )}
+
+        <div className='mt-6 flex justify-end gap-2'>
+          <Button variant='outline' onClick={onClose} disabled={isSubmitting}>
+            Cancel
+          </Button>
+          <Button
+            variant='primary'
+            disabled={!isValid || isSubmitting}
+            onClick={() => onConfirm(trimmed)}
+          >
+            {isSubmitting
+              ? 'Marking…'
+              : batchCount === 1
+                ? 'Mark Refunded'
+                : `Mark ${batchCount} Refunded`}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/frontend/src/components/views/AdminPanel/RefundTxHashModal.tsx
+++ b/apps/frontend/src/components/views/AdminPanel/RefundTxHashModal.tsx
@@ -3,13 +3,9 @@
 import { useEffect, useState } from 'react';
 import { Button } from '@auto-drive/ui';
 import { AlertTriangle, X } from 'lucide-react';
-
-/**
- * Strict EVM transaction hash format: 0x followed by 64 hex characters.
- * Mirrors the backend validation — the backend rejects anything else and
- * the batch is NOT marked as refunded.
- */
-export const REFUND_TX_HASH_REGEX = /^0x[0-9a-fA-F]{64}$/;
+// Same regex the backend validates with — the backend rejects anything else
+// and the batch is NOT marked as refunded.
+import { EVM_TX_HASH_REGEX } from '@auto-drive/models';
 
 /**
  * Modal that collects the mandatory on-chain refund transaction hash before
@@ -40,7 +36,7 @@ export const RefundTxHashModal = ({
 }) => {
   const [txHash, setTxHash] = useState('');
   const trimmed = txHash.trim();
-  const isValid = REFUND_TX_HASH_REGEX.test(trimmed);
+  const isValid = EVM_TX_HASH_REGEX.test(trimmed);
   const showFormatHint = trimmed.length > 0 && !isValid;
 
   // Close on Escape (unless a submission is in flight).

--- a/apps/frontend/src/components/views/AdminPanel/index.tsx
+++ b/apps/frontend/src/components/views/AdminPanel/index.tsx
@@ -9,9 +9,10 @@ import {
   AccountInfoWithUser,
 } from '@auto-drive/models';
 import { useNetwork } from 'contexts/network';
-import { Button } from '@auto-drive/ui';
+import { Button, ROUTES } from '@auto-drive/ui';
 import { AdminStats } from './AdminStats';
-import { AdminCredits } from './AdminCredits';
+import Link from 'next/link';
+import { CreditCard, ChevronRight } from 'lucide-react';
 
 export const AdminPanel = () => {
   const [accountsWithUsers, setAccountsWithUsers] = useState<
@@ -135,10 +136,22 @@ export const AdminPanel = () => {
       {/* Analytics Section */}
       <AdminStats />
 
-      {/* Purchased Credits Section */}
-      <div className='rounded-lg border border-gray-200 bg-background p-6'>
-        <AdminCredits />
-      </div>
+      {/* Purchased Credits — dedicated screen */}
+      <Link
+        href={ROUTES.adminCredits(network.network.id)}
+        className='flex items-center justify-between rounded-lg border border-gray-200 bg-background p-6 hover:bg-muted/30'
+      >
+        <div className='flex items-center gap-3'>
+          <CreditCard className='h-5 w-5 text-muted-foreground' />
+          <div>
+            <h2 className='text-xl font-semibold'>Purchased Credits</h2>
+            <p className='text-sm text-muted-foreground'>
+              All credit batches, over-cap intents, and refund processing.
+            </p>
+          </div>
+        </div>
+        <ChevronRight className='h-5 w-5 text-muted-foreground' />
+      </Link>
 
       {/* Users Section */}
       <div className='rounded-lg border border-gray-200 bg-background p-6'>

--- a/apps/frontend/src/services/api.ts
+++ b/apps/frontend/src/services/api.ts
@@ -48,9 +48,13 @@ export type ExpiringCreditBatch = {
 };
 
 // Wire-format of rows from GET /credits/batches/all (admin endpoint).
-// Extends ExpiringCreditBatch with the owner's userPublicId.
+// Extends ExpiringCreditBatch with the owner's userPublicId and refund state.
 export type AdminCreditBatch = ExpiringCreditBatch & {
   userPublicId: string;
+  /** ISO timestamp of the refund action, or null if not yet refunded. */
+  refundedAt: string | null;
+  /** On-chain tx hash of the AI3 refund transfer, or null if not refunded. */
+  refundTxHash: string | null;
 };
 
 // Wire-format of GET /credits/economics (admin)
@@ -82,6 +86,8 @@ export type AdminUserCreditBatch = ExpiringCreditBatch & {
   fromAddress: string | null;
   /** ISO timestamp of the refund action, or null if not yet refunded. */
   refundedAt: string | null;
+  /** On-chain tx hash of the AI3 refund transfer, or null if not refunded. */
+  refundTxHash: string | null;
 };
 import { getAuthSession } from 'utils/auth';
 import { uploadFileContent } from 'utils/file';
@@ -1229,9 +1235,14 @@ export const createApiService = ({
   // -------------------------------------------------------------------------
   // Admin: mark a credit batch as refunded
   // POST /credits/batches/:id/refund
+  // The on-chain refund transaction hash is mandatory — the backend rejects
+  // requests without it and the batch is NOT marked as refunded.
   // -------------------------------------------------------------------------
 
-  refundCreditBatch: async (batchId: string): Promise<void> => {
+  refundCreditBatch: async (
+    batchId: string,
+    refundTxHash: string,
+  ): Promise<void> => {
     const session = await getAuthSession();
     if (!session?.authProvider || !session.accessToken) {
       throw new Error('No session');
@@ -1244,12 +1255,62 @@ export const createApiService = ({
         headers: {
           Authorization: `Bearer ${session.accessToken}`,
           'X-Auth-Provider': session.authProvider,
+          'Content-Type': 'application/json',
         },
+        body: JSON.stringify({ refundTxHash }),
       },
     );
 
     if (!response.ok) {
-      throw new Error(`Network response was not ok: ${response.statusText}`);
+      const message = await response
+        .json()
+        .then((body) => body?.error as string | undefined)
+        .catch(() => undefined);
+      throw new Error(
+        message ?? `Network response was not ok: ${response.statusText}`,
+      );
     }
+  },
+
+  // -------------------------------------------------------------------------
+  // Admin: mark several credit batches as refunded in one atomic operation
+  // POST /credits/batches/refund
+  // The same on-chain refund transaction hash is recorded on every batch
+  // (one AI3 transfer can cover multiple batches of the same account).
+  // -------------------------------------------------------------------------
+
+  refundCreditBatches: async (
+    batchIds: string[],
+    refundTxHash: string,
+  ): Promise<{ refundedCount: number; alreadyRefundedCount: number }> => {
+    const session = await getAuthSession();
+    if (!session?.authProvider || !session.accessToken) {
+      throw new Error('No session');
+    }
+
+    const response = await fetch(`${apiBaseUrl}/credits/batches/refund`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${session.accessToken}`,
+        'X-Auth-Provider': session.authProvider,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ batchIds, refundTxHash }),
+    });
+
+    if (!response.ok) {
+      const message = await response
+        .json()
+        .then((body) => body?.error as string | undefined)
+        .catch(() => undefined);
+      throw new Error(
+        message ?? `Network response was not ok: ${response.statusText}`,
+      );
+    }
+
+    return response.json() as Promise<{
+      refundedCount: number;
+      alreadyRefundedCount: number;
+    }>;
   },
 });

--- a/apps/frontend/src/services/api.ts
+++ b/apps/frontend/src/services/api.ts
@@ -55,6 +55,8 @@ export type AdminCreditBatch = ExpiringCreditBatch & {
   refundedAt: string | null;
   /** On-chain tx hash of the AI3 refund transfer, or null if not refunded. */
   refundTxHash: string | null;
+  /** EVM purchasing wallet that paid for the batch, if known. */
+  fromAddress: string | null;
 };
 
 // Wire-format of GET /credits/economics (admin)

--- a/packages/models/src/common/evm.ts
+++ b/packages/models/src/common/evm.ts
@@ -1,0 +1,9 @@
+/**
+ * Strict EVM transaction hash format: 0x followed by 64 hex characters.
+ * Shared by the backend refund validation and the frontend refund modal so
+ * the two can never drift apart.
+ */
+export const EVM_TX_HASH_REGEX = /^0x[0-9a-fA-F]{64}$/
+
+export const isEvmTxHash = (value: string): boolean =>
+  EVM_TX_HASH_REGEX.test(value)

--- a/packages/models/src/common/index.ts
+++ b/packages/models/src/common/index.ts
@@ -1,3 +1,4 @@
+export * from './evm.js'
 export * from './pagination.js'
 export * from './banner.js'
 export * from './tou.js'

--- a/packages/models/src/users/purchasedCredit.ts
+++ b/packages/models/src/users/purchasedCredit.ts
@@ -19,6 +19,14 @@ export const PurchasedCreditSchema = z.object({
    * Set by POST /credits/batches/:id/refund, which also zeros remaining bytes.
    */
   refundedAt: z.date().nullable(),
+  /**
+   * On-chain transaction hash of the AI3 refund transfer. Mandatory when
+   * marking a batch as refunded — the refund endpoints reject requests
+   * without it. Batches refunded together in one on-chain transaction share
+   * the same hash. Null only on rows refunded before this field existed,
+   * or rows never refunded.
+   */
+  refundTxHash: z.string().nullable(),
   createdAt: z.date(),
   updatedAt: z.date(),
 });

--- a/packages/ui/src/constants/routes.ts
+++ b/packages/ui/src/constants/routes.ts
@@ -64,6 +64,7 @@ export const ROUTES = {
     `/${networkId}/drive/admin/deletions`,
   adminOrganization: (networkId: NetworkId, organizationId: string) =>
     `/${networkId}/drive/admin/organization/${organizationId}`,
+  adminCredits: (networkId: NetworkId) => `/${networkId}/drive/admin/credits`,
   adminUserCredits: (networkId: NetworkId, userPublicId: string) =>
     `/${networkId}/drive/admin/credits/${encodeURIComponent(userPublicId)}`,
   explorer: (networkId: NetworkId) => `/${networkId}/explorer`,


### PR DESCRIPTION
### Summary

Expands the existing "mark as refunded" feature for credits purchased with AI3 that expired unused:

1. **Dedicated credits screen** — purchased credits move out of the admin dashboard into `/{chain}/drive/admin/credits`. Batches are grouped by account, each rendered as a single summary line (batch count, storage purchased / remaining / expired unused) with a per-account toggle to expand the full batch list, plus Expand all / Collapse all.
2. **Combined refunds** — multiple unused batches of the same account can be selected and marked as refunded in one atomic operation, while single-batch refunds still work as before.
3. **Mandatory refund transaction hash** — every refund must record the on-chain tx hash of the AI3 transfer (strict `0x` + 64 hex format). Without a valid hash the request is rejected and nothing is marked refunded.

### Backend

- New migration `20260611000000` adds `purchased_credits.refund_tx_hash VARCHAR(255)` (NULL only on rows refunded before this column existed).
- `POST /credits/batches/:id/refund` now requires `{ refundTxHash }` in the body; 400 on missing/malformed hash.
- New `POST /credits/batches/refund` with `{ batchIds, refundTxHash }`:
  - All-or-nothing transaction: if any id is unknown → 404 listing the missing ids, nothing updated.
  - **Rejects batches spanning multiple accounts (400)** — one on-chain transfer goes to a single wallet, so cross-account combined refunds are blocked server-side.
  - Already-refunded batches are skipped (idempotent), same as the single endpoint; the same hash is recorded on every batch.
- Repository: `markAsRefunded(id, refundTxHash)` and new `markManyAsRefunded(ids, refundTxHash)` (row-locking transaction with rollback on missing ids / multiple accounts).
- `@auto-drive/models`: `PurchasedCredit.refundTxHash` added.

### Frontend

- New route + page `/{chain}/drive/admin/credits` (`ROUTES.adminCredits`); the dashboard section is replaced by a link card.
- Per-user purchase history: checkboxes on non-refunded batches, select-all, and a "Mark N Refunded" action; both single and combined refunds go through a modal that requires a validly-formatted tx hash before the confirm button enables.
- Refunded rows display the refund timestamp and tx hash on both screens.
- Account ID on the purchase history header and an "Account →" shortcut on each group line link to the existing account details page (uploads/downloads) via the `accountId` already on batch rows.

### Tests

13 new unit tests in `apps/backend/__tests__/unit/useCases/credits.spec.ts` covering: admin-only access, missing/malformed tx hashes (verifying the repository is never called), hash trimming, 404 on unknown ids, multi-account rejection, idempotent no-ops, id de-duplication, and refunded/already-refunded counts.

### Deployment notes

- Run `yarn backend db-migrate up` before deploying.
- Existing refunded rows keep `refund_tx_hash = NULL`; all new refunds require a hash.