### PR TITLE
feat: add payment-asset columns to intents + repository mapping (USDC epic — step 2)

### DIFF
--- a/apps/backend/__tests__/unit/repositories/intents.spec.ts
+++ b/apps/backend/__tests__/unit/repositories/intents.spec.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeAll, afterAll } from '@jest/globals'
+import { intentsRepository } from '../../../src/infrastructure/repositories/users/intents.js'
+import { Intent, IntentStatus, PaymentMethod } from '@auto-drive/models'
+import { dbMigration } from '../../utils/dbMigrate.js'
+
+// Exercises the payment-asset columns added by 20260616000000-intent-payment-fields
+// together with the repository read/write mapping. Runs against the migrated
+// TestContainers Postgres (requires Docker), like the other repository specs.
+describe('Intents Repository — payment fields', () => {
+  beforeAll(async () => {
+    await dbMigration.up()
+  })
+
+  afterAll(async () => {
+    await dbMigration.down()
+  })
+
+  const baseIntent = (id: string): Intent => ({
+    id,
+    userPublicId: `user-${id}`,
+    status: IntentStatus.PENDING,
+    shannonsPerByte: 1000n,
+    expiresAt: new Date('2030-01-01T00:00:00Z'),
+  })
+
+  it('defaults payment_method to ai3_native and leaves token fields NULL', async () => {
+    const created = await intentsRepository.createIntent(baseIntent('ai3-1'))
+    expect(created.paymentMethod).toBe(PaymentMethod.AI3_NATIVE)
+    expect(created.tokenAmount).toBeUndefined()
+    expect(created.quotedTokenAmount).toBeUndefined()
+    expect(created.usdRateAtCreation).toBeUndefined()
+
+    const fetched = await intentsRepository.getById('ai3-1')
+    expect(fetched?.paymentMethod).toBe(PaymentMethod.AI3_NATIVE)
+    expect(fetched?.tokenAmount).toBeUndefined()
+  })
+
+  it('round-trips a USDC intent with token amounts and locked rate as bigints', async () => {
+    const usdcIntent: Intent = {
+      ...baseIntent('usdc-1'),
+      paymentMethod: PaymentMethod.USDC_ETH,
+      tokenAmount: 5_000_000n, // 5 USDC (6 decimals)
+      quotedTokenAmount: 5_000_000n,
+      usdRateAtCreation: 6_400_000_000_000_000n, // 0.0064 USD/AI3 * 1e18
+    }
+    await intentsRepository.createIntent(usdcIntent)
+
+    const fetched = await intentsRepository.getById('usdc-1')
+    expect(fetched?.paymentMethod).toBe(PaymentMethod.USDC_ETH)
+    expect(fetched?.tokenAmount).toBe(5_000_000n)
+    expect(fetched?.quotedTokenAmount).toBe(5_000_000n)
+    expect(fetched?.usdRateAtCreation).toBe(6_400_000_000_000_000n)
+    expect(typeof fetched?.usdRateAtCreation).toBe('bigint')
+  })
+
+  it('preserves payment fields across an update that spreads the loaded intent', async () => {
+    const usdcIntent: Intent = {
+      ...baseIntent('usdc-2'),
+      paymentMethod: PaymentMethod.USDC_ETH,
+      tokenAmount: 1_000_000n,
+      quotedTokenAmount: 1_000_000n,
+      usdRateAtCreation: 6_400_000_000_000_000n,
+    }
+    await intentsRepository.createIntent(usdcIntent)
+
+    const loaded = await intentsRepository.getById('usdc-2')
+    expect(loaded).not.toBeNull()
+
+    // Mirrors how the use cases update intents: spread the loaded row, override
+    // only the changed field. The token/method fields must survive untouched.
+    await intentsRepository.updateIntent({
+      ...(loaded as Intent),
+      status: IntentStatus.CONFIRMED,
+      paymentAmount: 5_000_000n,
+    })
+
+    const updated = await intentsRepository.getById('usdc-2')
+    expect(updated?.status).toBe(IntentStatus.CONFIRMED)
+    expect(updated?.paymentMethod).toBe(PaymentMethod.USDC_ETH)
+    expect(updated?.tokenAmount).toBe(1_000_000n)
+    expect(updated?.quotedTokenAmount).toBe(1_000_000n)
+    expect(updated?.usdRateAtCreation).toBe(6_400_000_000_000_000n)
+  })
+})

