### PR TITLE
feat(s3): move S3-compatible API to dedicated subdomain

### DIFF
--- a/apps/backend/src/app/controllers/s3/s3.ts
+++ b/apps/backend/src/app/controllers/s3/s3.ts
@@ -61,6 +61,37 @@ const getUploadOptions = (req: Request) => {
   return UploadOptions
 }
 
+/**
+ * Build the absolute, host-aware object URL for the CompleteMultipartUpload
+ * `Location` response field — per the S3 spec, the URL of the newly created
+ * object as seen from the endpoint the client used.
+ *
+ * The backend mounts the S3 API at `/s3`, but the public-facing endpoint
+ * differs per vhost (the dedicated `s3.` subdomain serves it at the root; the
+ * legacy host serves it under `/s3`) and nginx rewrites both onto `/s3` before
+ * the request reaches here. So the URL is reconstructed from the forwarding
+ * headers nginx sets rather than from the request's own (rewritten) path:
+ *   - X-Forwarded-Proto — scheme at the edge (nginx terminates TLS and proxies
+ *     over http, so req.protocol alone would always read 'http').
+ *   - Host — the public hostname (forwarded via `proxy_set_header Host`).
+ *   - X-Forwarded-Prefix — the public path prefix the S3 API is exposed under:
+ *     '/s3' on the legacy host, root on the subdomain. nginx drops
+ *     empty-valued headers, so the subdomain sends '/', normalized here to ''.
+ * With no forwarding headers (requests straight to Express, e.g. tests), this
+ * falls back to req.protocol, the Host header, and the '/s3' mount.
+ */
+const buildObjectLocation = (
+  req: Request,
+  bucket: string,
+  key: string,
+): string => {
+  const proto = (req.headers['x-forwarded-proto'] as string) || req.protocol
+  const host = req.headers.host ?? ''
+  const rawPrefix = (req.headers['x-forwarded-prefix'] as string) ?? '/s3'
+  const prefix = rawPrefix === '/' ? '' : rawPrefix.replace(/\/+$/, '')
+  return `${proto}://${host}${prefix}/${bucket}/${key}`
+}
+
 /** Thrown when a CompleteMultipartUpload body is not valid per the S3 spec. */
 export class MalformedMultipartError extends Error {}
 
