### PR TITLE
fix(s3): parse CompleteMultipartUpload XML with a real parser

### DIFF
--- a/apps/backend/__tests__/unit/controllers/s3-multipart-parser.spec.ts
+++ b/apps/backend/__tests__/unit/controllers/s3-multipart-parser.spec.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from '@jest/globals'
+import { createHash } from 'crypto'
+import { multipartETag } from '@autonomys/file-server'
+import {
+  MalformedMultipartError,
+  parseMultipartParts,
+} from '../../../src/app/controllers/s3/s3.js'
+
+// Two known per-part MD5s: md5("") and md5("a").
+const M1 = 'd41d8cd98f00b204e9800998ecf8427e'
+const M2 = '0cc175b9c0f1b6a831c399e269772661'
+
+// The AWS composite ETag = md5( raw(M1) ++ raw(M2) ) + "-" + partCount.
+const expectedComposite = `${createHash('md5')
+  .update(Buffer.concat([Buffer.from(M1, 'hex'), Buffer.from(M2, 'hex')]))
+  .digest('hex')}-2`
+
+const buf = (s: string) => Buffer.from(s, 'utf-8')
+
+// aws-cli / boto3: PartNumber before ETag, quotes emitted literally.
+const botoBody = `<?xml version="1.0" encoding="UTF-8"?>
+<CompleteMultipartUpload xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Part><PartNumber>1</PartNumber><ETag>"${M1}"</ETag></Part><Part><PartNumber>2</PartNumber><ETag>"${M2}"</ETag></Part></CompleteMultipartUpload>`
+
+// aws-sdk-go-v2 / rclone: ETag before PartNumber, quotes escaped as &#34;.
+const goSdkBody = `<CompleteMultipartUpload xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Part><ETag>&#34;${M1}&#34;</ETag><PartNumber>1</PartNumber></Part><Part><ETag>&#34;${M2}&#34;</ETag><PartNumber>2</PartNumber></Part></CompleteMultipartUpload>`
+
+describe('parseMultipartParts', () => {
+  it('parses the aws-cli (boto3) body', () => {
+    expect(parseMultipartParts(buf(botoBody))).toEqual([
+      { PartNumber: 1, ETag: `"${M1}"` },
+      { PartNumber: 2, ETag: `"${M2}"` },
+    ])
+  })
+
+  it('parses the aws-sdk-go-v2 (rclone) body, decoding &#34; to literal quotes', () => {
+    const parts = parseMultipartParts(buf(goSdkBody))
+    expect(parts).toEqual([
+      { PartNumber: 1, ETag: `"${M1}"` },
+      { PartNumber: 2, ETag: `"${M2}"` },
+    ])
+    // The bug was that &#34; survived and broke the hex decode.
+    expect(parts.every((p) => !p.ETag.includes('&#34;'))).toBe(true)
+  })
+
+  it('yields identical parts for both SDK encodings', () => {
+    expect(parseMultipartParts(buf(goSdkBody))).toEqual(
+      parseMultipartParts(buf(botoBody)),
+    )
+  })
+
+  it('produces the correct AWS composite ETag from the go-sdk body', () => {
+    const parts = parseMultipartParts(buf(goSdkBody))
+    const composite = multipartETag(parts.map((p) => p.ETag)).replace(/"/g, '')
+    expect(composite).toBe(expectedComposite)
+    // Regression guard: must not be the MD5-of-empty value the old parser stored.
+    expect(composite.startsWith('d41d8cd98f00b204e9800998ecf8427e-')).toBe(false)
+  })
+
+  it('handles namespace-prefixed elements', () => {
+    const nsBody = `<s3:CompleteMultipartUpload xmlns:s3="http://s3.amazonaws.com/doc/2006-03-01/"><s3:Part><s3:PartNumber>1</s3:PartNumber><s3:ETag>"${M1}"</s3:ETag></s3:Part></s3:CompleteMultipartUpload>`
+    expect(parseMultipartParts(buf(nsBody))).toEqual([
+      { PartNumber: 1, ETag: `"${M1}"` },
+    ])
+  })
+
+  it('sorts parts by PartNumber', () => {
+    const body = `<CompleteMultipartUpload><Part><PartNumber>2</PartNumber><ETag>"${M2}"</ETag></Part><Part><PartNumber>1</PartNumber><ETag>"${M1}"</ETag></Part></CompleteMultipartUpload>`
+    expect(parseMultipartParts(buf(body)).map((p) => p.PartNumber)).toEqual([
+      1, 2,
+    ])
+  })
+
+  describe('rejects malformed bodies with MalformedMultipartError', () => {
+    it('missing root element', () => {
+      expect(() => parseMultipartParts(buf('<Other></Other>'))).toThrow(
+        MalformedMultipartError,
+      )
+    })
+
+    it('empty body', () => {
+      expect(() => parseMultipartParts(buf(''))).toThrow(MalformedMultipartError)
+    })
+
+    it('no parts', () => {
+      expect(() =>
+        parseMultipartParts(
+          buf('<CompleteMultipartUpload></CompleteMultipartUpload>'),
+        ),
+      ).toThrow(MalformedMultipartError)
+    })
+
+    it('part missing PartNumber', () => {
+      expect(() =>
+        parseMultipartParts(
+          buf(
+            `<CompleteMultipartUpload><Part><ETag>"${M1}"</ETag></Part></CompleteMultipartUpload>`,
+          ),
+        ),
+      ).toThrow(MalformedMultipartError)
+    })
+
+    it('part with empty ETag', () => {
+      expect(() =>
+        parseMultipartParts(
+          buf(
+            '<CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag></ETag></Part></CompleteMultipartUpload>',
+          ),
+        ),
+      ).toThrow(MalformedMultipartError)
+    })
+
+    it('part with non-integer PartNumber', () => {
+      expect(() =>
+        parseMultipartParts(
+          buf(
+            `<CompleteMultipartUpload><Part><PartNumber>1.5</PartNumber><ETag>"${M1}"</ETag></Part></CompleteMultipartUpload>`,
+          ),
+        ),
+      ).toThrow(MalformedMultipartError)
+    })
+  })
+})

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -44,6 +44,7 @@
     "debug-level": "^4.1.1",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
+    "fast-xml-parser": "5.5.8",
     "js2xmlparser": "^5.0.0",
     "jsonwebtoken": "^9.0.2",
     "keyv": "^5.3.1",

--- a/apps/backend/src/app/controllers/s3/s3.ts
+++ b/apps/backend/src/app/controllers/s3/s3.ts
@@ -11,6 +11,7 @@ import { createLogger } from '../../../infrastructure/drivers/logger.js'
 import { Request, Response } from 'express'
 import { sendXML } from './utils.js'
 import js2xmlparser from 'js2xmlparser'
+import { XMLParser } from 'fast-xml-parser'
 import { UploadOptions } from '@auto-drive/models'
 import {
   CompressionAlgorithm,
@@ -60,48 +61,64 @@ const getUploadOptions = (req: Request) => {
   return UploadOptions
 }
 
-/**
- * Extract part ETags from a CompleteMultipartUpload XML request body.
- *
- * AWS SDK v3 for JavaScript serialises <ETag> BEFORE <PartNumber> inside
- * each <Part> element:
- *
- *   <CompleteMultipartUpload>
- *     <Part><ETag>"md5hex"</ETag><PartNumber>1</PartNumber></Part>
- *     ...
- *   </CompleteMultipartUpload>
- *
- * Other clients (e.g. older SDKs, rclone) may use the opposite order.  To
- * handle both, each <Part> block is extracted first and then the two fields
- * are parsed independently from its content.
- *
- * Returns parts sorted by PartNumber (ascending) so the composite ETag is
- * computed in the correct order.
- */
-const parseMultipartParts = (
+/** Thrown when a CompleteMultipartUpload body is not valid per the S3 spec. */
+export class MalformedMultipartError extends Error {}
+
+// processEntities (on by default) decodes the &#34; that aws-sdk-go-v2 (rclone)
+// uses for the ETag quotes — the crux of the fix; boto3 emits literal quotes
+// and both land on `"<hex>"`. removeNSPrefix handles <s3:Part>; parseTagValue
+// off keeps ETags as strings.
+const multipartXmlParser = new XMLParser({
+  ignoreAttributes: true,
+  removeNSPrefix: true,
+  parseTagValue: false,
+  trimValues: true,
+})
+
+// Extract the part list from a CompleteMultipartUpload body. A real parser
+// (not a regex) so namespaces, ordering, and entity encoding work across
+// clients. Each <Part> needs an integer PartNumber (>= 1) and a non-empty
+// ETag, else throws MalformedMultipartError so the caller can return 400
+// MalformedXML. Returns parts sorted by PartNumber.
+export const parseMultipartParts = (
   body: Buffer,
 ): Array<{ PartNumber: number; ETag: string }> => {
-  const xml = body.toString('utf-8')
-  // Extract each <Part>…</Part> block, then parse fields independently so
-  // that element order within the block doesn't matter.
-  const partBlockRegex = /<Part>([\s\S]*?)<\/Part>/g
-  const parts: Array<{ PartNumber: number; ETag: string }> = []
-  let block: RegExpExecArray | null
-  while ((block = partBlockRegex.exec(xml)) !== null) {
-    const content = block[1]
-    const partNumberMatch = content.match(/<PartNumber>(\d+)<\/PartNumber>/)
-    const etagMatch = content.match(/<ETag>([^<]+)<\/ETag>/)
-    if (partNumberMatch && etagMatch) {
-      // AWS SDK v3 XML-encodes the double-quotes around the ETag hex digest
-      // as &quot; (e.g. &quot;d41d…&quot;).  Decode before storing so that
-      // multipartETag can strip the quotes and read the raw hex correctly.
-      const etag = etagMatch[1].trim().replace(/&quot;/g, '"')
-      parts.push({
-        PartNumber: parseInt(partNumberMatch[1], 10),
-        ETag: etag,
-      })
-    }
+  let parsed: unknown
+  try {
+    parsed = multipartXmlParser.parse(body.toString('utf-8'))
+  } catch {
+    throw new MalformedMultipartError('Malformed CompleteMultipartUpload XML')
   }
+
+  const root = (parsed as Record<string, unknown> | undefined)
+    ?.CompleteMultipartUpload as Record<string, unknown> | undefined
+  if (root == null || typeof root !== 'object') {
+    throw new MalformedMultipartError(
+      'Missing CompleteMultipartUpload root element',
+    )
+  }
+
+  // <Part> is a single object for one part and an array for many.
+  const rawPart = root.Part
+  const rawParts =
+    rawPart == null ? [] : Array.isArray(rawPart) ? rawPart : [rawPart]
+  if (rawParts.length === 0) {
+    throw new MalformedMultipartError('CompleteMultipartUpload has no parts')
+  }
+
+  const parts = rawParts.map((part) => {
+    const record = part as Record<string, unknown>
+    const partNumber = Number(record?.PartNumber)
+    const etag = record?.ETag
+    if (!Number.isInteger(partNumber) || partNumber < 1) {
+      throw new MalformedMultipartError('Part is missing a valid PartNumber')
+    }
+    if (typeof etag !== 'string' || etag.trim() === '') {
+      throw new MalformedMultipartError('Part is missing a non-empty ETag')
+    }
+    return { PartNumber: partNumber, ETag: etag.trim() }
+  })
+
   return parts.sort((a, b) => a.PartNumber - b.PartNumber)
 }
 
@@ -297,7 +314,21 @@ export const completeMultipartUploadHandler = async (
 
   // Parse the part list from the XML request body so we can compute the
   // standard S3 composite ETag (MD5 of concatenated per-part MD5s + part count).
-  const parts = Buffer.isBuffer(req.body) ? parseMultipartParts(req.body) : []
+  // A body that can't be parsed into valid parts is a client error, not a
+  // reason to silently store a wrong ETag — reject it with 400 MalformedXML.
+  let parts: Array<{ PartNumber: number; ETag: string }>
+  try {
+    parts = parseMultipartParts(Buffer.isBuffer(req.body) ? req.body : Buffer.alloc(0))
+  } catch (error) {
+    if (error instanceof MalformedMultipartError) {
+      sendXML(res.status(400), 'Error', {
+        Code: 'MalformedXML',
+        Message: error.message,
+      })
+      return
+    }
+    throw error
+  }
 
   const result = await S3UseCases.completeMultipartUpload(user, {
     Bucket: bucket,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10289,6 +10289,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^5.2.1"
     eslint-plugin-require-extensions: "npm:^0.1.3"
     express: "npm:^4.19.2"
+    fast-xml-parser: "npm:5.5.8"
     interface-blockstore: "npm:^5.3.1"
     interface-store: "npm:^6.0.2"
     jest: "npm:^29.7.0"


### PR DESCRIPTION
Fixes #759

## Problem

Multipart uploads driven by aws-sdk-go-v2 clients (e.g. rclone) persisted a **wrong composite ETag**:
`d41d8cd98f00b204e9800998ecf8427e-N` — the MD5 of empty input, followed by the part count. This is a
persisted wrong value, returned on every subsequent `HeadObject`/`GetObject`/`ListObjectsV2`.

Root cause: `parseMultipartParts` used a regex that only un-escaped `&quot;`. Go's XML encoder escapes
the ETag's surrounding quotes as `&#34;` in element text (boto3 emits literal quotes), so the leftover
entities broke the per-part hex decode and the composite collapsed to the empty-input MD5. aws-cli
worked; rclone did not.

## Fix

Replace the regex with `fast-xml-parser` (already resolved transitively via `@aws-sdk/xml-builder`,
promoted to a direct dependency), which decodes entities and handles namespaces, attribute ordering,
and whitespace uniformly across clients. Validate that each `<Part>` has an integer `PartNumber` (>= 1)
and a non-empty `<ETag>`; reject anything else with **400 `MalformedXML`** rather than silently storing
a wrong ETag.

## Tests

Fixtures for both the aws-cli/boto3 body (literal quotes) and the aws-sdk-go-v2 body (`&#34;`-escaped
quotes, reversed element order, namespaced) assert they parse to identical parts, that `&#34;` is gone,
and — end to end — that feeding the parsed go-sdk ETags through `multipartETag` yields the correct AWS
composite and not the empty-MD5 value. Plus namespace-prefixed parsing, part sorting, and malformed-body
cases (missing root, empty body, no parts, missing PartNumber, empty ETag, non-integer PartNumber).

Note: the SDK fixtures are reconstructed from each library's serialization, not captured off the wire.
