### PR TITLE
feat: add AutoDriveUSDCReceiver contract for USDC intent payments

### DIFF
--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -144,9 +144,10 @@
 ### Errors
 
 - `InvalidAmount(uint256 amount)` — zero (or zero received) amount.
-- `InvalidToken(address token)` — zero token address at construction.
+- `InvalidToken(address token)` — zero or non-contract token address at construction.
 - `InvalidRecipient(address recipient)` — zero sweep recipient.
 - `InsufficientBalance(uint256 balance, uint256 amount)` — sweep exceeds balance.
+- `RenounceOwnershipDisabled()` — `renounceOwnership` is disabled (see below).
 
 ### Functions
 
@@ -162,9 +163,14 @@
 - `pause() external onlyOwner` / `unpause() external onlyOwner`
   - Halts/resumes `payIntentWithToken`.
 
+- `renounceOwnership() public view override onlyOwner`
+  - Always reverts with `RenounceOwnershipDisabled`. Renouncing ownership would permanently strand any tokens held by the contract, since sweeps are owner-gated.
+
 ### Security Considerations
 
 - `SafeERC20` for all token transfers (does not assume a bool return); `ReentrancyGuard` on the pay and sweep paths.
+- The constructor rejects a token address with no deployed code, catching typos and wrong-chain addresses at deploy time.
+- `renounceOwnership` is disabled so the contract can never end up ownerless with stranded funds.
 - No `minimumBalance`: that exists only for Auto-EVM's existential deposit and is meaningless for an ERC20 balance on Ethereum.
 - Sweeps are `onlyOwner` (unlike the native receiver's permissionless sweep) because the destination is arbitrary — use a multisig owner in production.
 - Permit2 / EIP-2612 (collapsing approve + pay into one signature) is intentionally deferred to a later iteration.
@@ -178,12 +184,12 @@
 
 ### Deploy
 
-Uses `script/DeployAutoDriveUSDCReceiver.s.sol`. Required env: `PRIVATE_KEY`, `USDC_TOKEN_ADDRESS`; optional `OWNER` (defaults to deployer — use a multisig in production).
+Uses `script/DeployAutoDriveUSDCReceiver.s.sol`. Required env: `PRIVATE_KEY`; optional `USDC_TOKEN_ADDRESS` (defaults to [Circle's canonical USDC](https://developers.circle.com/stablecoins/usdc-contract-addresses) on mainnet/Sepolia; required on other chains) and `OWNER` (defaults to deployer — use a multisig in production). The script verifies the token address has code on the target chain before deploying.
 
 ```bash
-# Ethereum mainnet USDC: 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48
-# Sepolia: point at your test USDC token
-PRIVATE_KEY=0x... USDC_TOKEN_ADDRESS=0x... OWNER=0x... \
+# Defaults: Ethereum mainnet 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48
+#           Sepolia          0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238
+PRIVATE_KEY=0x... OWNER=0x... \
   forge script script/DeployAutoDriveUSDCReceiver.s.sol \
   --rpc-url "$ETH_RPC_URL" --broadcast --verify
 ```

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -119,3 +119,71 @@
 
 - The `minimumBalance` default (1e12 wei) matches Auto-EVM's existential deposit requirement.
 - Consider using a multisig as the owner for production deployments.
+
+---
+
+## AutoDriveUSDCReceiver
+
+**Purpose**: ERC20 (USDC) counterpart of `AutoDriveCreditsReceiver`, for paying credit-purchase intents with a token on Ethereum. The backend watches `IntentTokenPaymentReceived` and grants credits at the intent's locked USD price (deferred-conversion / "Option C"). Owner can pause payments, sweep collected tokens to any recipient, and transfer ownership via two steps.
+
+### Inheritance
+
+- `Ownable2Step`
+- `ReentrancyGuard`
+- `Pausable`
+
+### State
+
+- `IERC20 public immutable token` — the accepted token (USDC), fixed at deploy. Redeploy for a different token/chain.
+
+### Events
+
+- `IntentTokenPaymentReceived(bytes32 indexed intentId, address token, uint256 amount, address indexed payer)` — emitted on each payment. `amount` is the **actual balance delta received**; `payer` is carried in the event (not read from the tx sender) because ERC20 payments can be relayed.
+- `Swept(address indexed caller, address indexed to, uint256 amount)` — emitted when the owner sweeps tokens.
+
+### Errors
+
+- `InvalidAmount(uint256 amount)` — zero (or zero received) amount.
+- `InvalidToken(address token)` — zero token address at construction.
+- `InvalidRecipient(address recipient)` — zero sweep recipient.
+- `InsufficientBalance(uint256 balance, uint256 amount)` — sweep exceeds balance.
+
+### Functions
+
+- `payIntentWithToken(bytes32 intentId, uint256 amount) external nonReentrant whenNotPaused`
+  - Pulls `amount` of `token` from the caller (who must have approved first) and emits `IntentTokenPaymentReceived` with the **actual received delta**, so a fee-on-transfer token can never cause over-crediting.
+
+- `sweep(address to, uint256 amount) external onlyOwner nonReentrant`
+  - Transfers `amount` of `token` to `to`. `onlyOwner` because the destination is caller-specified (`to` may later be a swapper contract). **Callable while paused** so the owner can always move funds to safety.
+
+- `sweepAll(address to) external onlyOwner nonReentrant`
+  - Transfers the entire `token` balance to `to`.
+
+- `pause() external onlyOwner` / `unpause() external onlyOwner`
+  - Halts/resumes `payIntentWithToken`.
+
+### Security Considerations
+
+- `SafeERC20` for all token transfers (does not assume a bool return); `ReentrancyGuard` on the pay and sweep paths.
+- No `minimumBalance`: that exists only for Auto-EVM's existential deposit and is meaningless for an ERC20 balance on Ethereum.
+- Sweeps are `onlyOwner` (unlike the native receiver's permissionless sweep) because the destination is arbitrary — use a multisig owner in production.
+- Permit2 / EIP-2612 (collapsing approve + pay into one signature) is intentionally deferred to a later iteration.
+
+### Typical Flow
+
+1. Deploy with `(initialOwner, token)`.
+2. User calls `token.approve(receiver, amount)` then `payIntentWithToken(intentId, amount)`.
+3. Backend confirms `IntentTokenPaymentReceived` and grants credits.
+4. Owner periodically calls `sweep(to, amount)` / `sweepAll(to)` to move collected USDC to the treasury/swapper.
+
+### Deploy
+
+Uses `script/DeployAutoDriveUSDCReceiver.s.sol`. Required env: `PRIVATE_KEY`, `USDC_TOKEN_ADDRESS`; optional `OWNER` (defaults to deployer — use a multisig in production).
+
+```bash
+# Ethereum mainnet USDC: 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48
+# Sepolia: point at your test USDC token
+PRIVATE_KEY=0x... USDC_TOKEN_ADDRESS=0x... OWNER=0x... \
+  forge script script/DeployAutoDriveUSDCReceiver.s.sol \
+  --rpc-url "$ETH_RPC_URL" --broadcast --verify
+```

--- a/packages/contracts/script/DeployAutoDriveUSDCReceiver.s.sol
+++ b/packages/contracts/script/DeployAutoDriveUSDCReceiver.s.sol
@@ -10,26 +10,45 @@ import {AutoDriveUSDCReceiver} from "../src/AutoDriveUSDCReceiver.sol";
  *
  * Required env vars:
  *   PRIVATE_KEY        - deployer key (hex, 0x-prefixed)
- *   USDC_TOKEN_ADDRESS - ERC20 (USDC) address on the target chain
  * Optional:
+ *   USDC_TOKEN_ADDRESS - ERC20 (USDC) address on the target chain. Defaults to
+ *                        Circle's canonical USDC on mainnet/Sepolia (see
+ *                        https://developers.circle.com/stablecoins/usdc-contract-addresses);
+ *                        required on any other chain.
  *   OWNER              - initial owner; defaults to the deployer address.
  *                        Use a multisig for production.
  *
  * Known USDC addresses:
  *   Ethereum mainnet: 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48
- *   Sepolia:          deploy/point at your test USDC token
+ *   Sepolia:          0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238
  *
  * Usage:
  *   forge script script/DeployAutoDriveUSDCReceiver.s.sol \
  *     --rpc-url "$ETH_RPC_URL" --broadcast --verify
  */
 contract DeployAutoDriveUSDCReceiver is Script {
+    /// @dev Circle's canonical USDC deployments.
+    address internal constant USDC_MAINNET =
+        0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+    address internal constant USDC_SEPOLIA =
+        0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238;
+
     function run() external returns (AutoDriveUSDCReceiver receiver) {
         uint256 deployerKey = vm.envUint("PRIVATE_KEY");
-        address tokenAddress = vm.envAddress("USDC_TOKEN_ADDRESS");
+        address tokenAddress = vm.envOr(
+            "USDC_TOKEN_ADDRESS",
+            _defaultUsdc(block.chainid)
+        );
         address initialOwner = vm.envOr("OWNER", vm.addr(deployerKey));
 
-        require(tokenAddress != address(0), "USDC_TOKEN_ADDRESS is zero");
+        require(
+            tokenAddress != address(0),
+            "USDC_TOKEN_ADDRESS required: no known USDC default for this chain"
+        );
+        require(
+            tokenAddress.code.length > 0,
+            "USDC_TOKEN_ADDRESS is not a contract on the target chain"
+        );
 
         vm.startBroadcast(deployerKey);
         receiver = new AutoDriveUSDCReceiver(
@@ -41,5 +60,11 @@ contract DeployAutoDriveUSDCReceiver is Script {
         console.log("AutoDriveUSDCReceiver deployed at:", address(receiver));
         console.log("Initial owner:", initialOwner);
         console.log("Token:", tokenAddress);
+    }
+
+    function _defaultUsdc(uint256 chainId) internal pure returns (address) {
+        if (chainId == 1) return USDC_MAINNET;
+        if (chainId == 11155111) return USDC_SEPOLIA;
+        return address(0);
     }
 }

--- a/packages/contracts/script/DeployAutoDriveUSDCReceiver.s.sol
+++ b/packages/contracts/script/DeployAutoDriveUSDCReceiver.s.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Script, console} from "forge-std/Script.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {AutoDriveUSDCReceiver} from "../src/AutoDriveUSDCReceiver.sol";
+
+/**
+ * @notice Deploys AutoDriveUSDCReceiver to Ethereum mainnet or Sepolia.
+ *
+ * Required env vars:
+ *   PRIVATE_KEY        - deployer key (hex, 0x-prefixed)
+ *   USDC_TOKEN_ADDRESS - ERC20 (USDC) address on the target chain
+ * Optional:
+ *   OWNER              - initial owner; defaults to the deployer address.
+ *                        Use a multisig for production.
+ *
+ * Known USDC addresses:
+ *   Ethereum mainnet: 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48
+ *   Sepolia:          deploy/point at your test USDC token
+ *
+ * Usage:
+ *   forge script script/DeployAutoDriveUSDCReceiver.s.sol \
+ *     --rpc-url "$ETH_RPC_URL" --broadcast --verify
+ */
+contract DeployAutoDriveUSDCReceiver is Script {
+    function run() external returns (AutoDriveUSDCReceiver receiver) {
+        uint256 deployerKey = vm.envUint("PRIVATE_KEY");
+        address tokenAddress = vm.envAddress("USDC_TOKEN_ADDRESS");
+        address initialOwner = vm.envOr("OWNER", vm.addr(deployerKey));
+
+        require(tokenAddress != address(0), "USDC_TOKEN_ADDRESS is zero");
+
+        vm.startBroadcast(deployerKey);
+        receiver = new AutoDriveUSDCReceiver(
+            initialOwner,
+            IERC20(tokenAddress)
+        );
+        vm.stopBroadcast();
+
+        console.log("AutoDriveUSDCReceiver deployed at:", address(receiver));
+        console.log("Initial owner:", initialOwner);
+        console.log("Token:", tokenAddress);
+    }
+}

--- a/packages/contracts/src/AutoDriveUSDCReceiver.sol
+++ b/packages/contracts/src/AutoDriveUSDCReceiver.sol
@@ -17,8 +17,11 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
  * @dev Differs from the native receiver in three deliberate ways:
  *      - Accepts a single, immutable ERC20 token (redeploy for a different
  *        token/chain) rather than native value.
- *      - Emits the `payer` in the event instead of relying on the tx sender,
- *        because ERC20 payments can be relayed by a third party.
+ *      - Emits the `payer` in the event instead of relying on the tx origin,
+ *        because ERC20 payments can be relayed by a third party. The payer is
+ *        the account whose token allowance funds the payment — i.e. the
+ *        account that should receive any refund — never an intermediary that
+ *        merely initiated the transaction.
  *      - Sweeps are owner-gated to a caller-specified recipient (not a fixed
  *        treasury), so funds can later be routed to a swapper contract. There is
  *        no `minimumBalance` — that exists only for Auto-EVM's existential
@@ -42,9 +45,10 @@ contract AutoDriveUSDCReceiver is Ownable2Step, ReentrancyGuard, Pausable {
     error InvalidToken(address token);
     error InvalidRecipient(address recipient);
     error InsufficientBalance(uint256 balance, uint256 amount);
+    error RenounceOwnershipDisabled();
 
     constructor(address initialOwner, IERC20 token_) Ownable(initialOwner) {
-        if (address(token_) == address(0)) {
+        if (address(token_) == address(0) || address(token_).code.length == 0) {
             revert InvalidToken(address(token_));
         }
         token = token_;
@@ -132,5 +136,13 @@ contract AutoDriveUSDCReceiver is Ownable2Step, ReentrancyGuard, Pausable {
 
     function unpause() external onlyOwner {
         _unpause();
+    }
+
+    /**
+     * @notice Disabled. Renouncing ownership would permanently strand any
+     *         tokens held by the contract (sweeps are owner-gated).
+     */
+    function renounceOwnership() public view override onlyOwner {
+        revert RenounceOwnershipDisabled();
     }
 }

--- a/packages/contracts/src/AutoDriveUSDCReceiver.sol
+++ b/packages/contracts/src/AutoDriveUSDCReceiver.sol
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Ownable2Step} from "@openzeppelin/contracts/access/Ownable2Step.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+/**
+ * @title AutoDriveUSDCReceiver
+ * @notice ERC20 (USDC) counterpart of AutoDriveCreditsReceiver, for paying
+ *         credit-purchase intents with a token on Ethereum. The backend watches
+ *         IntentTokenPaymentReceived and grants credits at the intent's locked
+ *         USD price (deferred-conversion / "Option C").
+ * @dev Differs from the native receiver in three deliberate ways:
+ *      - Accepts a single, immutable ERC20 token (redeploy for a different
+ *        token/chain) rather than native value.
+ *      - Emits the `payer` in the event instead of relying on the tx sender,
+ *        because ERC20 payments can be relayed by a third party.
+ *      - Sweeps are owner-gated to a caller-specified recipient (not a fixed
+ *        treasury), so funds can later be routed to a swapper contract. There is
+ *        no `minimumBalance` — that exists only for Auto-EVM's existential
+ *        deposit and is meaningless for an ERC20 balance on Ethereum.
+ */
+contract AutoDriveUSDCReceiver is Ownable2Step, ReentrancyGuard, Pausable {
+    using SafeERC20 for IERC20;
+
+    /// @notice The ERC20 token accepted for payment (USDC on the target chain).
+    IERC20 public immutable token;
+
+    event IntentTokenPaymentReceived(
+        bytes32 indexed intentId,
+        address token,
+        uint256 amount,
+        address indexed payer
+    );
+    event Swept(address indexed caller, address indexed to, uint256 amount);
+
+    error InvalidAmount(uint256 amount);
+    error InvalidToken(address token);
+    error InvalidRecipient(address recipient);
+    error InsufficientBalance(uint256 balance, uint256 amount);
+
+    constructor(address initialOwner, IERC20 token_) Ownable(initialOwner) {
+        if (address(token_) == address(0)) {
+            revert InvalidToken(address(token_));
+        }
+        token = token_;
+    }
+
+    /**
+     * @notice Pay an intent with the configured ERC20 token. The caller must
+     *         have approved this contract for at least `amount` beforehand.
+     * @param intentId The intent being paid.
+     * @param amount   The token amount to pull from the caller (token's smallest
+     *                  unit; USDC has 6 decimals).
+     * @dev The amount carried in the event is the *actual* balance delta
+     *      received, so a fee-on-transfer token can never cause the backend to
+     *      over-credit. `nonReentrant` guards against tokens with transfer
+     *      callbacks.
+     */
+    function payIntentWithToken(bytes32 intentId, uint256 amount)
+        external
+        nonReentrant
+        whenNotPaused
+    {
+        if (amount == 0) {
+            revert InvalidAmount(amount);
+        }
+
+        uint256 balanceBefore = token.balanceOf(address(this));
+        token.safeTransferFrom(msg.sender, address(this), amount);
+        uint256 received = token.balanceOf(address(this)) - balanceBefore;
+
+        if (received == 0) {
+            revert InvalidAmount(received);
+        }
+
+        emit IntentTokenPaymentReceived(
+            intentId,
+            address(token),
+            received,
+            msg.sender
+        );
+    }
+
+    /**
+     * @notice Owner sweeps `amount` of the token to `to`.
+     * @dev onlyOwner because the destination is caller-specified; `to` may later
+     *      be a swapper contract. Intentionally callable while paused so the
+     *      owner can always move funds to safety during an incident.
+     */
+    function sweep(address to, uint256 amount) external onlyOwner nonReentrant {
+        if (to == address(0)) {
+            revert InvalidRecipient(to);
+        }
+        if (amount == 0) {
+            revert InvalidAmount(amount);
+        }
+
+        uint256 balance = token.balanceOf(address(this));
+        if (amount > balance) {
+            revert InsufficientBalance(balance, amount);
+        }
+
+        token.safeTransfer(to, amount);
+        emit Swept(msg.sender, to, amount);
+    }
+
+    /**
+     * @notice Owner sweeps the entire token balance to `to`.
+     */
+    function sweepAll(address to) external onlyOwner nonReentrant {
+        if (to == address(0)) {
+            revert InvalidRecipient(to);
+        }
+
+        uint256 balance = token.balanceOf(address(this));
+        if (balance == 0) {
+            revert InsufficientBalance(balance, 0);
+        }
+
+        token.safeTransfer(to, balance);
+        emit Swept(msg.sender, to, balance);
+    }
+
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+}

--- a/packages/contracts/test/AutoDriveUSDCReceiver.t.sol
+++ b/packages/contracts/test/AutoDriveUSDCReceiver.t.sol
@@ -47,6 +47,18 @@ contract AutoDriveUSDCReceiverTest is Test {
         new AutoDriveUSDCReceiver(owner, IERC20(address(0)));
     }
 
+    function testConstructorRevertsOnNonContractToken() public {
+        // An EOA (no code) must be rejected as the token.
+        address eoa = address(0x1234);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AutoDriveUSDCReceiver.InvalidToken.selector,
+                eoa
+            )
+        );
+        new AutoDriveUSDCReceiver(owner, IERC20(eoa));
+    }
+
     function testTokenIsImmutable() public view {
         assertEq(address(receiver.token()), address(usdc));
     }
@@ -295,5 +307,24 @@ contract AutoDriveUSDCReceiverTest is Test {
         receiver.acceptOwnership();
         assertEq(receiver.owner(), newOwner);
         assertEq(receiver.pendingOwner(), address(0));
+    }
+
+    function testRenounceOwnershipDisabled() public {
+        vm.expectRevert(
+            AutoDriveUSDCReceiver.RenounceOwnershipDisabled.selector
+        );
+        receiver.renounceOwnership();
+        assertEq(receiver.owner(), owner);
+    }
+
+    function testRenounceOwnershipOnlyOwner() public {
+        vm.prank(stranger);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Ownable.OwnableUnauthorizedAccount.selector,
+                stranger
+            )
+        );
+        receiver.renounceOwnership();
     }
 }

--- a/packages/contracts/test/AutoDriveUSDCReceiver.t.sol
+++ b/packages/contracts/test/AutoDriveUSDCReceiver.t.sol
@@ -1,0 +1,299 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Test} from "forge-std/Test.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {AutoDriveUSDCReceiver} from "../src/AutoDriveUSDCReceiver.sol";
+import {MockERC20, FeeOnTransferERC20, ReentrantERC20} from "./mocks.sol";
+
+contract AutoDriveUSDCReceiverTest is Test {
+    AutoDriveUSDCReceiver public receiver;
+    MockERC20 public usdc;
+
+    address public owner = address(this);
+    address public payer = address(0xA11CE);
+    address public recipient = address(0xBEEF);
+    address public stranger = address(0xCAFE);
+
+    bytes32 public constant INTENT_ID = bytes32(uint256(0xABCD));
+
+    // Re-declared to assert emission with vm.expectEmit.
+    event IntentTokenPaymentReceived(
+        bytes32 indexed intentId,
+        address token,
+        uint256 amount,
+        address indexed payer
+    );
+    event Swept(address indexed caller, address indexed to, uint256 amount);
+
+    function setUp() public {
+        usdc = new MockERC20();
+        receiver = new AutoDriveUSDCReceiver(owner, IERC20(address(usdc)));
+        usdc.mint(payer, 1_000_000_000); // 1,000 USDC
+    }
+
+    // --- constructor -------------------------------------------------------
+
+    function testConstructorRevertsOnZeroToken() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AutoDriveUSDCReceiver.InvalidToken.selector,
+                address(0)
+            )
+        );
+        new AutoDriveUSDCReceiver(owner, IERC20(address(0)));
+    }
+
+    function testTokenIsImmutable() public view {
+        assertEq(address(receiver.token()), address(usdc));
+    }
+
+    // --- payIntentWithToken ------------------------------------------------
+
+    function testPayIntentWithTokenHappyPath() public {
+        uint256 amount = 5_000_000; // 5 USDC
+
+        vm.prank(payer);
+        usdc.approve(address(receiver), amount);
+
+        vm.expectEmit(true, true, false, true);
+        emit IntentTokenPaymentReceived(INTENT_ID, address(usdc), amount, payer);
+
+        vm.prank(payer);
+        receiver.payIntentWithToken(INTENT_ID, amount);
+
+        assertEq(usdc.balanceOf(address(receiver)), amount);
+    }
+
+    function testPayIntentRevertsWithoutApproval() public {
+        vm.prank(payer);
+        vm.expectRevert(); // ERC20InsufficientAllowance
+        receiver.payIntentWithToken(INTENT_ID, 5_000_000);
+    }
+
+    function testPayIntentRevertsWithoutBalance() public {
+        // poorPayer approves but holds no tokens.
+        address poorPayer = address(0xD00D);
+        vm.prank(poorPayer);
+        usdc.approve(address(receiver), 5_000_000);
+
+        vm.prank(poorPayer);
+        vm.expectRevert(); // ERC20InsufficientBalance
+        receiver.payIntentWithToken(INTENT_ID, 5_000_000);
+    }
+
+    function testPayIntentRevertsOnZeroAmount() public {
+        vm.prank(payer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AutoDriveUSDCReceiver.InvalidAmount.selector,
+                0
+            )
+        );
+        receiver.payIntentWithToken(INTENT_ID, 0);
+    }
+
+    function testPayIntentRevertsWhenPaused() public {
+        receiver.pause();
+
+        vm.prank(payer);
+        usdc.approve(address(receiver), 5_000_000);
+
+        vm.prank(payer);
+        vm.expectRevert(Pausable.EnforcedPause.selector);
+        receiver.payIntentWithToken(INTENT_ID, 5_000_000);
+    }
+
+    function testPayIntentEmitsActualReceivedForFeeOnTransferToken() public {
+        FeeOnTransferERC20 feeToken = new FeeOnTransferERC20();
+        AutoDriveUSDCReceiver feeReceiver = new AutoDriveUSDCReceiver(
+            owner,
+            IERC20(address(feeToken))
+        );
+
+        uint256 amount = 1_000_000;
+        uint256 fee = (amount * feeToken.FEE_BPS()) / 10000;
+        uint256 received = amount - fee;
+
+        feeToken.mint(payer, amount);
+        vm.prank(payer);
+        feeToken.approve(address(feeReceiver), amount);
+
+        // Event carries the real delta (received), not the requested amount.
+        vm.expectEmit(true, true, false, true);
+        emit IntentTokenPaymentReceived(
+            INTENT_ID,
+            address(feeToken),
+            received,
+            payer
+        );
+
+        vm.prank(payer);
+        feeReceiver.payIntentWithToken(INTENT_ID, amount);
+
+        assertEq(feeToken.balanceOf(address(feeReceiver)), received);
+    }
+
+    function testPayIntentReentrancyReverts() public {
+        ReentrantERC20 evil = new ReentrantERC20();
+        AutoDriveUSDCReceiver evilReceiver = new AutoDriveUSDCReceiver(
+            owner,
+            IERC20(address(evil))
+        );
+        evil.setReceiver(evilReceiver);
+        evil.mint(payer, 10_000_000);
+
+        vm.prank(payer);
+        evil.approve(address(evilReceiver), 10_000_000);
+
+        evil.setAttack(true);
+
+        vm.prank(payer);
+        vm.expectRevert(ReentrancyGuard.ReentrancyGuardReentrantCall.selector);
+        evilReceiver.payIntentWithToken(INTENT_ID, 5_000_000);
+    }
+
+    // --- sweep / sweepAll --------------------------------------------------
+
+    function _fund(uint256 amount) internal {
+        vm.prank(payer);
+        usdc.approve(address(receiver), amount);
+        vm.prank(payer);
+        receiver.payIntentWithToken(INTENT_ID, amount);
+    }
+
+    function testSweepOnlyOwner() public {
+        _fund(5_000_000);
+        vm.prank(stranger);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Ownable.OwnableUnauthorizedAccount.selector,
+                stranger
+            )
+        );
+        receiver.sweep(recipient, 1_000_000);
+    }
+
+    function testSweepHappyPath() public {
+        _fund(5_000_000);
+        uint256 amount = 2_000_000;
+
+        vm.expectEmit(true, true, false, true);
+        emit Swept(owner, recipient, amount);
+
+        receiver.sweep(recipient, amount);
+
+        assertEq(usdc.balanceOf(recipient), amount);
+        assertEq(usdc.balanceOf(address(receiver)), 3_000_000);
+    }
+
+    function testSweepRevertsOnZeroRecipient() public {
+        _fund(5_000_000);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AutoDriveUSDCReceiver.InvalidRecipient.selector,
+                address(0)
+            )
+        );
+        receiver.sweep(address(0), 1_000_000);
+    }
+
+    function testSweepRevertsOnZeroAmount() public {
+        _fund(5_000_000);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AutoDriveUSDCReceiver.InvalidAmount.selector,
+                0
+            )
+        );
+        receiver.sweep(recipient, 0);
+    }
+
+    function testSweepRevertsOnInsufficientBalance() public {
+        _fund(1_000_000);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AutoDriveUSDCReceiver.InsufficientBalance.selector,
+                1_000_000,
+                2_000_000
+            )
+        );
+        receiver.sweep(recipient, 2_000_000);
+    }
+
+    function testSweepAllHappyPath() public {
+        _fund(5_000_000);
+
+        vm.expectEmit(true, true, false, true);
+        emit Swept(owner, recipient, 5_000_000);
+
+        receiver.sweepAll(recipient);
+
+        assertEq(usdc.balanceOf(address(receiver)), 0);
+        assertEq(usdc.balanceOf(recipient), 5_000_000);
+    }
+
+    function testSweepAllRevertsWhenEmpty() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AutoDriveUSDCReceiver.InsufficientBalance.selector,
+                0,
+                0
+            )
+        );
+        receiver.sweepAll(recipient);
+    }
+
+    function testSweepWorksWhilePaused() public {
+        _fund(5_000_000);
+        receiver.pause();
+
+        // Deliberate: owner can always move funds to safety while paused.
+        receiver.sweep(recipient, 1_000_000);
+        assertEq(usdc.balanceOf(recipient), 1_000_000);
+    }
+
+    // --- pause / ownership -------------------------------------------------
+
+    function testPauseUnpauseOnlyOwner() public {
+        vm.prank(stranger);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Ownable.OwnableUnauthorizedAccount.selector,
+                stranger
+            )
+        );
+        receiver.pause();
+
+        receiver.pause();
+        assertTrue(receiver.paused());
+
+        receiver.unpause();
+        assertFalse(receiver.paused());
+    }
+
+    function testTwoStepOwnershipTransfer() public {
+        address newOwner = address(0xBEEF);
+
+        receiver.transferOwnership(newOwner);
+        assertEq(receiver.owner(), owner);
+        assertEq(receiver.pendingOwner(), newOwner);
+
+        vm.prank(stranger);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Ownable.OwnableUnauthorizedAccount.selector,
+                stranger
+            )
+        );
+        receiver.acceptOwnership();
+
+        vm.prank(newOwner);
+        receiver.acceptOwnership();
+        assertEq(receiver.owner(), newOwner);
+        assertEq(receiver.pendingOwner(), address(0));
+    }
+}

