### PR TITLE
feat(frontend): open purchase screen to all users with Google sign-in gate

### DIFF
--- a/apps/frontend/src/app/[chain]/drive/purchase/page.tsx
+++ b/apps/frontend/src/app/[chain]/drive/purchase/page.tsx
@@ -1,10 +1,9 @@
 import { PurchaseCredits } from '@/components/views/PurchaseCredits';
-import { UserProtectedLayout } from '@/components/layouts/UserProtectedLayout';
 
-export default async function Page() {
-  return (
-    <UserProtectedLayout>
-      <PurchaseCredits />
-    </UserProtectedLayout>
-  );
+// The purchase screen is intentionally available to all visitors — including
+// unauthenticated and non-Google users — so the credit packages are
+// discoverable. Authentication is enforced at the point of action: selecting a
+// package prompts a Google sign-in (see Step1_SelectPackage / GoogleAuthGate).
+export default function Page() {
+  return <PurchaseCredits />;
 }

--- a/apps/frontend/src/components/atoms/BuyMoreCreditsButton.tsx
+++ b/apps/frontend/src/components/atoms/BuyMoreCreditsButton.tsx
@@ -7,7 +7,11 @@ export const BuyMoreCreditsButton = () => {
 
   return (
     <InternalLink href={ROUTES.purchase(network.id)} className='contents'>
-      <Button variant='outline' size='sm' className='w-full text-xs'>
+      <Button
+        variant='primary'
+        size='sm'
+        className='w-full text-xs font-semibold'
+      >
         Buy more credits
       </Button>
     </InternalLink>

--- a/apps/frontend/src/components/organisms/SideNavBar/index.tsx
+++ b/apps/frontend/src/components/organisms/SideNavBar/index.tsx
@@ -135,13 +135,16 @@ export const SideNavbar = ({ networkId }: SideNavbarProps) => {
             creditHistoryHref={creditHistoryHref}
           />
         )}
-        {isLoggedIn && account ? (
-          hasBuyCreditsFeature ? (
-            <BuyMoreCreditsButton />
-          ) : (
-            <AskForCreditsButton />
-          )
-        ) : (
+        {/* The buy-credits CTA is shown to everyone — the purchase screen is
+            open to all users and prompts a Google sign-in when required. */}
+        <BuyMoreCreditsButton />
+        {/* Non-Google accounts can't purchase directly, so keep the existing
+            "request credits" form available to them. */}
+        {isLoggedIn && account && !hasBuyCreditsFeature && (
+          <AskForCreditsButton />
+        )}
+        {/* Logged-out visitors keep a clear login entry point. */}
+        {!isLoggedIn && (
           <Button
             variant='outline'
             size='sm'

--- a/apps/frontend/src/components/views/PurchaseCredits/GoogleAuthGate.tsx
+++ b/apps/frontend/src/components/views/PurchaseCredits/GoogleAuthGate.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import {
+  Dialog,
+  DialogPanel,
+  DialogTitle,
+  Transition,
+  TransitionChild,
+} from '@headlessui/react';
+import { Fragment } from 'react';
+import { Button } from '@auto-drive/ui';
+import { useLogIn } from '../../../hooks/useAuth';
+
+interface GoogleAuthGateProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Shown when a logged-out or non-Google user tries to select a package on the
+ * purchase screen. Purchasing storage credits requires a Google-verified
+ * account (enforced server-side on intent creation), so we surface a clear
+ * sign-in / sign-up prompt rather than letting them proceed into a flow that
+ * would ultimately be rejected.
+ */
+export const GoogleAuthGate = ({ isOpen, onClose }: GoogleAuthGateProps) => {
+  const { signIn } = useLogIn();
+
+  return (
+    <Transition appear show={isOpen} as={Fragment}>
+      <Dialog as='div' className='relative z-10' onClose={onClose}>
+        <TransitionChild
+          as={Fragment}
+          enter='ease-out duration-300'
+          enterFrom='opacity-0'
+          enterTo='opacity-100'
+          leave='ease-in duration-200'
+          leaveFrom='opacity-100'
+          leaveTo='opacity-0'
+        >
+          <div className='bg-background-hover fixed inset-0 bg-opacity-25' />
+        </TransitionChild>
+
+        <div className='fixed inset-0 overflow-y-auto'>
+          <div className='flex min-h-full items-center justify-center p-4 text-center'>
+            <TransitionChild
+              as={Fragment}
+              enter='ease-out duration-300'
+              enterFrom='opacity-0 scale-95'
+              enterTo='opacity-100 scale-100'
+              leave='ease-in duration-200'
+              leaveFrom='opacity-100 scale-100'
+              leaveTo='opacity-0 scale-95'
+            >
+              <DialogPanel className='w-full max-w-md transform overflow-hidden rounded-2xl bg-background p-6 text-left align-middle text-foreground shadow-xl transition-all'>
+                <div className='space-y-2'>
+                  <DialogTitle className='text-center text-2xl font-bold'>
+                    Sign in to buy credits
+                  </DialogTitle>
+                  <div className='text-center text-muted-foreground'>
+                    Purchasing storage credits requires a Google account. Please
+                    sign in or sign up with Google to continue.
+                  </div>
+                </div>
+
+                <div className='space-y-3 py-4'>
+                  <Button
+                    variant='primary'
+                    className='h-12 w-full justify-center space-x-3 font-semibold'
+                    onClick={() => signIn('google')}
+                  >
+                    <svg className='h-5 w-5' viewBox='0 0 24 24'>
+                      <path
+                        fill='currentColor'
+                        d='M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z'
+                      />
+                      <path
+                        fill='currentColor'
+                        d='M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z'
+                      />
+                      <path
+                        fill='currentColor'
+                        d='M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z'
+                      />
+                      <path
+                        fill='currentColor'
+                        d='M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z'
+                      />
+                    </svg>
+                    <span>Sign in with Google</span>
+                  </Button>
+
+                  <Button
+                    variant='outline'
+                    className='w-full'
+                    onClick={onClose}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              </DialogPanel>
+            </TransitionChild>
+          </div>
+        </div>
+      </Dialog>
+    </Transition>
+  );
+};

--- a/apps/frontend/src/components/views/PurchaseCredits/GoogleAuthGate.tsx
+++ b/apps/frontend/src/components/views/PurchaseCredits/GoogleAuthGate.tsx
@@ -14,6 +14,12 @@ import { useLogIn } from '../../../hooks/useAuth';
 interface GoogleAuthGateProps {
   isOpen: boolean;
   onClose: () => void;
+  /**
+   * Where to return after Google OAuth completes. Pass the purchase route so
+   * the user resumes the buy-credits flow instead of being dropped on the
+   * default drive view.
+   */
+  callbackUrl?: string;
 }
 
 /**
@@ -23,7 +29,11 @@ interface GoogleAuthGateProps {
  * sign-in / sign-up prompt rather than letting them proceed into a flow that
  * would ultimately be rejected.
  */
-export const GoogleAuthGate = ({ isOpen, onClose }: GoogleAuthGateProps) => {
+export const GoogleAuthGate = ({
+  isOpen,
+  onClose,
+  callbackUrl,
+}: GoogleAuthGateProps) => {
   const { signIn } = useLogIn();
 
   return (
@@ -67,7 +77,7 @@ export const GoogleAuthGate = ({ isOpen, onClose }: GoogleAuthGateProps) => {
                   <Button
                     variant='primary'
                     className='h-12 w-full justify-center space-x-3 font-semibold'
-                    onClick={() => signIn('google')}
+                    onClick={() => signIn('google', { callbackUrl })}
                   >
                     <svg className='h-5 w-5' viewBox='0 0 24 24'>
                       <path

--- a/apps/frontend/src/components/views/PurchaseCredits/index.tsx
+++ b/apps/frontend/src/components/views/PurchaseCredits/index.tsx
@@ -112,6 +112,9 @@ export const PurchaseCredits = () => {
       setCurrentStep(2);
       navigateWithParams({ ...pendingSelection, step: 2 });
       setPendingSelection(null);
+      // Close the gate in case it was opened earlier and the session has since
+      // become Google-authenticated (e.g. signed in from another tab).
+      setAuthGateOpen(false);
     } else {
       // Resolved non-Google → prompt sign-in. Keep pendingSelection so the
       // gate's callbackUrl retains the chosen package.
@@ -199,7 +202,13 @@ export const PurchaseCredits = () => {
     <div className='flex flex-col gap-4'>
       <GoogleAuthGate
         isOpen={authGateOpen}
-        onClose={() => setAuthGateOpen(false)}
+        onClose={() => {
+          // Dismissing the prompt discards the pending selection too —
+          // otherwise a later switch to a Google session would auto-advance
+          // the wizard as if the user had confirmed.
+          setAuthGateOpen(false);
+          setPendingSelection(null);
+        }}
         callbackUrl={authGateCallbackUrl}
       />
       {steps.find((s) => s.id === effectiveStep)?.component}

--- a/apps/frontend/src/components/views/PurchaseCredits/index.tsx
+++ b/apps/frontend/src/components/views/PurchaseCredits/index.tsx
@@ -35,12 +35,17 @@ export const PurchaseCredits = () => {
     session?.status === 'unauthenticated';
 
   const [authGateOpen, setAuthGateOpen] = useState(false);
-  const [pendingPackageId, setPendingPackageId] = useState<string | null>(null);
+  // The package the user picked, awaiting an auth decision. Stored as a fresh
+  // object per click so re-picking the same package still re-triggers the
+  // handler effect below.
+  const [pendingSelection, setPendingSelection] = useState<{
+    packageId?: string;
+  } | null>(null);
 
   // Return the user to the purchase flow (with their package preselected) after
   // Google OAuth, rather than the default drive view.
-  const authGateCallbackUrl = pendingPackageId
-    ? `${ROUTES.purchase(network.id)}?step=2&packageId=${pendingPackageId}`
+  const authGateCallbackUrl = pendingSelection?.packageId
+    ? `${ROUTES.purchase(network.id)}?step=2&packageId=${pendingSelection.packageId}`
     : ROUTES.purchase(network.id);
 
   const navigateWithParams = useCallback(
@@ -96,6 +101,24 @@ export const PurchaseCredits = () => {
   const effectiveStep: PurchaseStep =
     authResolved && !isGoogleAuthed && currentStep > 1 ? 1 : currentStep;
 
+  // Act on a pending package selection, but only once the session has resolved.
+  // Deferring keeps this consistent with `effectiveStep`: a still-loading
+  // session is never treated as non-Google, so Google users don't get the
+  // sign-in gate during the brief load window after SessionEnsurer renders.
+  useEffect(() => {
+    if (!pendingSelection || !authResolved) return;
+    if (isGoogleAuthed) {
+      setContext((prev) => ({ ...prev, ...pendingSelection }));
+      setCurrentStep(2);
+      navigateWithParams({ ...pendingSelection, step: 2 });
+      setPendingSelection(null);
+    } else {
+      // Resolved non-Google → prompt sign-in. Keep pendingSelection so the
+      // gate's callbackUrl retains the chosen package.
+      setAuthGateOpen(true);
+    }
+  }, [pendingSelection, authResolved, isGoogleAuthed, navigateWithParams]);
+
   const onBack = useCallback(() => {
     const newStep = Math.max(1, currentStep - 1);
     setCurrentStep(newStep as PurchaseStep);
@@ -110,18 +133,14 @@ export const PurchaseCredits = () => {
         component: (
           <PurchaseStep1SelectPackage
             onNext={(data) => {
-              // Selecting a package is the "point of action" — non-Google
-              // users are prompted to sign in instead of advancing.
-              if (!isGoogleAuthed) {
-                setPendingPackageId(
-                  typeof data.packageId === 'string' ? data.packageId : null,
-                );
-                setAuthGateOpen(true);
-                return;
-              }
-              setContext((prev) => ({ ...prev, ...data }));
-              setCurrentStep(2);
-              navigateWithParams({ ...data, step: 2 });
+              // Record the selection; the handler effect advances (Google) or
+              // opens the sign-in gate (non-Google) once the session resolves.
+              setPendingSelection({
+                packageId:
+                  typeof data.packageId === 'string'
+                    ? data.packageId
+                    : undefined,
+              });
             }}
             context={context}
           />
@@ -173,7 +192,7 @@ export const PurchaseCredits = () => {
     // Intentionally exclude navigateWithParams from deps to avoid re-render loop
     // as it's a stable function over the lifetime of the component.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [context, isGoogleAuthed],
+    [context],
   );
 
   return (

--- a/apps/frontend/src/components/views/PurchaseCredits/index.tsx
+++ b/apps/frontend/src/components/views/PurchaseCredits/index.tsx
@@ -1,11 +1,15 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { SessionContext } from 'next-auth/react';
+import { ROUTES } from '@auto-drive/ui';
+import { useNetwork } from '../../../contexts/network';
 import { PurchaseStep1SelectPackage } from './steps/Step1_SelectPackage';
 import { PurchaseStep2ConnectWallet } from './steps/Step2_ConfirmPurchase';
 import { PurchaseStep3TransferTokens } from './steps/Step3_TransferTokens';
 import { PurchaseStep4Success } from './steps/Step4_Success';
+import { GoogleAuthGate } from './GoogleAuthGate';
 import { StepDefinition } from './molecules/Stepper';
 
 export type PurchaseStep = 1 | 2 | 3 | 4 | 5;
@@ -16,6 +20,28 @@ export const PurchaseCredits = () => {
   const searchParams = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();
+  const { network } = useNetwork();
+
+  // Purchasing requires a Google-verified account. The screen is open to
+  // everyone so packages are discoverable, but only Google users may advance
+  // past package selection. We gate here (not in Step 1) so the rule also
+  // covers deep-links to later steps via ?step=.
+  const session = useContext(SessionContext);
+  const isGoogleAuthed = session?.data?.underlyingProvider === 'google';
+  // Wait for the session to resolve before enforcing — otherwise a Google user
+  // refreshing on a later step would be bounced to step 1 during loading.
+  const authResolved =
+    session?.status === 'authenticated' ||
+    session?.status === 'unauthenticated';
+
+  const [authGateOpen, setAuthGateOpen] = useState(false);
+  const [pendingPackageId, setPendingPackageId] = useState<string | null>(null);
+
+  // Return the user to the purchase flow (with their package preselected) after
+  // Google OAuth, rather than the default drive view.
+  const authGateCallbackUrl = pendingPackageId
+    ? `${ROUTES.purchase(network.id)}?step=2&packageId=${pendingPackageId}`
+    : ROUTES.purchase(network.id);
 
   const navigateWithParams = useCallback(
     (changes: Record<string, unknown>) => {
@@ -63,6 +89,13 @@ export const PurchaseCredits = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams?.toString()]);
 
+  // Enforce the Google gate at render: non-Google users (once auth resolves)
+  // can never see beyond package selection, regardless of how `currentStep`
+  // was reached (deep-link, ?step=, back/forward). The gate modal handles the
+  // actual sign-in prompt when they try to advance.
+  const effectiveStep: PurchaseStep =
+    authResolved && !isGoogleAuthed && currentStep > 1 ? 1 : currentStep;
+
   const onBack = useCallback(() => {
     const newStep = Math.max(1, currentStep - 1);
     setCurrentStep(newStep as PurchaseStep);
@@ -77,6 +110,15 @@ export const PurchaseCredits = () => {
         component: (
           <PurchaseStep1SelectPackage
             onNext={(data) => {
+              // Selecting a package is the "point of action" — non-Google
+              // users are prompted to sign in instead of advancing.
+              if (!isGoogleAuthed) {
+                setPendingPackageId(
+                  typeof data.packageId === 'string' ? data.packageId : null,
+                );
+                setAuthGateOpen(true);
+                return;
+              }
               setContext((prev) => ({ ...prev, ...data }));
               setCurrentStep(2);
               navigateWithParams({ ...data, step: 2 });
@@ -131,12 +173,17 @@ export const PurchaseCredits = () => {
     // Intentionally exclude navigateWithParams from deps to avoid re-render loop
     // as it's a stable function over the lifetime of the component.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [context],
+    [context, isGoogleAuthed],
   );
 
   return (
     <div className='flex flex-col gap-4'>
-      {steps.find((s) => s.id === currentStep)?.component}
+      <GoogleAuthGate
+        isOpen={authGateOpen}
+        onClose={() => setAuthGateOpen(false)}
+        callbackUrl={authGateCallbackUrl}
+      />
+      {steps.find((s) => s.id === effectiveStep)?.component}
     </div>
   );
 };

--- a/apps/frontend/src/components/views/PurchaseCredits/steps/Step1_SelectPackage.tsx
+++ b/apps/frontend/src/components/views/PurchaseCredits/steps/Step1_SelectPackage.tsx
@@ -1,10 +1,7 @@
 'use client';
 
 import { Button, Card, cn } from '@auto-drive/ui';
-import { useContext, useState } from 'react';
-import { SessionContext } from 'next-auth/react';
 import { CreditCurrentPrice } from '../CreditCurrentPrice';
-import { GoogleAuthGate } from '../GoogleAuthGate';
 import { usePrices } from '../../../../hooks/usePrices';
 import { usePaymentIntent } from '../../../../hooks/usePaymentIntent';
 import { useUserStore } from '../../../../globalStates/user';
@@ -68,22 +65,6 @@ export const PurchaseStep1SelectPackage = ({
 
   const { MINIMUM_CONFIRMATIONS } = usePaymentIntent();
 
-  // Purchasing requires a Google-verified account. The screen itself is open to
-  // everyone (so packages are discoverable), but selecting one prompts a Google
-  // sign-in for logged-out and non-Google users.
-  const session = useContext(SessionContext);
-  const isGoogleAuthed = session?.data?.underlyingProvider === 'google';
-  const [authGateOpen, setAuthGateOpen] = useState(false);
-
-  const handleSelect = (packageId: string, disabled: boolean) => {
-    if (disabled) return;
-    if (!isGoogleAuthed) {
-      setAuthGateOpen(true);
-      return;
-    }
-    onNext({ packageId });
-  };
-
   const creditSummary = useUserStore((s) => s.creditSummary);
 
   // Number of days credits are valid — sourced from CREDIT_EXPIRY_DAYS env-var
@@ -123,10 +104,6 @@ export const PurchaseStep1SelectPackage = ({
 
   return (
     <div className='grid grid-cols-1 gap-6 xl:grid-cols-4'>
-      <GoogleAuthGate
-        isOpen={authGateOpen}
-        onClose={() => setAuthGateOpen(false)}
-      />
       <div className='xl:col-span-4'>
         <CreditCurrentPrice />
 
@@ -163,7 +140,9 @@ export const PurchaseStep1SelectPackage = ({
                           : 'hover:ring-2 hover:ring-primary'
                       }`
                 }`}
-                onClick={() => handleSelect(p.id, disabled)}
+                onClick={() => {
+                  if (!disabled) onNext({ packageId: p.id });
+                }}
               >
                 <div className='flex h-full flex-col gap-3 p-5'>
                   <div className='flex items-center justify-between'>

--- a/apps/frontend/src/components/views/PurchaseCredits/steps/Step1_SelectPackage.tsx
+++ b/apps/frontend/src/components/views/PurchaseCredits/steps/Step1_SelectPackage.tsx
@@ -1,7 +1,10 @@
 'use client';
 
 import { Button, Card, cn } from '@auto-drive/ui';
+import { useContext, useState } from 'react';
+import { SessionContext } from 'next-auth/react';
 import { CreditCurrentPrice } from '../CreditCurrentPrice';
+import { GoogleAuthGate } from '../GoogleAuthGate';
 import { usePrices } from '../../../../hooks/usePrices';
 import { usePaymentIntent } from '../../../../hooks/usePaymentIntent';
 import { useUserStore } from '../../../../globalStates/user';
@@ -65,6 +68,22 @@ export const PurchaseStep1SelectPackage = ({
 
   const { MINIMUM_CONFIRMATIONS } = usePaymentIntent();
 
+  // Purchasing requires a Google-verified account. The screen itself is open to
+  // everyone (so packages are discoverable), but selecting one prompts a Google
+  // sign-in for logged-out and non-Google users.
+  const session = useContext(SessionContext);
+  const isGoogleAuthed = session?.data?.underlyingProvider === 'google';
+  const [authGateOpen, setAuthGateOpen] = useState(false);
+
+  const handleSelect = (packageId: string, disabled: boolean) => {
+    if (disabled) return;
+    if (!isGoogleAuthed) {
+      setAuthGateOpen(true);
+      return;
+    }
+    onNext({ packageId });
+  };
+
   const creditSummary = useUserStore((s) => s.creditSummary);
 
   // Number of days credits are valid — sourced from CREDIT_EXPIRY_DAYS env-var
@@ -104,6 +123,10 @@ export const PurchaseStep1SelectPackage = ({
 
   return (
     <div className='grid grid-cols-1 gap-6 xl:grid-cols-4'>
+      <GoogleAuthGate
+        isOpen={authGateOpen}
+        onClose={() => setAuthGateOpen(false)}
+      />
       <div className='xl:col-span-4'>
         <CreditCurrentPrice />
 
@@ -140,9 +163,7 @@ export const PurchaseStep1SelectPackage = ({
                           : 'hover:ring-2 hover:ring-primary'
                       }`
                 }`}
-                onClick={() => {
-                  if (!disabled) onNext({ packageId: p.id });
-                }}
+                onClick={() => handleSelect(p.id, disabled)}
               >
                 <div className='flex h-full flex-col gap-3 p-5'>
                   <div className='flex items-center justify-between'>

--- a/apps/frontend/src/hooks/useAuth.ts
+++ b/apps/frontend/src/hooks/useAuth.ts
@@ -9,8 +9,13 @@ import { useUserStore } from '@/globalStates/user';
 
 export type AuthProvider = 'google' | 'discord' | 'web3-wallet' | 'github';
 
+interface SignInOptions {
+  /** Where to land after OAuth completes. Defaults to the default drive view. */
+  callbackUrl?: string;
+}
+
 interface UseAuth {
-  signIn: (provider: AuthProvider) => void;
+  signIn: (provider: AuthProvider, options?: SignInOptions) => void;
 }
 
 export const useLogIn = (): UseAuth => {
@@ -20,13 +25,13 @@ export const useLogIn = (): UseAuth => {
   const [isClicked, setIsClicked] = useState<AuthProvider>();
 
   const signIn = useCallback(
-    (provider: AuthProvider) => {
+    (provider: AuthProvider, options?: SignInOptions) => {
       setIsClicked(provider);
       if (provider === 'web3-wallet') {
         if (openConnectModal) openConnectModal();
       } else {
         nextAuthSignIn(provider, {
-          callbackUrl: `/${defaultNetworkId}/drive`,
+          callbackUrl: options?.callbackUrl ?? `/${defaultNetworkId}/drive`,
         });
       }
     },

--- a/apps/frontend/src/services/api.ts
+++ b/apps/frontend/src/services/api.ts
@@ -818,17 +818,18 @@ export const createApiService = ({
     return response.json() as Promise<ExpiringCreditBatch[]>;
   },
   getCreditPrice: async (): Promise<{ price: number; pricePerGB: number }> => {
+    // GET /intents/price is a public endpoint (registered before the auth /
+    // feature-flag middleware). Attach auth headers when a session exists, but
+    // don't require one — this lets the purchase screen show live pricing to
+    // logged-out and non-Google visitors too.
     const session = await getAuthSession();
-    if (!session?.authProvider || !session.accessToken) {
-      throw new Error('No session');
+    const headers: Record<string, string> = {};
+    if (session?.authProvider && session.accessToken) {
+      headers['X-Auth-Provider'] = session.authProvider;
+      headers['Authorization'] = `Bearer ${session.accessToken}`;
     }
 
-    const response = await fetch(`${apiBaseUrl}/intents/price`, {
-      headers: {
-        'X-Auth-Provider': session.authProvider,
-        Authorization: `Bearer ${session.accessToken}`,
-      },
-    });
+    const response = await fetch(`${apiBaseUrl}/intents/price`, { headers });
 
     if (!response.ok) {
       throw new Error(`Network response was not ok: ${response.statusText}`);


### PR DESCRIPTION
## What

Makes the Buy Credits flow discoverable for everyone, while keeping the actual purchase action gated to Google-verified accounts.

### Changes
- **More visible "Buy more credits" button** — switched from `outline` to the filled `primary` variant (`+ font-semibold`). Primary uses the `--primary` / `--primary-foreground` theme variables, so it renders with consistent, intentional colors in both light and dark schemes instead of a low-contrast outline.
- **Purchase screen open to all users** — removed the `UserProtectedLayout` wrapper from `purchase/page.tsx`. That layout was the only thing blocking unauthenticated access (it redirected logged-out users to `/drive/global` and refused to render until a `user` existed). The Next.js middleware does not gate this route — its matcher only covers `/drive/*`, not the chain-prefixed `/[chain]/drive/*`.
- **Live pricing for everyone** — `api.getCreditPrice()` no longer throws `'No session'`. `GET /intents/price` is already a public backend endpoint (registered before the auth/feature-flag middleware), so auth headers are now optional. Logged-out and non-Google visitors see real prices instead of `—` / `$0.00`.
- **Google sign-in gate** — new `GoogleAuthGate` modal. When a logged-out or non-Google user clicks **Select Package** / **Configure**, they get a prompt to sign in or sign up with Google (with a Google sign-in button) instead of advancing. Detection uses `session.underlyingProvider === 'google'`.
- **Sidebar footer** — "Buy more credits" is now always shown, while the existing "Log In" (logged-out) and "Ask for more credits" (non-Google) buttons are preserved.

## Why

So that the credit packages are discoverable by all visitors (driving conversions), with authentication enforced at the point of action rather than by hiding the screen entirely.

## Behavior by user type
- **Google-authenticated:** unchanged — packages work exactly as before.
- **Non-Google authenticated / logged-out:** can browse packages and see pricing; selecting one opens the Google sign-in prompt.

## Reviewer notes
- The gate keys on Google auth specifically (per request). On production where `buyCredits` is publicly active this matches current behavior. Edge case: during a *staff-only* rollout, a non-staff Google user would now pass the UI gate and could reach the final step before the backend rejects intent creation. Easy to additionally gate on the `buyCredits` feature flag if preferred.
- Verified with `tsc --noEmit` and ESLint (both pass) on the changed files. Not exercised in a running browser (local stack not provisioned in this worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Follow-up fixes (review feedback)
- **Gate can't be bypassed via query params:** the Google check moved from the Step 1 click handler into the wizard and is enforced at render (`effectiveStep`), so non-Google users can't reach later steps via `?step=`. The sign-in prompt still fires at the point of action (package click).
- **Sign-in returns to the flow:** `useLogIn().signIn` now accepts a `callbackUrl`; after Google OAuth the user lands back on the purchase page with their package preselected (`…/drive/purchase?step=2&packageId=<id>`) instead of the default drive view.
