### PR TITLE
feat(frontend): open purchase screen to all users with Google sign-in gate

### DIFF
--- a/apps/frontend/src/app/[chain]/drive/purchase/page.tsx
+++ b/apps/frontend/src/app/[chain]/drive/purchase/page.tsx
@@ -1,10 +1,9 @@
 import { PurchaseCredits } from '@/components/views/PurchaseCredits';
-import { UserProtectedLayout } from '@/components/layouts/UserProtectedLayout';
 
-export default async function Page() {
-  return (
-    <UserProtectedLayout>
-      <PurchaseCredits />
-    </UserProtectedLayout>
-  );
+// The purchase screen is intentionally available to all visitors — including
+// unauthenticated and non-Google users — so the credit packages are
+// discoverable. Authentication is enforced at the point of action: selecting a
+// package prompts a Google sign-in (see Step1_SelectPackage / GoogleAuthGate).
+export default function Page() {
+  return <PurchaseCredits />;
 }

--- a/apps/frontend/src/components/atoms/BuyMoreCreditsButton.tsx
+++ b/apps/frontend/src/components/atoms/BuyMoreCreditsButton.tsx
@@ -7,7 +7,11 @@ export const BuyMoreCreditsButton = () => {
 
   return (
     <InternalLink href={ROUTES.purchase(network.id)} className='contents'>
-      <Button variant='outline' size='sm' className='w-full text-xs'>
+      <Button
+        variant='primary'
+        size='sm'
+        className='w-full text-xs font-semibold'
+      >
         Buy more credits
       </Button>
     </InternalLink>

--- a/apps/frontend/src/components/organisms/SideNavBar/index.tsx
+++ b/apps/frontend/src/components/organisms/SideNavBar/index.tsx
@@ -135,13 +135,16 @@ export const SideNavbar = ({ networkId }: SideNavbarProps) => {
             creditHistoryHref={creditHistoryHref}
           />
         )}
-        {isLoggedIn && account ? (
-          hasBuyCreditsFeature ? (
-            <BuyMoreCreditsButton />
-          ) : (
-            <AskForCreditsButton />
-          )
-        ) : (
+        {/* The buy-credits CTA is shown to everyone — the purchase screen is
+            open to all users and prompts a Google sign-in when required. */}
+        <BuyMoreCreditsButton />
+        {/* Non-Google accounts can't purchase directly, so keep the existing
+            "request credits" form available to them. */}
+        {isLoggedIn && account && !hasBuyCreditsFeature && (
+          <AskForCreditsButton />
+        )}
+        {/* Logged-out visitors keep a clear login entry point. */}
+        {!isLoggedIn && (
           <Button
             variant='outline'
             size='sm'

--- a/apps/frontend/src/components/views/PurchaseCredits/GoogleAuthGate.tsx
+++ b/apps/frontend/src/components/views/PurchaseCredits/GoogleAuthGate.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import {
+  Dialog,
+  DialogPanel,
+  DialogTitle,
+  Transition,
+  TransitionChild,
+} from '@headlessui/react';
+import { Fragment } from 'react';
+import { Button } from '@auto-drive/ui';
+import { useLogIn } from '../../../hooks/useAuth';
+
+interface GoogleAuthGateProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Shown when a logged-out or non-Google user tries to select a package on the
+ * purchase screen. Purchasing storage credits requires a Google-verified
+ * account (enforced server-side on intent creation), so we surface a clear
+ * sign-in / sign-up prompt rather than letting them proceed into a flow that
+ * would ultimately be rejected.
+ */
+export const GoogleAuthGate = ({ isOpen, onClose }: GoogleAuthGateProps) => {
+  const { signIn } = useLogIn();
+
+  return (
+    <Transition appear show={isOpen} as={Fragment}>
+      <Dialog as='div' className='relative z-10' onClose={onClose}>
+        <TransitionChild
+          as={Fragment}
+          enter='ease-out duration-300'
+          enterFrom='opacity-0'
+          enterTo='opacity-100'
+          leave='ease-in duration-200'
+          leaveFrom='opacity-100'
+          leaveTo='opacity-0'
+        >
+          <div className='bg-background-hover fixed inset-0 bg-opacity-25' />
+        </TransitionChild>
+
+        <div className='fixed inset-0 overflow-y-auto'>
+          <div className='flex min-h-full items-center justify-center p-4 text-center'>
+            <TransitionChild
+              as={Fragment}
+              enter='ease-out duration-300'
+              enterFrom='opacity-0 scale-95'
+              enterTo='opacity-100 scale-100'
+              leave='ease-in duration-200'
+              leaveFrom='opacity-100 scale-100'
+              leaveTo='opacity-0 scale-95'
+            >
+              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-background p-6 text-left align-middle text-foreground shadow-xl transition-all'>
+                <div className='space-y-2'>
+                  <DialogTitle className='text-center text-2xl font-bold'>
+                    Sign in to buy credits
+                  </DialogTitle>
+                  <div className='text-center text-muted-foreground'>
+                    Purchasing storage credits requires a Google account. Please
+                    sign in or sign up with Google to continue.
+                  </div>
+                </div>
+
+                <div className='space-y-3 py-4'>
+                  <Button
+                    variant='primary'
+                    className='h-12 w-full justify-center space-x-3 font-semibold'
+                    onClick={() => signIn('google')}
+                  >
+                    <svg className='h-5 w-5' viewBox='0 0 24 24'>
+                      <path
+                        fill='currentColor'
+                        d='M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z'
+                      />
+                      <path
+                        fill='currentColor'
+                        d='M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z'
+                      />
+                      <path
+                        fill='currentColor'
+                        d='M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z'
+                      />
+                      <path
+                        fill='currentColor'
+                        d='M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z'
+                      />
+                    </svg>
+                    <span>Sign in with Google</span>
+                  </Button>
+
+                  <Button
+                    variant='outline'
+                    className='w-full'
+                    onClick={onClose}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              </DialogPanel>
+            </TransitionChild>
+          </div>
+        </div>
+      </Dialog>
+    </Transition>
+  );
+};

--- a/apps/frontend/src/components/views/PurchaseCredits/steps/Step1_SelectPackage.tsx
+++ b/apps/frontend/src/components/views/PurchaseCredits/steps/Step1_SelectPackage.tsx
@@ -1,7 +1,10 @@
 'use client';
 
 import { Button, Card, cn } from '@auto-drive/ui';
+import { useContext, useState } from 'react';
+import { SessionContext } from 'next-auth/react';
 import { CreditCurrentPrice } from '../CreditCurrentPrice';
+import { GoogleAuthGate } from '../GoogleAuthGate';
 import { usePrices } from '../../../../hooks/usePrices';
 import { usePaymentIntent } from '../../../../hooks/usePaymentIntent';
 import { useUserStore } from '../../../../globalStates/user';
@@ -65,6 +68,22 @@ export const PurchaseStep1SelectPackage = ({
 
   const { MINIMUM_CONFIRMATIONS } = usePaymentIntent();
 
+  // Purchasing requires a Google-verified account. The screen itself is open to
+  // everyone (so packages are discoverable), but selecting one prompts a Google
+  // sign-in for logged-out and non-Google users.
+  const session = useContext(SessionContext);
+  const isGoogleAuthed = session?.data?.underlyingProvider === 'google';
+  const [authGateOpen, setAuthGateOpen] = useState(false);
+
+  const handleSelect = (packageId: string, disabled: boolean) => {
+    if (disabled) return;
+    if (!isGoogleAuthed) {
+      setAuthGateOpen(true);
+      return;
+    }
+    onNext({ packageId });
+  };
+
   const creditSummary = useUserStore((s) => s.creditSummary);
 
   // Number of days credits are valid — sourced from CREDIT_EXPIRY_DAYS env-var
@@ -104,6 +123,10 @@ export const PurchaseStep1SelectPackage = ({
 
   return (
     <div className='grid grid-cols-1 gap-6 xl:grid-cols-4'>
+      <GoogleAuthGate
+        isOpen={authGateOpen}
+        onClose={() => setAuthGateOpen(false)}
+      />
       <div className='xl:col-span-4'>
         <CreditCurrentPrice />
 
@@ -140,9 +163,7 @@ export const PurchaseStep1SelectPackage = ({
                           : 'hover:ring-2 hover:ring-primary'
                       }`
                 }`}
-                onClick={() => {
-                  if (!disabled) onNext({ packageId: p.id });
-                }}
+                onClick={() => handleSelect(p.id, disabled)}
               >
                 <div className='flex h-full flex-col gap-3 p-5'>
                   <div className='flex items-center justify-between'>

--- a/apps/frontend/src/services/api.ts
+++ b/apps/frontend/src/services/api.ts
@@ -818,17 +818,18 @@ export const createApiService = ({
     return response.json() as Promise<ExpiringCreditBatch[]>;
   },
   getCreditPrice: async (): Promise<{ price: number; pricePerGB: number }> => {
+    // GET /intents/price is a public endpoint (registered before the auth /
+    // feature-flag middleware). Attach auth headers when a session exists, but
+    // don't require one — this lets the purchase screen show live pricing to
+    // logged-out and non-Google visitors too.
     const session = await getAuthSession();
-    if (!session?.authProvider || !session.accessToken) {
-      throw new Error('No session');
+    const headers: Record<string, string> = {};
+    if (session?.authProvider && session.accessToken) {
+      headers['X-Auth-Provider'] = session.authProvider;
+      headers['Authorization'] = `Bearer ${session.accessToken}`;
     }
 
-    const response = await fetch(`${apiBaseUrl}/intents/price`, {
-      headers: {
-        'X-Auth-Provider': session.authProvider,
-        Authorization: `Bearer ${session.accessToken}`,
-      },
-    });
+    const response = await fetch(`${apiBaseUrl}/intents/price`, { headers });
 
     if (!response.ok) {
       throw new Error(`Network response was not ok: ${response.statusText}`);


### PR DESCRIPTION
## What

Makes the Buy Credits flow discoverable for everyone, while keeping the actual purchase action gated to Google-verified accounts.

### Changes
- **More visible "Buy more credits" button** — switched from `outline` to the filled `primary` variant (`+ font-semibold`). Primary uses the `--primary` / `--primary-foreground` theme variables, so it renders with consistent, intentional colors in both light and dark schemes instead of a low-contrast outline.
- **Purchase screen open to all users** — removed the `UserProtectedLayout` wrapper from `purchase/page.tsx`. That layout was the only thing blocking unauthenticated access (it redirected logged-out users to `/drive/global` and refused to render until a `user` existed). The Next.js middleware does not gate this route — its matcher only covers `/drive/*`, not the chain-prefixed `/[chain]/drive/*`.
- **Live pricing for everyone** — `api.getCreditPrice()` no longer throws `'No session'`. `GET /intents/price` is already a public backend endpoint (registered before the auth/feature-flag middleware), so auth headers are now optional. Logged-out and non-Google visitors see real prices instead of `—` / `$0.00`.
- **Google sign-in gate** — new `GoogleAuthGate` modal. When a logged-out or non-Google user clicks **Select Package** / **Configure**, they get a prompt to sign in or sign up with Google (with a Google sign-in button) instead of advancing. Detection uses `session.underlyingProvider === 'google'`.
- **Sidebar footer** — "Buy more credits" is now always shown, while the existing "Log In" (logged-out) and "Ask for more credits" (non-Google) buttons are preserved.

## Why

So that the credit packages are discoverable by all visitors (driving conversions), with authentication enforced at the point of action rather than by hiding the screen entirely.

## Behavior by user type
- **Google-authenticated:** unchanged — packages work exactly as before.
- **Non-Google authenticated / logged-out:** can browse packages and see pricing; selecting one opens the Google sign-in prompt.

## Reviewer notes
- The gate keys on Google auth specifically (per request). On production where `buyCredits` is publicly active this matches current behavior. Edge case: during a *staff-only* rollout, a non-staff Google user would now pass the UI gate and could reach the final step before the backend rejects intent creation. Easy to additionally gate on the `buyCredits` feature flag if preferred.
- Verified with `tsc --noEmit` and ESLint (both pass) on the changed files. Not exercised in a running browser (local stack not provisioned in this worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)