--- a/apps/backend/migrations/20260616000000-intent-payment-fields.js
+++ b/apps/backend/migrations/20260616000000-intent-payment-fields.js
@@ -1,0 +1,53 @@
+'use strict'
+
+var dbm
+var type
+var seed
+var fs = require('fs')
+var path = require('path')
+var Promise
+
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  var filePath = path.join(
+    __dirname,
+    'sqls',
+    '20260616000000-intent-payment-fields-up.sql',
+  )
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+      resolve(data)
+    })
+  }).then(function (data) {
+    return db.runSql(data)
+  })
+}
+
+exports.down = function (db) {
+  var filePath = path.join(
+    __dirname,
+    'sqls',
+    '20260616000000-intent-payment-fields-down.sql',
+  )
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+      resolve(data)
+    })
+  }).then(function (data) {
+    return db.runSql(data)
+  })
+}
+
+exports._meta = {
+  version: 1,
+}

--- a/apps/backend/migrations/sqls/20260616000000-intent-payment-fields-down.sql
+++ b/apps/backend/migrations/sqls/20260616000000-intent-payment-fields-down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE intents
+  DROP COLUMN IF EXISTS usd_rate_at_creation,
+  DROP COLUMN IF EXISTS quoted_token_amount,
+  DROP COLUMN IF EXISTS token_amount,
+  DROP COLUMN IF EXISTS payment_method;

--- a/apps/backend/migrations/sqls/20260616000000-intent-payment-fields-up.sql
+++ b/apps/backend/migrations/sqls/20260616000000-intent-payment-fields-up.sql
@@ -1,0 +1,25 @@
+-- Add payment-asset columns to intents for USDC-on-Ethereum support.
+--
+-- The payment asset is a first-class concept (see PaymentMethod in
+-- @auto-drive/models) so new tokens/chains become configuration rather than
+-- schema changes.
+--
+-- payment_method is NOT NULL with a default of 'ai3_native'. Every existing row
+-- is a native-AI3 payment, so the default backfills them correctly and all
+-- future rows carry an explicit method. (No CHECK constraint — the value set is
+-- enforced in the application layer, matching the existing `status` column.)
+--
+-- The token_* / usd_rate columns apply only to token (USDC) payments and stay
+-- NULL for native-AI3 intents:
+--   token_amount         — raw on-chain amount received, token's smallest unit
+--   quoted_token_amount  — amount quoted to the user at intent creation
+--   usd_rate_at_creation — AI3/USD rate locked at creation, scaled by 1e18 (see
+--                          USD_RATE_SCALE)
+-- All three are numeric(78,0) to match the bigint base-unit convention already
+-- used by payment_amount / shannons_per_byte.
+
+ALTER TABLE intents
+  ADD COLUMN IF NOT EXISTS payment_method       VARCHAR(32) NOT NULL DEFAULT 'ai3_native',
+  ADD COLUMN IF NOT EXISTS token_amount         numeric(78,0),
+  ADD COLUMN IF NOT EXISTS quoted_token_amount  numeric(78,0),
+  ADD COLUMN IF NOT EXISTS usd_rate_at_creation numeric(78,0);

--- a/apps/backend/src/infrastructure/repositories/users/intents.ts
+++ b/apps/backend/src/infrastructure/repositories/users/intents.ts
@@ -1,5 +1,5 @@
 import { getDatabase } from '../../drivers/pg.js'
-import { Intent, IntentStatus } from '@auto-drive/models'
+import { Intent, IntentStatus, PaymentMethod } from '@auto-drive/models'
 
 type DBIntent = {
   id: string
@@ -10,6 +10,12 @@ type DBIntent = {
   shannons_per_byte: string
   expires_at: Date | null
   from_address: string | null
+  // NOT NULL in the DB (defaults to 'ai3_native'), so always present.
+  payment_method: PaymentMethod
+  // Token-payment columns: populated for USDC_ETH intents, NULL for AI3_NATIVE.
+  token_amount: string | null
+  quoted_token_amount: string | null
+  usd_rate_at_creation: string | null
 }
 
 const mapRows = (rows: DBIntent[]): Intent[] => {
@@ -24,6 +30,16 @@ const mapRows = (rows: DBIntent[]): Intent[] => {
     shannonsPerByte: BigInt(row.shannons_per_byte).valueOf(),
     expiresAt: row.expires_at ?? undefined,
     fromAddress: row.from_address ?? undefined,
+    paymentMethod: row.payment_method,
+    tokenAmount: row.token_amount
+      ? BigInt(row.token_amount).valueOf()
+      : undefined,
+    quotedTokenAmount: row.quoted_token_amount
+      ? BigInt(row.quoted_token_amount).valueOf()
+      : undefined,
+    usdRateAtCreation: row.usd_rate_at_creation
+      ? BigInt(row.usd_rate_at_creation).valueOf()
+      : undefined,
   }))
 }
 
