### PR TITLE
feat(s3): expose Object Lock contract (GetObjectLockConfiguration / Retention / LegalHold)

### DIFF
--- a/apps/backend/__tests__/unit/controllers/s3-object-lock.spec.ts
+++ b/apps/backend/__tests__/unit/controllers/s3-object-lock.spec.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from '@jest/globals'
+import { Request } from 'express'
+import js2xmlparser from 'js2xmlparser'
+import { getS3Method } from '../../../src/app/controllers/s3/http.js'
+import {
+  objectLegalHoldBody,
+  objectLockConfigurationBody,
+  objectRetentionBody,
+} from '../../../src/app/controllers/s3/s3.js'
+
+const req = (
+  method: string,
+  query: Record<string, unknown>,
+  headers: Record<string, unknown> = {},
+): Request => ({ method, query, headers }) as unknown as Request
+
+describe('getS3Method — Object Lock dispatch', () => {
+  it('routes GET ?object-lock / ?retention / ?legal-hold to the read handlers', () => {
+    expect(getS3Method(req('GET', { 'object-lock': '' }))).toBe(
+      'GetObjectLockConfiguration',
+    )
+    expect(getS3Method(req('GET', { retention: '' }))).toBe(
+      'GetObjectRetention',
+    )
+    expect(getS3Method(req('GET', { 'legal-hold': '' }))).toBe(
+      'GetObjectLegalHold',
+    )
+  })
+
+  it('routes PUT ?object-lock / ?retention / ?legal-hold to the 501 (Put*) operations', () => {
+    expect(getS3Method(req('PUT', { 'object-lock': '' }))).toBe(
+      'PutObjectLockConfiguration',
+    )
+    expect(getS3Method(req('PUT', { retention: '' }))).toBe(
+      'PutObjectRetention',
+    )
+    expect(getS3Method(req('PUT', { 'legal-hold': '' }))).toBe(
+      'PutObjectLegalHold',
+    )
+  })
+
+  it('does not disturb existing GET/PUT routing', () => {
+    expect(getS3Method(req('GET', { 'list-type': '2' }))).toBe('ListObjectsV2')
+    expect(getS3Method(req('GET', {}))).toBe('GetObject')
+    expect(getS3Method(req('GET', { uploadId: '1' }))).toBe('ListParts')
+    expect(getS3Method(req('PUT', {}))).toBe('PutObject')
+    expect(
+      getS3Method(req('PUT', {}, { 'x-amz-copy-source': '/b/k' })),
+    ).toBe('CopyObject')
+  })
+})
+
+describe('Object Lock response bodies', () => {
+  it('GetObjectLockConfiguration advertises Enabled + COMPLIANCE default retention', () => {
+    expect(objectLockConfigurationBody()).toEqual({
+      ObjectLockEnabled: 'Enabled',
+      Rule: { DefaultRetention: { Mode: 'COMPLIANCE', Years: 100 } },
+    })
+    const xml = js2xmlparser.parse(
+      'ObjectLockConfiguration',
+      objectLockConfigurationBody(),
+    )
+    expect(xml).toContain('<ObjectLockEnabled>Enabled</ObjectLockEnabled>')
+    expect(xml).toContain('<Mode>COMPLIANCE</Mode>')
+    expect(xml).toContain('<Years>100</Years>')
+  })
+
+  it('GetObjectRetention is COMPLIANCE with the max-date "forever" RetainUntilDate', () => {
+    const body = objectRetentionBody()
+    expect(body.Mode).toBe('COMPLIANCE')
+    // Year 9999 is the max date common clients (e.g. Python datetime.max) parse.
+    expect(body.RetainUntilDate).toBe('9999-12-31T23:59:59Z')
+    const xml = js2xmlparser.parse('Retention', body)
+    expect(xml).toContain('<Mode>COMPLIANCE</Mode>')
+    expect(xml).toContain(`<RetainUntilDate>${body.RetainUntilDate}`)
+  })
+
+  it('GetObjectLegalHold is ON', () => {
+    expect(objectLegalHoldBody()).toEqual({ Status: 'ON' })
+    expect(js2xmlparser.parse('LegalHold', objectLegalHoldBody())).toContain(
+      '<Status>ON</Status>',
+    )
+  })
+})

--- a/apps/backend/__tests__/unit/core/s3.spec.ts
+++ b/apps/backend/__tests__/unit/core/s3.spec.ts
@@ -493,4 +493,29 @@ describe('S3UseCases', () => {
       expect(batch.length).toBe(dbLimit)
     })
   })
