### PR TITLE
fix(s3): handle control-char keys in ListObjectsV2 via encoding-type=url

### DIFF
--- a/apps/backend/__tests__/unit/controllers/s3-listing-encoding.spec.ts
+++ b/apps/backend/__tests__/unit/controllers/s3-listing-encoding.spec.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from '@jest/globals'
+import {
+  encodeS3Key,
+  hasXmlIllegalChars,
+  planListingEncoding,
+} from '../../../src/app/controllers/s3/utils.js'
+
+describe('hasXmlIllegalChars', () => {
+  it('returns false for ordinary keys', () => {
+    expect(hasXmlIllegalChars('dir/file.txt')).toBe(false)
+    expect(hasXmlIllegalChars('hello world (1).txt')).toBe(false)
+    expect(hasXmlIllegalChars('Hello, 世界/ " \' @ < > & ? + ≠')).toBe(false)
+  })
+
+  it('treats TAB, LF and CR as legal (XML permits them)', () => {
+    expect(hasXmlIllegalChars('a\tb')).toBe(false)
+    expect(hasXmlIllegalChars('a\nb')).toBe(false)
+    expect(hasXmlIllegalChars('a\rb')).toBe(false)
+  })
+
+  it('detects control characters XML 1.0 cannot represent', () => {
+    expect(hasXmlIllegalChars('recon-ctrl-\x01\x02-test.txt')).toBe(true)
+    expect(hasXmlIllegalChars('\x00')).toBe(true)
+    expect(hasXmlIllegalChars('\x0B')).toBe(true)
+    expect(hasXmlIllegalChars('\x0C')).toBe(true)
+    expect(hasXmlIllegalChars('\x1F')).toBe(true)
+  })
+})
+
+describe('encodeS3Key', () => {
+  it('percent-encodes control characters', () => {
+    expect(encodeS3Key('a\x01b')).toBe('a%01b')
+  })
+
+  it('encodes spaces as %20 (never +) and encodes a literal +', () => {
+    expect(encodeS3Key('a b')).toBe('a%20b')
+    expect(encodeS3Key('a+b')).toBe('a%2Bb')
+  })
+
+  it('encodes reserved characters so decoding round-trips', () => {
+    expect(encodeS3Key('dir/file')).toBe('dir%2Ffile')
+    expect(encodeS3Key('a%b')).toBe('a%25b')
+  })
+
+  it('round-trips back to the original via decodeURIComponent', () => {
+    const key = 'dir/weird key+\x01\x02-世界.txt'
+    expect(decodeURIComponent(encodeS3Key(key))).toBe(key)
+  })
+
+  it('leaves the unreserved set untouched', () => {
+    expect(encodeS3Key('abcABC123-_.!~*\'()')).toBe('abcABC123-_.!~*\'()')
+  })
+})
+
+describe('planListingEncoding', () => {
+  const cleanKeys = ['dir/a.txt', 'dir/b.txt', 'sub/']
+  const dirtyKeys = ['dir/a.txt', 'recon-ctrl-\x01\x02-test.txt']
+
+  it('renders a clean page unchanged when the client does not opt in', () => {
+    expect(planListingEncoding(cleanKeys, null)).toBe('plain')
+  })
+
+  it('encodes when the client opts in, even for a clean page', () => {
+    expect(planListingEncoding(cleanKeys, 'url')).toBe('encode')
+  })
+
+  it('encodes an affected page when the client opts in', () => {
+    expect(planListingEncoding(dirtyKeys, 'url')).toBe('encode')
+  })
+
+  it('rejects an affected page when the client did not opt in', () => {
+    expect(planListingEncoding(dirtyKeys, null)).toBe('reject')
+  })
+
+  it('treats an illegal CommonPrefix the same as an illegal key', () => {
+    expect(planListingEncoding(['ok/', 'bad\x07/'], null)).toBe('reject')
+    expect(planListingEncoding(['ok/', 'bad\x07/'], 'url')).toBe('encode')
+  })
+})