@@ -416,12 +447,16 @@ export const completeMultipartUploadHandler = async (
   // (which calls res.send()). res.send() triggers Express's auto-ETag generation
   // which would overwrite our composite MD5 ETag with a body-derived hash.
   const { Cid: completeCid, ETag: completeETag, ...completeXmlBody } = result.value
+  // Location is built here (not in the use case) because it depends on the
+  // public endpoint the request arrived on — see buildObjectLocation.
+  const Location = buildObjectLocation(req, bucket, key)
   res.set('ETag', completeETag)
   res.set('x-amz-meta-cid', completeCid)
   res.setHeader('Content-Type', 'application/xml')
   res.end(
     js2xmlparser.parse('CompleteMultipartUploadResult', {
       ETag: completeETag,
+      Location,
       ...completeXmlBody,
     }),
   )

--- a/apps/backend/src/core/s3/index.ts
+++ b/apps/backend/src/core/s3/index.ts
@@ -30,8 +30,17 @@ import {
 /** PutObject result extended with the Autonomys CID for the x-amz-meta-cid header. */
 type PutObjectResult = PutObjectCommandResult & { Cid: string }
 
-/** CompleteMultipartUpload result extended with the Autonomys CID. */
-type CompleteMultipartUploadResult = CompleteMultipartUploadCommandResult & {
+/** CompleteMultipartUpload result extended with the Autonomys CID.
+ *
+ *  `Location` is intentionally omitted here. Per the S3 spec it is the absolute
+ *  URL of the new object, which depends on the public endpoint the client used
+ *  (the dedicated S3 subdomain vs. the legacy /s3 path). That is request/host
+ *  state the HTTP layer owns, so it is built in `completeMultipartUploadHandler`
+ *  and this use case stays host-agnostic. */
+type CompleteMultipartUploadResult = Omit<
+  CompleteMultipartUploadCommandResult,
+  'Location'
+> & {
   Cid: string
 }
 
@@ -179,7 +188,6 @@ const completeMultipartUpload = async (
   )
 
   return ok({
-    Location: objectDownloadPath(params.Bucket, params.Key),
     Bucket: params.Bucket,
     Key: params.Key,
     ETag: etag,
@@ -234,10 +242,6 @@ const putObject = async (
 
 const listBuckets = async (): Promise<S3BucketInfo[]> => {
   return s3ObjectMappingsRepository.listBuckets()
-}
-
-const objectDownloadPath = (bucket: string, key: string) => {
-  return `/s3/${bucket}/${key}`
 }
 
 const objectExists = async (bucket: string, key: string): Promise<boolean> => {

--- a/nginx/backend.mainnet.public.conf
+++ b/nginx/backend.mainnet.public.conf
@@ -71,6 +71,12 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_http_version 1.1;
 
+        # Let the backend build absolute object URLs (CompleteMultipartUpload
+        # Location) for the public endpoint, not its internal http://…/s3 mount.
+        # On this legacy host the S3 API is exposed under the /s3 prefix.
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Prefix /s3;
+
         proxy_read_timeout 600;
         proxy_send_timeout 600;
 
@@ -200,6 +206,14 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_http_version 1.1;
+
+        # Let the backend build absolute object URLs (CompleteMultipartUpload
+        # Location) for the public endpoint, not its internal http://…/s3 mount.
+        # This subdomain serves S3 at the root, so the public prefix is empty;
+        # nginx drops empty-valued headers, so send "/" — the backend normalizes
+        # it to "".
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Prefix /;
 
         proxy_read_timeout 600;
         proxy_send_timeout 600;

--- a/nginx/backend.mainnet.public.conf
+++ b/nginx/backend.mainnet.public.conf
@@ -171,6 +171,83 @@ server {
 
 }
 
+# Dedicated S3-compatible API subdomain.
+#
+# This serves the exact same backend as the legacy `public.auto-drive.autonomys.xyz/s3`
+# path (which is kept alive indefinitely for existing clients — see the `location /s3`
+# block above). The subdomain serves S3 at the root: requests are rewritten to the
+# backend's `/s3` mount point, so no application code changes are required.
+#
+# Note: this is intentionally NOT an HTTP redirect from the old path. S3 clients sign
+# requests with AWS SigV4 over the Host header and path, so a redirect to a different
+# host would invalidate the signature and break SDK uploads. Both endpoints are served
+# directly instead.
+server {
+    root /var/www/html;
+    index index.html index.htm index.nginx-debian.html;
+
+    server_name s3.auto-drive.autonomys.xyz;
+
+    location / {
+        limit_req zone=mylimit burst=200 nodelay;
+        limit_conn addr 5;
+        limit_req_log_level warn;
+
+        proxy_request_buffering off;
+        proxy_buffering off;
+        proxy_pass http://127.0.0.1:3000;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_http_version 1.1;
+
+        proxy_read_timeout 600;
+        proxy_send_timeout 600;
+
+        add_header 'Access-Control-Allow-Origin' '*' always;
+        add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, HEAD, OPTIONS' always;
+        add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,Content-MD5,x-amz-content-sha256,x-amz-date,x-amz-security-token,x-amz-user-agent,x-amz-decoded-content-length,x-amz-checksum-crc64nvme,x-amz-trailer' always;
+        add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range,ETag,x-amz-meta-cid,x-amz-request-id,x-amz-id-2' always;
+        add_header 'Access-Control-Max-Age' '3600' always;
+
+        if ($request_method = 'OPTIONS') {
+            add_header 'Access-Control-Allow-Origin' '*' always;
+            add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, HEAD, OPTIONS' always;
+            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,Content-MD5,x-amz-content-sha256,x-amz-date,x-amz-security-token,x-amz-user-agent,x-amz-decoded-content-length,x-amz-checksum-crc64nvme,x-amz-trailer' always;
+            add_header 'Access-Control-Max-Age' 1728000 always;
+            add_header 'Content-Type' 'text/plain charset=UTF-8' always;
+            add_header 'Content-Length' 0 always;
+            return 204;
+        }
+
+        # Serve S3 at the root of this subdomain by mapping onto the backend's /s3 mount.
+        rewrite ^/(.*)$ /s3/$1 break;
+    }
+
+    # TLS: the cert must cover s3.auto-drive.autonomys.xyz before this block can serve
+    # HTTPS. Either expand the existing cert to include the new name
+    # (certbot --expand -d public.auto-drive.autonomys.xyz -d s3.auto-drive.autonomys.xyz)
+    # or issue a dedicated cert and point the paths below at it. The paths below assume
+    # the expanded shared cert.
+    listen 443 ssl http2; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/public.auto-drive.autonomys.xyz/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/public.auto-drive.autonomys.xyz/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+}
+
+# Redirect plain HTTP for the S3 subdomain to HTTPS (mirrors the Certbot-managed
+# redirect block for public.auto-drive.autonomys.xyz at the bottom of this file).
+server {
+    if ($host = s3.auto-drive.autonomys.xyz) {
+        return 301 https://$host$request_uri;
+    }
+
+    server_name s3.auto-drive.autonomys.xyz;
+    listen 80;
+    return 404;
+}
+
 server {
     root /var/www/html;
     index index.html index.htm index.nginx-debian.html;

--- a/scripts/live-integration/test-s3-api.sh
+++ b/scripts/live-integration/test-s3-api.sh
@@ -52,7 +52,7 @@
 #   AUTO_DRIVE_API_KEY=<api_key> ./scripts/live-integration/test-s3-api.sh
 #
 # Optional overrides:
-#   AUTO_DRIVE_ENDPOINT   default: https://public.auto-drive.autonomys.xyz/s3
+#   AUTO_DRIVE_ENDPOINT   default: https://s3.auto-drive.autonomys.xyz
 #   TEST_BUCKET           default: s3-smoke-test
 
 set -uo pipefail
@@ -90,7 +90,7 @@ sha256_of() {
 
 # ── Configuration ─────────────────────────────────────────────────────────────
 
-ENDPOINT="${AUTO_DRIVE_ENDPOINT:-https://public.auto-drive.autonomys.xyz/s3}"
+ENDPOINT="${AUTO_DRIVE_ENDPOINT:-https://s3.auto-drive.autonomys.xyz}"
 API_KEY="${AUTO_DRIVE_API_KEY:-}"
 TEST_BUCKET="${TEST_BUCKET:-s3-smoke-test}"
 

--- a/scripts/live-integration/test-s3-rclone.sh
+++ b/scripts/live-integration/test-s3-rclone.sh
@@ -54,7 +54,7 @@
 #   AUTO_DRIVE_API_KEY=<api_key> ./scripts/live-integration/test-s3-rclone.sh
 #
 # Optional overrides:
-#   AUTO_DRIVE_ENDPOINT   default: https://public.auto-drive.autonomys.xyz/s3
+#   AUTO_DRIVE_ENDPOINT   default: https://s3.auto-drive.autonomys.xyz
 #   TEST_BUCKET           default: s3-smoke-test
 #   RCLONE_REMOTE         default: autodrive
 
@@ -88,7 +88,7 @@ md5_of() {
 
 # ── Configuration ─────────────────────────────────────────────────────────────
 
-ENDPOINT="${AUTO_DRIVE_ENDPOINT:-https://public.auto-drive.autonomys.xyz/s3}"
+ENDPOINT="${AUTO_DRIVE_ENDPOINT:-https://s3.auto-drive.autonomys.xyz}"
 API_KEY="${AUTO_DRIVE_API_KEY:-}"
 TEST_BUCKET="${TEST_BUCKET:-s3-smoke-test}"
 RCLONE_REMOTE="${RCLONE_REMOTE:-autodrive}"


### PR DESCRIPTION
## What

Moves the S3-compatible API onto a dedicated subdomain, `https://s3.auto-drive.autonomys.xyz`, served at the root — replacing the clumsy `https://public.auto-drive.autonomys.xyz/s3` path.

Part of #762.

## How

**1. nginx — dedicated S3 subdomain (`feat(s3): serve S3 API on dedicated subdomain`)**
- New `server` block for `s3.auto-drive.autonomys.xyz` serving S3 at the root. A `rewrite ^/(.*)$ /s3/$1 break;` maps requests onto the backend's existing `/s3` mount, so **no backend routing change is needed**.
- HTTP→HTTPS redirect block for the subdomain.
- The legacy `location /s3` block is **left intact and served in parallel** — this is dual-serve, **not** a redirect. AWS SigV4 signs the Host header and path, so redirecting to a different host would invalidate SDK signatures. Existing clients keep working untouched; we simply stop advertising the old path.
- Live-integration smoke-test scripts now default to the subdomain.

**2. Host-aware `Location` (`feat(s3): return absolute, host-aware Location from CompleteMultipartUpload`)**
- `CompleteMultipartUpload` previously returned a relative `/s3/<bucket>/<key>` `Location`, which is non-compliant (S3 spec wants an absolute URL) and would resolve to a non-existent `/s3/s3/...` on the root-served subdomain.
- Now built in the HTTP layer from proxy forwarding headers (`X-Forwarded-Proto`, `Host`, `X-Forwarded-Prefix`) so it reflects the public endpoint the client used rather than the backend's internal `/s3` mount. The S3 use case drops `Location` and stays host-agnostic. nginx sets the forwarding headers on both S3 vhosts (`/s3` on the legacy host, root on the subdomain).

## Notes

- **The `/s3` CORS + proxy config is intentionally duplicated** between the legacy and subdomain blocks. nginx's only DRY mechanism is `include` (separate files), which would add deployment coupling and hurt at-a-glance readability of each vhost; the duplication is bounded and the blocks are self-documenting.
- Scope is **mainnet/production only** — staging gets its own S3 endpoint in the separate staging refactor.

## Verification

- `yarn backend build` — clean (exit 0)
- S3 unit tests — 53/53 pass
- S3 SDK integration test (real multipart upload via AWS SDK) — 38/38 pass
- `yarn backend lint` — clean

## Depends on (infra, tracked in #762)

This cannot serve traffic until the infra side lands:
1. DNS record `s3.auto-drive.autonomys.xyz` → same host as `public.auto-drive.autonomys.xyz`
2. TLS cert expanded to cover the new name (`certbot --expand -d public.auto-drive.autonomys.xyz -d s3.auto-drive.autonomys.xyz`)

Post-deploy verification (round-trip + S3-key encoding-fidelity check) and the docs updates (rclone #698, developer_docs) are tracked in #762.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