+
+  describe('objectExists', () => {
+    it('returns false when no mapping exists', async () => {
+      jest
+        .spyOn(s3ObjectMappingsRepository, 'findByKey')
+        .mockResolvedValue(null)
+
+      expect(await S3UseCases.objectExists('my-bucket', 'missing.txt')).toBe(
+        false,
+      )
+    })
+
+    it('returns true when a mapping exists', async () => {
+      jest
+        .spyOn(s3ObjectMappingsRepository, 'findByKey')
+        .mockResolvedValue({
+          bucket: 'my-bucket',
+          key: 'file.txt',
+          cid: 'cid123',
+          md5: null,
+        } as any)
+
+      expect(await S3UseCases.objectExists('my-bucket', 'file.txt')).toBe(true)
+    })
+  })
 })

--- a/apps/backend/src/app/controllers/s3/http.ts
+++ b/apps/backend/src/app/controllers/s3/http.ts
@@ -6,6 +6,9 @@ import {
   createMultipartUploadHandler,
   deleteObjectHandler,
   getObjectHandler,
+  getObjectLegalHoldHandler,
+  getObjectLockConfigurationHandler,
+  getObjectRetentionHandler,
   headObjectHandler,
   listBucketsHandler,
   listObjectsV2Handler,
@@ -32,17 +35,25 @@ const S3HandlerConfig: S3HandlerConfig = {
   DeleteObject: deleteObjectHandler,
   ListBuckets: listBucketsHandler,
   ListObjectsV2: listObjectsV2Handler,
+  // Object Lock — read-only declarative contract (Auto Drive is immutable).
+  GetObjectLockConfiguration: getObjectLockConfigurationHandler,
+  GetObjectRetention: getObjectRetentionHandler,
+  GetObjectLegalHold: getObjectLegalHoldHandler,
   // Recognised but unimplemented — mapped to 501, never to a write handler.
   CopyObject: notImplementedHandler,
   ListParts: notImplementedHandler,
   ListMultipartUploads: notImplementedHandler,
   AbortMultipartUpload: notImplementedHandler,
   PostObject: notImplementedHandler,
+  // Object Lock is intrinsic and cannot be configured by clients — 501.
+  PutObjectLockConfiguration: notImplementedHandler,
+  PutObjectRetention: notImplementedHandler,
+  PutObjectLegalHold: notImplementedHandler,
 }
 
 // Match on method first: the same query param (?uploadId, ?uploads) selects a
 // different operation per verb.
-const getS3Method = (req: Request): string => {
+export const getS3Method = (req: Request): string => {
   const q = req.query
   const isCopy = req.headers['x-amz-copy-source'] != null
 
@@ -50,12 +61,18 @@ const getS3Method = (req: Request): string => {
     case 'GET':
       if ('uploadId' in q) return 'ListParts'
       if ('uploads' in q) return 'ListMultipartUploads'
+      if ('object-lock' in q) return 'GetObjectLockConfiguration'
+      if ('retention' in q) return 'GetObjectRetention'
+      if ('legal-hold' in q) return 'GetObjectLegalHold'
       if (q['list-type'] === '2') return 'ListObjectsV2'
       return 'GetObject'
     case 'HEAD':
       return 'HeadObject'
     case 'PUT':
       if ('uploadId' in q && 'partNumber' in q) return 'UploadPart'
+      if ('object-lock' in q) return 'PutObjectLockConfiguration'
+      if ('retention' in q) return 'PutObjectRetention'
+      if ('legal-hold' in q) return 'PutObjectLegalHold'
       if (isCopy) return 'CopyObject'
       return 'PutObject'
     case 'POST':

--- a/apps/backend/src/app/controllers/s3/s3.ts
+++ b/apps/backend/src/app/controllers/s3/s3.ts
@@ -213,6 +213,76 @@ export const headObjectHandler = async (req: Request, res: Response) => {
   res.status(200).end()
 }
 
+// ── Object Lock ───────────────────────────────────────────────────────────
+// Auto Drive storage is immutable (WORM) by construction, so we expose a fixed
+// COMPLIANCE-mode lock contract with a far-future retention. The contract is
+// intrinsic and cannot be configured by clients, so the PutObjectLock* / Put*
+// Retention / Put*LegalHold counterparts stay 501 (wired in http.ts).
+
+// "Forever" sentinel for RetainUntilDate. S3 has no infinity value, so use the
+// max representable date: year 9999 is the ceiling for SQL DATETIME and Python
+// datetime.max, so anything larger would overflow common clients (e.g. boto3).
+const OBJECT_LOCK_RETAIN_UNTIL = '9999-12-31T23:59:59Z'
+
+export const objectLockConfigurationBody = () => ({
+  ObjectLockEnabled: 'Enabled',
+  Rule: { DefaultRetention: { Mode: 'COMPLIANCE', Years: 100 } },
+})
+
+export const objectRetentionBody = () => ({
+  Mode: 'COMPLIANCE',
+  RetainUntilDate: OBJECT_LOCK_RETAIN_UNTIL,
+})
+
+export const objectLegalHoldBody = () => ({ Status: 'ON' })
+
+export const getObjectLockConfigurationHandler = async (
+  req: Request,
+  res: Response,
+) => {
+  const user = await handleS3Auth(req, res)
+  if (!user) return
+  sendXML(res, 'ObjectLockConfiguration', objectLockConfigurationBody())
+}
+
+// The retention and legal-hold contracts are object-level, so reject a key
+// that doesn't exist with NoSuchKey rather than asserting a lock over nothing.
+const sendNoSuchKey = (res: Response, key: string) => {
+  sendXML(res.status(404), 'Error', {
+    Code: 'NoSuchKey',
+    Message: 'The specified key does not exist.',
+    Key: key,
+  })
+}
+
+export const getObjectRetentionHandler = async (
+  req: Request,
+  res: Response,
+) => {
+  const user = await handleS3Auth(req, res)
+  if (!user) return
+  const { bucket, key } = parseBucketAndKey(req.params.key)
+  if (!(await S3UseCases.objectExists(bucket, key))) {
+    sendNoSuchKey(res, key)
+    return
+  }
+  sendXML(res, 'Retention', objectRetentionBody())
+}
+
+export const getObjectLegalHoldHandler = async (
+  req: Request,
+  res: Response,
+) => {
+  const user = await handleS3Auth(req, res)
+  if (!user) return
+  const { bucket, key } = parseBucketAndKey(req.params.key)
+  if (!(await S3UseCases.objectExists(bucket, key))) {
+    sendNoSuchKey(res, key)
+    return
+  }
+  sendXML(res, 'LegalHold', objectLegalHoldBody())
+}
+
 export const createMultipartUploadHandler = async (
   req: Request,
   res: Response,

--- a/apps/backend/src/core/s3/index.ts
+++ b/apps/backend/src/core/s3/index.ts
@@ -240,6 +240,11 @@ const objectDownloadPath = (bucket: string, key: string) => {
   return `/s3/${bucket}/${key}`
 }
 
+const objectExists = async (bucket: string, key: string): Promise<boolean> => {
+  const mapping = await s3ObjectMappingsRepository.findByKey(bucket, key)
+  return mapping !== null
+}
+
 export const S3UseCases = {
   getObject,
   createMultipartUpload,
@@ -248,4 +253,5 @@ export const S3UseCases = {
   putObject,
   listBuckets,
   listObjects,
+  objectExists,
 }


### PR DESCRIPTION
Fixes #757

## Summary

Auto Drive storage is immutable (WORM) by construction. This exposes that guarantee as a **declarative
S3 Object Lock contract** so compliance-aware tooling (Veeam, Commvault, Rubrik) and WORM-detection
checks recognise Auto Drive as an immutable target. Pure declarative work — no enforcement code; the
storage layer already enforces immutability.

## Endpoints

Read (implemented):
- `GET /<bucket>?object-lock` → `ObjectLockConfiguration`: `Enabled`, `COMPLIANCE`, 100-year default retention.
- `GET /<bucket>/<key>?retention` → `Retention`: `COMPLIANCE`, `RetainUntilDate = 9999-12-31T23:59:59Z`.
- `GET /<bucket>/<key>?legal-hold` → `LegalHold`: `Status: ON`.

Write (kept 501): `PutObjectLockConfiguration`, `PutObjectRetention`, `PutObjectLegalHold` — the
contract is intrinsic and cannot be configured by clients.

## Notes

- **"Forever" date:** S3 has no infinity sentinel, so `RetainUntilDate` uses the max representable date,
  `9999-12-31T23:59:59Z`. Year 9999 is the ceiling for SQL `DATETIME`, .NET `DateTime.MaxValue`, and
  Python `datetime.max`, so a larger value would overflow common clients (e.g. boto3) on parse.
- **Missing objects:** `GetObjectRetention` / `GetObjectLegalHold` return S3 XML `NoSuchKey` (404) for a
  key that doesn't exist, rather than asserting a lock over nothing. Implemented via a new
  `S3UseCases.objectExists` use case (mapping lookup, no download), keeping the controller → core →
  repository layering intact.
- **Bucket-level:** `GetObjectLockConfiguration` returns the contract unconditionally. Auto Drive
  buckets are implicit (no lifecycle), so there's no clean "bucket exists" gate; left as-is.
- **Not an rclone-test concern:** rclone's S3 integration tests are imperative and not Object Lock
  aware, so this does not affect those outcomes. It's a compliance-detection enhancement.

## Tests

- `getS3Method` dispatch for all six new operations plus regression checks for existing routing.
- Response-body builders, asserted as objects and as serialized XML.
- `S3UseCases.objectExists` (mapping present / absent).