--- a/packages/contracts/test/mocks.sol
+++ b/packages/contracts/test/mocks.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {AutoDriveUSDCReceiver} from "../src/AutoDriveUSDCReceiver.sol";
+
+/// @dev Minimal mintable USDC-like token (6 decimals) for tests.
+contract MockERC20 is ERC20 {
+    constructor() ERC20("Mock USD Coin", "USDC") {}
+
+    function decimals() public pure override returns (uint8) {
+        return 6;
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+/// @dev Token that burns a 1% fee on every transfer, so the recipient receives
+///      less than `value`. Used to prove the receiver emits the actual delta.
+contract FeeOnTransferERC20 is ERC20 {
+    uint256 public constant FEE_BPS = 100; // 1%
+
+    constructor() ERC20("Fee Token", "FEE") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function _update(address from, address to, uint256 value) internal override {
+        if (from != address(0) && to != address(0) && value > 0) {
+            uint256 fee = (value * FEE_BPS) / 10000;
+            super._update(from, to, value - fee);
+            if (fee > 0) {
+                super._update(from, address(0), fee); // burn the fee
+            }
+        } else {
+            super._update(from, to, value);
+        }
+    }
+}
+
+/// @dev Token whose transfer re-enters the receiver to exercise the
+///      ReentrancyGuard on payIntentWithToken.
+contract ReentrantERC20 is ERC20 {
+    AutoDriveUSDCReceiver public receiver;
+    bool public attack;
+
+    constructor() ERC20("Reentrant", "RE") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function setReceiver(AutoDriveUSDCReceiver receiver_) external {
+        receiver = receiver_;
+    }
+
+    function setAttack(bool attack_) external {
+        attack = attack_;
+    }
+
+    function _update(address from, address to, uint256 value) internal override {
+        if (attack && to == address(receiver)) {
+            attack = false; // single shot — the guard will revert this call
+            receiver.payIntentWithToken(bytes32(uint256(1)), value);
+        }
+        super._update(from, to, value);
+    }
+}


### PR DESCRIPTION
**Part of #742 (USDC Payments for PayWithAI3 epic).**
**Closes #745 — Smart contract: AutoDriveUSDCReceiver.sol.**

Step 3: the ERC20 (USDC) receiver on Ethereum, mirroring `AutoDriveCreditsReceiver` (`Ownable2Step` + `ReentrancyGuard` + `Pausable`). **Independent of #755/#756** — Solidity/Foundry only, so this branches from `main` and can merge on its own.

## Contract — `AutoDriveUSDCReceiver.sol`
- **Immutable USDC token** set in the constructor (redeploy for a different token/chain — no owner repointing).
- `payIntentWithToken(intentId, amount)`: `SafeERC20.safeTransferFrom` + emits `IntentTokenPaymentReceived(intentId, token, amount, payer)`.
  - `payer` travels **in the event** (not read from the tx sender) because ERC20 payments can be relayed.
  - `amount` is the **actual balance delta received**, so a fee-on-transfer token can't make the backend over-credit.
  - Event matches the ABI locked in `@auto-drive/models` in #755 (`intentId` + `payer` indexed).
- **Owner-gated** `sweep(to, amount)` / `sweepAll(to)` to an arbitrary recipient (a swapper later, per Option C). **Callable while paused** so the owner can always rescue funds. (Differs from the native receiver's permissionless-to-fixed-treasury sweep — see design decisions.)
- `pause`/`unpause`; `nonReentrant` on pay + sweep paths.
- **No `minimumBalance`** — that's an Auto-EVM existential-deposit concern, meaningless for an ERC20 balance on Ethereum.

## Design decisions (asked up front)
| Decision | Choice |
| --- | --- |
| Sweep model | Owner-gated flexible `sweep(to, amount)` (B-ready for a swapper) |
| Token address | Immutable, set in constructor |
| Deploy | Foundry script + README |

## Tests — **19, all passing** (`forge test`)
Happy path · missing approval · missing balance · zero amount · paused · fee-on-transfer emits actual received · **reentrancy guard reverts** · sweep onlyOwner + zero-recipient/zero-amount/insufficient-balance · sweepAll happy + empty · sweep-while-paused · pause/unpause auth · two-step ownership · immutable token · zero-token constructor revert. Adds `mocks.sol` (`MockERC20` 6dp, `FeeOnTransferERC20`, `ReentrantERC20`).

## Deploy
`script/DeployAutoDriveUSDCReceiver.s.sol` (env: `PRIVATE_KEY`, `USDC_TOKEN_ADDRESS`, optional `OWNER`) for Sepolia + Ethereum mainnet, documented in the README.

## Verification
- `forge build` clean (Solc 0.8.28; the only warnings are pre-existing in `test/utils.sol`).
- `forge test`: **37/37 passing** (19 new + 18 existing native-contract tests).

## Deferred
Permit2 / EIP-2612 (one-signature approve+pay) intentionally left for a later iteration; v1 is two transactions (approve + pay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