--- a/apps/backend/src/app/controllers/s3/s3.ts
+++ b/apps/backend/src/app/controllers/s3/s3.ts
@@ -9,7 +9,7 @@ import {
 import { pipeline } from 'stream'
 import { createLogger } from '../../../infrastructure/drivers/logger.js'
 import { Request, Response } from 'express'
-import { sendXML } from './utils.js'
+import { encodeS3Key, planListingEncoding, sendXML } from './utils.js'
 import js2xmlparser from 'js2xmlparser'
 import { UploadOptions } from '@auto-drive/models'
 import {
@@ -341,6 +341,7 @@ export const listObjectsV2Handler = async (req: Request, res: Response) => {
   const maxKeys = Math.min(Math.max(rawMaxKeys > 0 ? rawMaxKeys : 1000, 1), 1000)
   const continuationToken =
     (req.query['continuation-token'] as string) ?? null
+  const encodingType = (req.query['encoding-type'] as string) ?? null
 
   const result = await S3UseCases.listObjects({
     bucket,
@@ -350,15 +351,41 @@ export const listObjectsV2Handler = async (req: Request, res: Response) => {
     continuationToken,
   })
 
+  // Keys may contain characters XML cannot represent; encoding-type=url is the
+  // S3 mechanism for returning them. Without opt-in, reject with 400 rather
+  // than throwing a 500 in the serializer.
+  const plan = planListingEncoding(
+    [...result.objects.map((o) => o.key), ...result.commonPrefixes],
+    encodingType,
+  )
+
+  if (plan === 'reject') {
+    sendXML(res.status(400), 'Error', {
+      Code: 'InvalidArgument',
+      Message:
+        'This listing contains keys with characters that require URL encoding. Retry the request with encoding-type=url.',
+      ArgumentName: 'encoding-type',
+      Resource: `/${bucket}/`,
+    })
+    return
+  }
+
+  const encode = plan === 'encode' ? encodeS3Key : (value: string) => value
+
   // Build the XML body.  js2xmlparser repeats a key for each array element,
   // which is exactly the S3 format (multiple <Contents> / <CommonPrefixes>
   // siblings at the root level).
   const xmlBody: Record<string, unknown> = {
     Name: result.name,
-    Prefix: result.prefix,
+    Prefix: encode(result.prefix),
     MaxKeys: result.maxKeys,
     KeyCount: result.objects.length + result.commonPrefixes.length,
     IsTruncated: result.isTruncated,
+  }
+
+  // Echo the encoding back so clients know to url-decode the keys below.
+  if (plan === 'encode') {
+    xmlBody.EncodingType = 'url'
   }
 
   if (result.nextContinuationToken) {
@@ -367,7 +394,7 @@ export const listObjectsV2Handler = async (req: Request, res: Response) => {
 
   if (result.objects.length > 0) {
     xmlBody.Contents = result.objects.map((obj) => ({
-      Key: obj.key,
+      Key: encode(obj.key),
       Size: obj.size.toString(),
       LastModified: obj.lastModified.toISOString(),
       // Return the stored MD5 so clients (rclone, AWS CLI) can verify
@@ -379,7 +406,7 @@ export const listObjectsV2Handler = async (req: Request, res: Response) => {
 
   if (result.commonPrefixes.length > 0) {
     xmlBody.CommonPrefixes = result.commonPrefixes.map((p) => ({
-      Prefix: p,
+      Prefix: encode(p),
     }))
   }
 

--- a/apps/backend/src/app/controllers/s3/utils.ts
+++ b/apps/backend/src/app/controllers/s3/utils.ts
@@ -10,3 +10,28 @@ export const sendXML = <T extends object>(
 
   res.send(js2xmlparser.parse(rootName, json))
 }
+
+// Control characters XML 1.0 cannot represent (all except TAB, LF, CR).
+// eslint-disable-next-line no-control-regex
+const XML_ILLEGAL_CHARS = /[\x00-\x08\x0B\x0C\x0E-\x1F]/
+
+export const hasXmlIllegalChars = (value: string): boolean =>
+  XML_ILLEGAL_CHARS.test(value)
+
+// Inverse of the url.QueryUnescape that encoding-type=url clients (e.g. rclone)
+// apply to every key, so encoding round-trips.
+export const encodeS3Key = (value: string): string => encodeURIComponent(value)
+
+export type ListingEncodingPlan = 'plain' | 'encode' | 'reject'
+
+// 'encode': client opted into encoding-type=url — encode every key/prefix.
+// 'reject': illegal keys present without opt-in — caller returns 400.
+// 'plain':  nothing illegal and no opt-in — render unchanged.
+export const planListingEncoding = (
+  values: string[],
+  encodingType: string | null,
+): ListingEncodingPlan => {
+  if (encodingType === 'url') return 'encode'
+  if (values.some(hasXmlIllegalChars)) return 'reject'
+  return 'plain'
+}


### PR DESCRIPTION
Fixes #758

## Problem

`ListObjectsV2` returned **HTTP 500 with an HTML body** when a bucket contained a key with control
characters. XML 1.0 cannot represent most control characters (`0x00–0x08`, `0x0B`, `0x0C`, `0x0E–0x1F`)
at all, so the serializer threw and Express returned its default HTML 500 page. Because storage is
immutable, such a key cannot be removed, so the bucket's listing was permanently broken.

Reproducer:

```bash
aws --endpoint-url https://public.auto-drive.autonomys.xyz/s3 s3api put-object \
  --bucket <bucket> --key $'recon-ctrl-\x01\x02-test.txt' --body somefile
AWS_MAX_ATTEMPTS=1 aws --endpoint-url https://public.auto-drive.autonomys.xyz/s3 \
  s3api list-objects-v2 --bucket <bucket>
# => An error occurred (500) ... Internal Server Error  (HTML body, not S3 XML)
```

## Fix

Implement the standard `encoding-type=url` parameter in `ListObjectsV2`:

- **`encoding-type=url`**: percent-encode every key and `CommonPrefix` and return
  `<EncodingType>url</EncodingType>` (encoding all keys, not just the affected ones, so clients that
  url-decode the whole listing stay correct for keys containing `+`, `%`, or `/`).
- **No opt-in, affected page**: return **400 `InvalidArgument`** (`<ArgumentName>encoding-type</ArgumentName>`)
  instead of throwing a 500.
- **No opt-in, clean page**: unchanged.

`PutObject` stays permissive (any UTF-8 key); storing the key was never the problem, the listing
serialization was.

This also lets the upstream rclone `Autonomys.yaml` flip `list_url_encode` from `false` back to the
default `true`.

## Tests

Unit tests for `hasXmlIllegalChars`, `encodeS3Key` (control chars, `%20`/`%2B`/`%2F`, round-trip,
unreserved set), and `planListingEncoding` (clean → plain, opt-in → encode, affected without opt-in →
reject, illegal `CommonPrefix` symmetric).