@@ -40,8 +56,10 @@ const createIntent = async (intent: Intent): Promise<Intent> => {
   const db = await getDatabase()
   const result = await db.query<DBIntent>(
     `INSERT INTO intents
-       (id, user_public_id, status, tx_hash, payment_amount, shannons_per_byte, expires_at)
-     VALUES ($1, $2, $3, $4, $5, $6, $7)
+       (id, user_public_id, status, tx_hash, payment_amount, shannons_per_byte,
+        expires_at, payment_method, token_amount, quoted_token_amount,
+        usd_rate_at_creation)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
      RETURNING *`,
     [
       intent.id,
@@ -51,6 +69,12 @@ const createIntent = async (intent: Intent): Promise<Intent> => {
       intent.paymentAmount?.toString() ?? null,
       intent.shannonsPerByte,
       intent.expiresAt ?? null,
+      // payment_method is NOT NULL; default to native AI3 when unset (the USDC
+      // creation flow sets it explicitly).
+      intent.paymentMethod ?? PaymentMethod.AI3_NATIVE,
+      intent.tokenAmount?.toString() ?? null,
+      intent.quotedTokenAmount?.toString() ?? null,
+      intent.usdRateAtCreation?.toString() ?? null,
     ],
   )
   return mapRows(result.rows)[0]
@@ -62,8 +86,9 @@ const updateIntent = async (intent: Intent): Promise<Intent> => {
     `UPDATE intents
      SET status = $1, user_public_id = $2, tx_hash = $3,
          payment_amount = $4, shannons_per_byte = $5, expires_at = $6,
-         from_address = $7
-     WHERE id = $8
+         from_address = $7, payment_method = $8, token_amount = $9,
+         quoted_token_amount = $10, usd_rate_at_creation = $11
+     WHERE id = $12
      RETURNING *`,
     [
       intent.status,
@@ -73,6 +98,12 @@ const updateIntent = async (intent: Intent): Promise<Intent> => {
       intent.shannonsPerByte,
       intent.expiresAt ?? null,
       intent.fromAddress ?? null,
+      // Callers load the intent (getById → mapRows) and spread it before
+      // updating, so these round-trip unchanged unless explicitly overridden.
+      intent.paymentMethod ?? PaymentMethod.AI3_NATIVE,
+      intent.tokenAmount?.toString() ?? null,
+      intent.quotedTokenAmount?.toString() ?? null,
+      intent.usdRateAtCreation?.toString() ?? null,
       intent.id,
     ],
   )


### PR DESCRIPTION
**Part of #742 (USDC Payments for PayWithAI3 epic).**
**Closes #744 — DB migration: extend intents with payment_method and token columns.**

> ⚠️ **Stacked on #755 (step 1).** Base is `feat/usdc-payments-epic-step-1-models`, not `main`, because the repository mapping uses the `PaymentMethod` enum and the new `Intent` fields introduced there. GitHub will auto-retarget this PR to `main` once #755 merges (a rebase may be needed if #755 is squash-merged).

Step 2: add the DB columns the step-1 types map to, and teach the intents repository to read/write them — so later steps only populate the `Intent` object, no further SQL changes.

## Migration `20260616000000-intent-payment-fields`
- `payment_method VARCHAR(32) NOT NULL DEFAULT 'ai3_native'` — backfills every existing (native-AI3) row and forces all future rows to carry a method. No `CHECK` constraint, matching the app-enforced `status` column.
- `token_amount`, `quoted_token_amount`, `usd_rate_at_creation` as `numeric(78,0)`, NULL for AI3 intents. `usd_rate_at_creation` holds the AI3/USD rate **scaled by 1e18**, matching the bigint base-unit convention of `payment_amount` / `shannons_per_byte`.
- Down migration drops all four columns.

## Repository (`repositories/users/intents.ts`)
- `DBIntent` + `mapRows` read the new columns (token fields → `bigint | undefined`).
- `createIntent` / `updateIntent` write them; `payment_method` defaults to `AI3_NATIVE` when unset (the USDC creation flow in #747 sets it explicitly).
- Adding the columns to `updateIntent`'s `SET` is safe: every call site spreads the loaded intent (`{ ...intent, ...overrides }`), so the fields round-trip unchanged unless explicitly overridden.

## Test
- New `intents.spec.ts` round-trips an AI3 intent (defaults applied, token fields NULL), a USDC intent (token amounts + locked rate as bigints), and an update that must preserve the payment fields.
- Integration-style against TestContainers Postgres, like the existing `nodes.spec.ts` / `metadata.spec.ts` — so it runs the new migration for real.

## Verification
- `models` + backend `tsc --noEmit` (incl. tests): **zero errors from this change**. (The lone pre-existing `@polkadot/wasm-crypto` error is an unrelated incomplete-install artifact in this environment.)
- The new spec needs **Docker/TestContainers**, which isn't available in my environment (true for every repository spec here), so it was not executed locally — it will run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
