### PR TITLE
fix(backend): make object removal hide and block the file everywhere

### DIFF
--- a/apps/backend/__tests__/e2e/objects/objectRemoval.spec.ts
+++ b/apps/backend/__tests__/e2e/objects/objectRemoval.spec.ts
@@ -1,0 +1,230 @@
+import { UserWithOrganization } from '@auto-drive/models'
+import { ObjectUseCases } from '../../../src/core/index.js'
+import {
+  AsyncDownloadsUseCases,
+  DownloadUseCase,
+} from '../../../src/core/downloads/index.js'
+import { dbMigration } from '../../utils/dbMigrate.js'
+import {
+  createMockUser,
+  mockRabbitPublish,
+  unmockMethods,
+} from '../../utils/mocks.js'
+import { uploadFile } from '../../utils/uploads.js'
+import { jest } from '@jest/globals'
+import { ObjectNotFoundError } from '../../../src/errors/index.js'
+
+/**
+ * Verifies the end-to-end behaviour of removing ("Remove" in the UI) a file:
+ * once an owner removes an object it must disappear from every view and stop
+ * being downloadable for everyone (owner, other users, anonymous, S3/SDK),
+ * remaining only in the owner's Trash. Restoring it reverses all of that.
+ */
+describe('Object removal', () => {
+  let owner: UserWithOrganization
+  let fileCid: string
+  // An async download queued while the object was still available — used to
+  // prove the worker refuses to serve it once the owner removes it.
+  let queuedDownloadId: string
+
+  const uploadedMetadata = (cid: string) =>
+    ObjectUseCases.getMetadata(cid).then((e) => e._unsafeUnwrap())
+
+  beforeAll(async () => {
+    mockRabbitPublish()
+    // Keep authorizeDownload off the file-gateway network during tests.
+    jest.spyOn(ObjectUseCases, 'syncingIsObjectBanned').mockResolvedValue(false)
+    await dbMigration.up()
+    owner = createMockUser()
+    fileCid = await uploadFile(owner, 'test.txt', 'test', 'text/plain')
+  })
+
+  afterAll(async () => {
+    unmockMethods()
+    await dbMigration.down()
+  })
+
+  describe('while available (before removal)', () => {
+    it('is not flagged as deleted', async () => {
+      expect(await ObjectUseCases.isObjectDeleted(fileCid)).toBe(false)
+    })
+
+    it('is listed under the owner files', async () => {
+      const summary = await ObjectUseCases.getRootObjects(
+        { scope: 'user', user: owner },
+        100,
+        0,
+      )
+      expect(summary.rows).toMatchObject([{ headCid: fileCid }])
+    })
+
+    it('is visible in the global explorer', async () => {
+      const summary = await ObjectUseCases.getRootObjects({ scope: 'global' })
+      expect(summary.rows).toMatchObject([{ headCid: fileCid }])
+    })
+
+    it('is discoverable by CID via global search', async () => {
+      const search = await ObjectUseCases.searchByCIDOrName(fileCid, 5, {
+        scope: 'global',
+      })
+      expect(search).toMatchObject([{ cid: fileCid }])
+    })
+
+    it('can be downloaded by the owner, by another user and anonymously', async () => {
+      const anotherUser = createMockUser()
+      const byOwner = await DownloadUseCase.downloadObjectByUser(owner, fileCid)
+      const byOther = await DownloadUseCase.downloadObjectByUser(
+        anotherUser,
+        fileCid,
+      )
+      const byAnonymous =
+        await DownloadUseCase.downloadObjectByAnonymous(fileCid)
+      expect(byOwner.isOk()).toBe(true)
+      expect(byOther.isOk()).toBe(true)
+      expect(byAnonymous.isOk()).toBe(true)
+    })
+
+    it('passes download authorization', async () => {
+      const authResult = await ObjectUseCases.authorizeDownload(fileCid)
+      expect(authResult.isOk()).toBe(true)
+    })
+
+    it('can have an async download queued', async () => {
+      const result = await AsyncDownloadsUseCases.createDownload(owner, fileCid)
+      expect(result.isOk()).toBe(true)
+      queuedDownloadId = result._unsafeUnwrap().id
+    })
+  })
+
+  describe('after the owner removes it', () => {
+    beforeAll(async () => {
+      const result = await ObjectUseCases.markAsDeleted(owner, fileCid)
+      expect(result.isOk()).toBe(true)
+    })
+
+    it('is flagged as deleted', async () => {
+      expect(await ObjectUseCases.isObjectDeleted(fileCid)).toBe(true)
+    })
+
+    it('no longer appears under the owner files', async () => {
+      const summary = await ObjectUseCases.getRootObjects(
+        { scope: 'user', user: owner },
+        100,
+        0,
+      )
+      expect(summary.rows).toMatchObject([])
+    })
+
+    it('is visible to the owner in Trash', async () => {
+      const deleted = await ObjectUseCases.getMarkedAsDeletedRoots(owner)
+      expect(deleted.rows).toMatchObject([{ headCid: fileCid }])
+    })
+
+    it('is no longer visible in the global explorer', async () => {
+      const summary = await ObjectUseCases.getRootObjects({ scope: 'global' })
+      expect(summary.rows).toMatchObject([])
+    })
+
+    it('can no longer be found by CID or name via global search', async () => {
+      const metadata = await uploadedMetadata(fileCid)
+      const byCid = await ObjectUseCases.searchByCIDOrName(fileCid, 5, {
+        scope: 'global',
+      })
+      const byName = await ObjectUseCases.searchMetadataByName(
+        metadata.name!,
+        5,
+        { scope: 'global' },
+      )
+      expect(byCid).toMatchObject([])
+      expect(byName).toMatchObject([])
+    })
+
+    it('fails download authorization with object-not-found', async () => {
+      const authResult = await ObjectUseCases.authorizeDownload(fileCid)
+      expect(authResult.isErr()).toBe(true)
+      expect(authResult._unsafeUnwrapErr()).toBeInstanceOf(ObjectNotFoundError)
+    })
+
+    it('cannot be downloaded by anyone (owner / other user / anonymous)', async () => {
+      const anotherUser = createMockUser()
+      const byOwner = await DownloadUseCase.downloadObjectByUser(owner, fileCid)
+      const byOther = await DownloadUseCase.downloadObjectByUser(
+        anotherUser,
+        fileCid,
+      )
+      const byAnonymous =
+        await DownloadUseCase.downloadObjectByAnonymous(fileCid)
+
+      expect(byOwner.isErr()).toBe(true)
+      expect(byOwner._unsafeUnwrapErr()).toBeInstanceOf(ObjectNotFoundError)
+      expect(byOther.isErr()).toBe(true)
+      expect(byOther._unsafeUnwrapErr()).toBeInstanceOf(ObjectNotFoundError)
+      expect(byAnonymous.isErr()).toBe(true)
+      expect(byAnonymous._unsafeUnwrapErr()).toBeInstanceOf(ObjectNotFoundError)
+    })
+
+    it('cannot have a new async download queued', async () => {
+      const result = await AsyncDownloadsUseCases.createDownload(owner, fileCid)
+      expect(result.isErr()).toBe(true)
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(ObjectNotFoundError)
+    })
+
+    it('is not served by a download queued before removal', async () => {
+      const result =
+        await AsyncDownloadsUseCases.asyncDownload(queuedDownloadId)
+      expect(result.isErr()).toBe(true)
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(ObjectNotFoundError)
+    })
+  })
+
+  describe('after the owner restores it', () => {
+    beforeAll(async () => {
+      const result = await ObjectUseCases.restoreObject(owner, fileCid)
+      expect(result.isOk()).toBe(true)
+    })
+
+    it('is no longer flagged as deleted', async () => {
+      expect(await ObjectUseCases.isObjectDeleted(fileCid)).toBe(false)
+    })
+
+    it('is no longer in Trash', async () => {
+      const deleted = await ObjectUseCases.getMarkedAsDeletedRoots(owner)
+      expect(deleted.rows).toMatchObject([])
+    })
+
+    it('is listed under the owner files again', async () => {
+      const summary = await ObjectUseCases.getRootObjects(
+        { scope: 'user', user: owner },
+        100,
+        0,
+      )
+      expect(summary.rows).toMatchObject([{ headCid: fileCid }])
+    })
+
+    it('is visible in the global explorer again', async () => {
+      const summary = await ObjectUseCases.getRootObjects({ scope: 'global' })
+      expect(summary.rows).toMatchObject([{ headCid: fileCid }])
+    })
+
+    it('is discoverable by CID via global search again', async () => {
+      const search = await ObjectUseCases.searchByCIDOrName(fileCid, 5, {
+        scope: 'global',
+      })
+      expect(search).toMatchObject([{ cid: fileCid }])
+    })
+
+    it('can be downloaded by anyone again', async () => {
+      const anotherUser = createMockUser()
+      const byOwner = await DownloadUseCase.downloadObjectByUser(owner, fileCid)
+      const byOther = await DownloadUseCase.downloadObjectByUser(
+        anotherUser,
+        fileCid,
+      )
+      const byAnonymous =
+        await DownloadUseCase.downloadObjectByAnonymous(fileCid)
+      expect(byOwner.isOk()).toBe(true)
+      expect(byOther.isOk()).toBe(true)
+      expect(byAnonymous.isOk()).toBe(true)
+    })
+  })
+})

--- a/apps/backend/__tests__/e2e/objects/objectRemoval.spec.ts
+++ b/apps/backend/__tests__/e2e/objects/objectRemoval.spec.ts
@@ -23,9 +23,11 @@ import { AuthManager } from '../../../src/infrastructure/services/auth/index.js'
 const S3_BUCKET = 'removal-bucket'
 const S3_KEY = 'dir/removed.txt'
 
-const listS3Keys = async (): Promise<string[]> => {
+const FOLDER_S3_BUCKET = 'folder-removal-bucket'
+
+const listS3Keys = async (bucket: string = S3_BUCKET): Promise<string[]> => {
   const result = await S3UseCases.listObjects({
-    bucket: S3_BUCKET,
+    bucket,
     prefix: '',
     delimiter: null,
     maxKeys: 1000,
@@ -326,6 +328,9 @@ describe('Folder removal hides child files', () => {
   let owner: UserWithOrganization
   let folderCid: string
   let childCids: Record<string, string>
+  // S3 key -> child CID, so we can assert each child's S3 surface tracks the
+  // folder's removal/restore even though removal only touches the folder root.
+  let childKeys: Record<string, string>
 
   const childCidList = () => Object.values(childCids)
 
@@ -340,12 +345,29 @@ describe('Folder removal hides child files', () => {
     ])
     folderCid = result.folderCid
     childCids = result.childCids
+
+    // Expose each child file over the S3 API so we can prove S3 list gating
+    // resolves a child mapping to its (removed) folder root, not the child's
+    // own vestigial active admin ownership.
+    childKeys = {}
+    for (const [name, cid] of Object.entries(childCids)) {
+      const key = `folder/${name}`
+      childKeys[key] = cid
+      await s3ObjectMappingsRepository.createMapping(
+        FOLDER_S3_BUCKET,
+        key,
+        cid,
+        null,
+      )
+    }
   })
 
   afterAll(async () => {
     unmockMethods()
     await dbMigration.down()
   })
+
+  const childKeyList = () => Object.keys(childKeys)
 
   it('grants each child its own active admin ownership (precondition)', async () => {
     for (const childCid of childCidList()) {
@@ -365,6 +387,22 @@ describe('Folder removal hides child files', () => {
       expect(auth.isOk()).toBe(true)
       const download = await DownloadUseCase.downloadObjectByAnonymous(childCid)
       expect(download.isOk()).toBe(true)
+    }
+  })
+
+  it('children are discoverable by CID via global search while available', async () => {
+    for (const childCid of childCidList()) {
+      const search = await ObjectUseCases.searchByCIDOrName(childCid, 5, {
+        scope: 'global',
+      })
+      expect(search).toMatchObject([{ cid: childCid }])
+    }
+  })
+
+  it('children are listed over the S3 API while available', async () => {
+    const keys = await listS3Keys(FOLDER_S3_BUCKET)
+    for (const key of childKeyList()) {
+      expect(keys).toContain(key)
     }
   })
 
@@ -416,6 +454,26 @@ describe('Folder removal hides child files', () => {
         expect(result._unsafeUnwrapErr()).toBeInstanceOf(ObjectNotFoundError)
       }
     })
+
+    it('hides every child from global CID and name search', async () => {
+      for (const [name, childCid] of Object.entries(childCids)) {
+        const byCid = await ObjectUseCases.searchByCIDOrName(childCid, 5, {
+          scope: 'global',
+        })
+        const byName = await ObjectUseCases.searchMetadataByName(name, 5, {
+          scope: 'global',
+        })
+        expect(byCid).toMatchObject([])
+        expect(byName).toMatchObject([])
+      }
+    })
+
+    it('hides every child from the S3 listing', async () => {
+      const keys = await listS3Keys(FOLDER_S3_BUCKET)
+      for (const key of childKeyList()) {
+        expect(keys).not.toContain(key)
+      }
+    })
   })
 
   describe('after the owner restores the folder', () => {
@@ -438,6 +496,22 @@ describe('Folder removal hides child files', () => {
         const download =
           await DownloadUseCase.downloadObjectByAnonymous(childCid)
         expect(download.isOk()).toBe(true)
+      }
+    })
+
+    it('makes every child discoverable by CID via global search again', async () => {
+      for (const childCid of childCidList()) {
+        const search = await ObjectUseCases.searchByCIDOrName(childCid, 5, {
+          scope: 'global',
+        })
+        expect(search).toMatchObject([{ cid: childCid }])
+      }
+    })
+
+    it('lists every child over the S3 API again', async () => {
+      const keys = await listS3Keys(FOLDER_S3_BUCKET)
+      for (const key of childKeyList()) {
+        expect(keys).toContain(key)
       }
     })
   })

--- a/apps/backend/__tests__/e2e/objects/objectRemoval.spec.ts
+++ b/apps/backend/__tests__/e2e/objects/objectRemoval.spec.ts
@@ -15,6 +15,7 @@ import {
 import { uploadFile } from '../../utils/uploads.js'
 import { jest } from '@jest/globals'
 import { ObjectNotFoundError } from '../../../src/errors/index.js'
+import { AuthManager } from '../../../src/infrastructure/services/auth/index.js'
 
 const S3_BUCKET = 'removal-bucket'
 const S3_KEY = 'dir/removed.txt'
@@ -38,6 +39,10 @@ const listS3Keys = async (): Promise<string[]> => {
  */
 describe('Object removal', () => {
   let owner: UserWithOrganization
+  // A user the owner shared the file with. Their (non-admin) share row stays
+  // active after the owner removes the file globally, so it guards against the
+  // share listing leaking objects the owner has trashed.
+  let sharedWith: UserWithOrganization
   let fileCid: string
   // An async download queued while the object was still available — used to
   // prove the worker refuses to serve it once the owner removes it.
@@ -52,6 +57,7 @@ describe('Object removal', () => {
     jest.spyOn(ObjectUseCases, 'syncingIsObjectBanned').mockResolvedValue(false)
     await dbMigration.up()
     owner = createMockUser()
+    sharedWith = createMockUser()
     fileCid = await uploadFile(owner, 'test.txt', 'test', 'text/plain')
     // Expose the same file over the S3 API so we can prove the S3 surface
     // (list + get) honours removal/restore in lockstep with the file, without
@@ -62,6 +68,14 @@ describe('Object removal', () => {
       fileCid,
       null,
     )
+    // Share the file with another user so the share-listing surface is covered.
+    jest.spyOn(AuthManager, 'getUserFromPublicId').mockResolvedValue(sharedWith)
+    const shareResult = await ObjectUseCases.shareObject(
+      owner,
+      fileCid,
+      sharedWith.publicId!,
+    )
+    expect(shareResult.isOk()).toBe(true)
   })
 
   afterAll(async () => {
@@ -127,6 +141,11 @@ describe('Object removal', () => {
         Key: S3_KEY,
       })
       expect(getResult.isOk()).toBe(true)
+    })
+
+    it('is listed under the share recipient files', async () => {
+      const shared = await ObjectUseCases.getSharedRoots(sharedWith)
+      expect(shared.rows).toMatchObject([{ headCid: fileCid }])
     })
   })
 
@@ -219,6 +238,11 @@ describe('Object removal', () => {
       expect(getResult.isErr()).toBe(true)
       expect(getResult._unsafeUnwrapErr()).toBeInstanceOf(ObjectNotFoundError)
     })
+
+    it('no longer appears under the share recipient files', async () => {
+      const shared = await ObjectUseCases.getSharedRoots(sharedWith)
+      expect(shared.rows).toMatchObject([])
+    })
   })
 
   describe('after the owner restores it', () => {
@@ -278,6 +302,11 @@ describe('Object removal', () => {
         Key: S3_KEY,
       })
       expect(getResult.isOk()).toBe(true)
+    })
+
+    it('is listed under the share recipient files again', async () => {
+      const shared = await ObjectUseCases.getSharedRoots(sharedWith)
+      expect(shared.rows).toMatchObject([{ headCid: fileCid }])
     })
   })
 })

--- a/apps/backend/__tests__/e2e/objects/objectRemoval.spec.ts
+++ b/apps/backend/__tests__/e2e/objects/objectRemoval.spec.ts
@@ -4,6 +4,8 @@ import {
   AsyncDownloadsUseCases,
   DownloadUseCase,
 } from '../../../src/core/downloads/index.js'
+import { S3UseCases } from '../../../src/core/s3/index.js'
+import { s3ObjectMappingsRepository } from '../../../src/infrastructure/repositories/index.js'
 import { dbMigration } from '../../utils/dbMigrate.js'
 import {
   createMockUser,
@@ -13,6 +15,20 @@ import {
 import { uploadFile } from '../../utils/uploads.js'
 import { jest } from '@jest/globals'
 import { ObjectNotFoundError } from '../../../src/errors/index.js'
+
+const S3_BUCKET = 'removal-bucket'
+const S3_KEY = 'dir/removed.txt'
+
+const listS3Keys = async (): Promise<string[]> => {
+  const result = await S3UseCases.listObjects({
+    bucket: S3_BUCKET,
+    prefix: '',
+    delimiter: null,
+    maxKeys: 1000,
+    continuationToken: null,
+  })
+  return result.objects.map((o) => o.key)
+}
 
 /**
  * Verifies the end-to-end behaviour of removing ("Remove" in the UI) a file:
@@ -37,6 +53,15 @@ describe('Object removal', () => {
     await dbMigration.up()
     owner = createMockUser()
     fileCid = await uploadFile(owner, 'test.txt', 'test', 'text/plain')
+    // Expose the same file over the S3 API so we can prove the S3 surface
+    // (list + get) honours removal/restore in lockstep with the file, without
+    // adding a second object that would perturb the global/owner listings.
+    await s3ObjectMappingsRepository.createMapping(
+      S3_BUCKET,
+      S3_KEY,
+      fileCid,
+      null,
+    )
   })
 
   afterAll(async () => {
@@ -93,6 +118,15 @@ describe('Object removal', () => {
       const result = await AsyncDownloadsUseCases.createDownload(owner, fileCid)
       expect(result.isOk()).toBe(true)
       queuedDownloadId = result._unsafeUnwrap().id
+    })
+
+    it('is listed and retrievable over the S3 API (rclone/aws-cli)', async () => {
+      expect(await listS3Keys()).toContain(S3_KEY)
+      const getResult = await S3UseCases.getObject({
+        Bucket: S3_BUCKET,
+        Key: S3_KEY,
+      })
+      expect(getResult.isOk()).toBe(true)
     })
   })
 
@@ -175,6 +209,16 @@ describe('Object removal', () => {
       expect(result.isErr()).toBe(true)
       expect(result._unsafeUnwrapErr()).toBeInstanceOf(ObjectNotFoundError)
     })
+
+    it('is hidden from S3 listing and not retrievable over S3', async () => {
+      expect(await listS3Keys()).not.toContain(S3_KEY)
+      const getResult = await S3UseCases.getObject({
+        Bucket: S3_BUCKET,
+        Key: S3_KEY,
+      })
+      expect(getResult.isErr()).toBe(true)
+      expect(getResult._unsafeUnwrapErr()).toBeInstanceOf(ObjectNotFoundError)
+    })
   })
 
   describe('after the owner restores it', () => {
@@ -225,6 +269,15 @@ describe('Object removal', () => {
       expect(byOwner.isOk()).toBe(true)
       expect(byOther.isOk()).toBe(true)
       expect(byAnonymous.isOk()).toBe(true)
+    })
+
+    it('is listed and retrievable over the S3 API again', async () => {
+      expect(await listS3Keys()).toContain(S3_KEY)
+      const getResult = await S3UseCases.getObject({
+        Bucket: S3_BUCKET,
+        Key: S3_KEY,
+      })
+      expect(getResult.isOk()).toBe(true)
     })
   })
 })

--- a/apps/backend/__tests__/e2e/objects/objectRemoval.spec.ts
+++ b/apps/backend/__tests__/e2e/objects/objectRemoval.spec.ts
@@ -5,14 +5,17 @@ import {
   DownloadUseCase,
 } from '../../../src/core/downloads/index.js'
 import { S3UseCases } from '../../../src/core/s3/index.js'
-import { s3ObjectMappingsRepository } from '../../../src/infrastructure/repositories/index.js'
+import {
+  ownershipRepository,
+  s3ObjectMappingsRepository,
+} from '../../../src/infrastructure/repositories/index.js'
 import { dbMigration } from '../../utils/dbMigrate.js'
 import {
   createMockUser,
   mockRabbitPublish,
   unmockMethods,
 } from '../../utils/mocks.js'
-import { uploadFile } from '../../utils/uploads.js'
+import { uploadFile, uploadFolder } from '../../utils/uploads.js'
 import { jest } from '@jest/globals'
 import { ObjectNotFoundError } from '../../../src/errors/index.js'
 import { AuthManager } from '../../../src/infrastructure/services/auth/index.js'
@@ -307,6 +310,135 @@ describe('Object removal', () => {
     it('is listed under the share recipient files again', async () => {
       const shared = await ObjectUseCases.getSharedRoots(sharedWith)
       expect(shared.rows).toMatchObject([{ headCid: fileCid }])
+    })
+  })
+})
+
+/**
+ * Removal is tracked per root upload, but every child file of a folder also
+ * gets its own active admin ownership row during finalization. Removing the
+ * folder only marks the folder root as deleted, so a naive deleted-check that
+ * inspects a child CID's own ownership would keep the child downloadable. These
+ * tests pin the behaviour that children of a removed folder become undownloadable
+ * (and reappear on restore), driven entirely through the folder root CID.
+ */
+describe('Folder removal hides child files', () => {
+  let owner: UserWithOrganization
+  let folderCid: string
+  let childCids: Record<string, string>
+
+  const childCidList = () => Object.values(childCids)
+
+  beforeAll(async () => {
+    mockRabbitPublish()
+    jest.spyOn(ObjectUseCases, 'syncingIsObjectBanned').mockResolvedValue(false)
+    await dbMigration.up()
+    owner = createMockUser()
+    const result = await uploadFolder(owner, 'folder', [
+      { name: 'a.txt', content: 'alpha', mimeType: 'text/plain' },
+      { name: 'b.txt', content: 'beta', mimeType: 'text/plain' },
+    ])
+    folderCid = result.folderCid
+    childCids = result.childCids
+  })
+
+  afterAll(async () => {
+    unmockMethods()
+    await dbMigration.down()
+  })
+
+  it('grants each child its own active admin ownership (precondition)', async () => {
+    for (const childCid of childCidList()) {
+      const { totalAdmins, activeAdmins } =
+        await ownershipRepository.getAdminOwnershipState(childCid)
+      // sanity: the child is reachable via an active root before removal
+      expect(totalAdmins).toBeGreaterThan(0)
+      expect(activeAdmins).toBeGreaterThan(0)
+    }
+  })
+
+  it('children are downloadable while the folder is available', async () => {
+    expect(await ObjectUseCases.isObjectDeleted(folderCid)).toBe(false)
+    for (const childCid of childCidList()) {
+      expect(await ObjectUseCases.isObjectDeleted(childCid)).toBe(false)
+      const auth = await ObjectUseCases.authorizeDownload(childCid)
+      expect(auth.isOk()).toBe(true)
+      const download = await DownloadUseCase.downloadObjectByAnonymous(childCid)
+      expect(download.isOk()).toBe(true)
+    }
+  })
+
+  describe('after the owner removes the folder', () => {
+    beforeAll(async () => {
+      const result = await ObjectUseCases.markAsDeleted(owner, folderCid)
+      expect(result.isOk()).toBe(true)
+    })
+
+    it('flags both the folder and every child as deleted', async () => {
+      expect(await ObjectUseCases.isObjectDeleted(folderCid)).toBe(true)
+      for (const childCid of childCidList()) {
+        expect(await ObjectUseCases.isObjectDeleted(childCid)).toBe(true)
+      }
+    })
+
+    it('blocks download authorization for every child', async () => {
+      for (const childCid of childCidList()) {
+        const auth = await ObjectUseCases.authorizeDownload(childCid)
+        expect(auth.isErr()).toBe(true)
+        expect(auth._unsafeUnwrapErr()).toBeInstanceOf(ObjectNotFoundError)
+      }
+    })
+
+    it('refuses to serve any child to anyone (owner / anonymous)', async () => {
+      for (const childCid of childCidList()) {
+        const byOwner = await DownloadUseCase.downloadObjectByUser(
+          owner,
+          childCid,
+        )
+        const byAnonymous =
+          await DownloadUseCase.downloadObjectByAnonymous(childCid)
+        expect(byOwner.isErr()).toBe(true)
+        expect(byOwner._unsafeUnwrapErr()).toBeInstanceOf(ObjectNotFoundError)
+        expect(byAnonymous.isErr()).toBe(true)
+        expect(byAnonymous._unsafeUnwrapErr()).toBeInstanceOf(
+          ObjectNotFoundError,
+        )
+      }
+    })
+
+    it('refuses to queue an async download for a child', async () => {
+      for (const childCid of childCidList()) {
+        const result = await AsyncDownloadsUseCases.createDownload(
+          owner,
+          childCid,
+        )
+        expect(result.isErr()).toBe(true)
+        expect(result._unsafeUnwrapErr()).toBeInstanceOf(ObjectNotFoundError)
+      }
+    })
+  })
+
+  describe('after the owner restores the folder', () => {
+    beforeAll(async () => {
+      const result = await ObjectUseCases.restoreObject(owner, folderCid)
+      expect(result.isOk()).toBe(true)
+    })
+
+    it('clears the deleted flag for the folder and every child', async () => {
+      expect(await ObjectUseCases.isObjectDeleted(folderCid)).toBe(false)
+      for (const childCid of childCidList()) {
+        expect(await ObjectUseCases.isObjectDeleted(childCid)).toBe(false)
+      }
+    })
+
+    it('makes every child downloadable again', async () => {
+      for (const childCid of childCidList()) {
+        const auth = await ObjectUseCases.authorizeDownload(childCid)
+        expect(auth.isOk()).toBe(true)
+        const download =
+          await DownloadUseCase.downloadObjectByAnonymous(childCid)
+        expect(download.isOk()).toBe(true)
+      }
     })
   })
 })

--- a/apps/backend/__tests__/unit/repositories/metadata.spec.ts
+++ b/apps/backend/__tests__/unit/repositories/metadata.spec.ts
@@ -252,6 +252,13 @@ describe('Metadata Repository', () => {
       name: 'very-specific-name-for-search',
     }
 
+    // Global name search only returns objects with an active admin owner, so
+    // an orphaned metadata row is intentionally hidden. Give it an owner.
+    await ownershipRepository.setUserAsAdmin(
+      headCid,
+      'test-provider',
+      'test-user-id',
+    )
     await metadataRepository.setMetadata(rootCid, headCid, metadata)
 
     const results = await metadataRepository.searchMetadataByName(

--- a/apps/backend/__tests__/utils/uploads.ts
+++ b/apps/backend/__tests__/utils/uploads.ts
@@ -1,4 +1,4 @@
-import { UserWithOrganization } from '@auto-drive/models'
+import { FolderTreeFolder, UserWithOrganization } from '@auto-drive/models'
 import { UploadsUseCases } from '../../src/core/uploads/uploads.js'
 import { PreconditionError } from './error.js'
 
@@ -32,4 +32,75 @@ export const uploadFile = async (
   )
 
   return cid
+}
+
+/**
+ * Uploads a flat folder (a single directory containing the given files) and
+ * returns the folder root CID alongside each child file CID. Mirrors the real
+ * finalization flow so every child file ends up with its own admin ownership
+ * row while removal only targets the folder root.
+ */
+export const uploadFolder = async (
+  user: UserWithOrganization,
+  folderName: string,
+  files: { name: string; content: Buffer | string; mimeType: string }[],
+): Promise<{ folderCid: string; childCids: Record<string, string> }> => {
+  const fileTree: FolderTreeFolder = {
+    name: folderName,
+    type: 'folder',
+    id: folderName,
+    children: files.map((file) => ({
+      type: 'file',
+      name: file.name,
+      id: file.name,
+    })),
+  }
+
+  const folderUpload = await UploadsUseCases.createFolderUpload(
+    user,
+    folderName,
+    fileTree,
+    null,
+  )
+  if (!folderUpload) {
+    throw new PreconditionError('Failed to create folder upload')
+  }
+
+  const childCids: Record<string, string> = {}
+  for (const file of files) {
+    const fileUpload = await UploadsUseCases.createFileInFolder(
+      user,
+      folderUpload.id,
+      file.name,
+      file.name,
+      file.mimeType,
+    )
+
+    const content =
+      typeof file.content === 'string'
+        ? Buffer.from(file.content)
+        : file.content
+
+    await UploadsUseCases.uploadChunk(user, fileUpload.id, 0, content).catch(
+      () => {
+        throw new PreconditionError('Failed to upload folder file chunk')
+      },
+    )
+
+    childCids[file.name] = await UploadsUseCases.completeUpload(
+      user,
+      fileUpload.id,
+    ).catch(() => {
+      throw new PreconditionError('Failed to complete folder file upload')
+    })
+  }
+
+  const folderCid = await UploadsUseCases.completeUpload(
+    user,
+    folderUpload.id,
+  ).catch(() => {
+    throw new PreconditionError('Failed to complete folder upload')
+  })
+
+  return { folderCid, childCids }
 }

--- a/apps/backend/src/app/controllers/object.ts
+++ b/apps/backend/src/app/controllers/object.ts
@@ -223,6 +223,14 @@ objectController.get(
       return
     }
 
+    // A removed object must not be discoverable by its CID.
+    if (await ObjectUseCases.isObjectDeleted(cid)) {
+      res.status(404).json({
+        error: `Object with cid=${cid} not found`,
+      })
+      return
+    }
+
     res.json(statusResult.value)
   }),
 )

--- a/apps/backend/src/app/controllers/object.ts
+++ b/apps/backend/src/app/controllers/object.ts
@@ -168,7 +168,7 @@ objectController.get(
     }
 
     const summary = summaryResult.value
-    if (!summary) {
+    if (!summary || (await ObjectUseCases.isObjectDeleted(cid))) {
       res.status(404).json({
         error: 'Metadata not found',
       })
@@ -191,6 +191,14 @@ objectController.get(
 
     if (metadataResult.isErr()) {
       handleError(metadataResult.error, res)
+      return
+    }
+
+    // A removed object must not be discoverable by its CID.
+    if (await ObjectUseCases.isObjectDeleted(cid)) {
+      res.status(404).json({
+        error: `Object with cid=${cid} not found`,
+      })
       return
     }
 
@@ -315,7 +323,7 @@ objectController.get(
     }
 
     const objectInformation = objectResult.value
-    if (!objectInformation) {
+    if (!objectInformation || (await ObjectUseCases.isObjectDeleted(cid))) {
       res.status(404).json({
         error: 'Object not found',
       })

--- a/apps/backend/src/core/downloads/async.ts
+++ b/apps/backend/src/core/downloads/async.ts
@@ -25,6 +25,11 @@ const createDownload = async (
   }
   const metadata = result.value
 
+  // Don't let anyone queue a download for an object removed by its owner.
+  if (await ObjectUseCases.isObjectDeleted(cid)) {
+    return err(new ObjectNotFoundError(`Object with cid=${cid} not found`))
+  }
+
   const download = await asyncDownloadsRepository.createDownload(
     v4(),
     user.oauthProvider,
@@ -138,6 +143,14 @@ const asyncDownload = async (
   const metadata = await ObjectUseCases.getMetadata(download.cid)
   if (metadata.isErr()) {
     return err(metadata.error)
+  }
+
+  // The object may have been removed by its owner after the download was
+  // queued — stop here so removed objects are never served.
+  if (await ObjectUseCases.isObjectDeleted(download.cid)) {
+    return err(
+      new ObjectNotFoundError(`Object with cid=${download.cid} not found`),
+    )
   }
 
   logger.info('Starting async download id=%s cid=%s', downloadId, download.cid)

--- a/apps/backend/src/core/objects/object.ts
+++ b/apps/backend/src/core/objects/object.ts
@@ -368,12 +368,20 @@ const restoreObject = async (
 }
 
 /**
- * An object is considered deleted (removed by its owner) once it has at least
- * one admin/owner ownership but none of them are still active — i.e. every
- * owner has moved it to their Trash. Shared (non-admin) viewers removing the
- * object from their own view does not delete it globally; restoring it by the
- * owner reverses this. A cid with no admin ownership at all (e.g. an internal
- * child node) is never treated as deleted, so legitimate access is unaffected.
+ * An object is considered deleted (removed by its owner) once the root
+ * object(s) containing it have at least one admin/owner ownership but none
+ * that is still active — i.e. every owner has moved it to their Trash.
+ *
+ * Removal is tracked per root upload: removing a folder only marks the folder
+ * root's ownership as deleted, while each child file keeps its own active admin
+ * row from upload finalization. We therefore resolve the cid to its root
+ * object(s) (see getAdminOwnershipState) instead of inspecting the cid's own
+ * ownership, so children of a trashed folder are correctly reported as deleted.
+ *
+ * Shared (non-admin) viewers removing the object from their own view does not
+ * delete it globally; restoring it by the owner reverses this. A cid that no
+ * admin-owned root references (e.g. an internal child node) is never treated as
+ * deleted, so legitimate access is unaffected.
  */
 const isObjectDeleted = async (cid: string): Promise<boolean> => {
   const { totalAdmins, activeAdmins } =

--- a/apps/backend/src/core/objects/object.ts
+++ b/apps/backend/src/core/objects/object.ts
@@ -367,6 +367,21 @@ const restoreObject = async (
   return ok()
 }
 
+/**
+ * An object is considered deleted (removed by its owner) once it has at least
+ * one admin/owner ownership but none of them are still active — i.e. every
+ * owner has moved it to their Trash. Shared (non-admin) viewers removing the
+ * object from their own view does not delete it globally; restoring it by the
+ * owner reverses this. A cid with no admin ownership at all (e.g. an internal
+ * child node) is never treated as deleted, so legitimate access is unaffected.
+ */
+const isObjectDeleted = async (cid: string): Promise<boolean> => {
+  const { totalAdmins, activeAdmins } =
+    await ownershipRepository.getAdminOwnershipState(cid)
+
+  return totalAdmins > 0 && activeAdmins === 0
+}
+
 const isArchived = async (cid: string) => {
   const metadata = await metadataRepository.getMetadata(cid)
   if (!metadata) {
@@ -727,6 +742,14 @@ const authorizeDownload = async (
     return err(new ObjectNotFoundError('Object not found'))
   }
 
+  // Objects removed by their owner must not be downloadable by anyone (the
+  // owner can still restore them from Trash). Treat them as not found so we
+  // don't leak their existence.
+  if (await ObjectUseCases.isObjectDeleted(cid)) {
+    logger.info('Download blocked for deleted object (cid=%s)', cid)
+    return err(new ObjectNotFoundError('Object not found'))
+  }
+
   if (metadata.tags?.includes(ObjectTag.Banned)) {
     return err(new IllegalContentError('Object is banned'))
   }
@@ -773,6 +796,7 @@ export const ObjectUseCases = {
   getMarkedAsDeletedRoots,
   markAsDeleted,
   restoreObject,
+  isObjectDeleted,
   getObjectSummaryByCID,
   isArchived,
   hasAllNodesArchived,

--- a/apps/backend/src/infrastructure/repositories/objects/metadata.ts
+++ b/apps/backend/src/infrastructure/repositories/objects/metadata.ts
@@ -51,7 +51,12 @@ const searchMetadataByCID = async (
 
   return db
     .query<MetadataEntry>({
-      text: 'SELECT metadata.* FROM metadata join object_ownership on metadata.head_cid = object_ownership.cid WHERE metadata.head_cid LIKE $1 LIMIT $2',
+      text: `SELECT DISTINCT metadata.* FROM metadata
+        JOIN object_ownership ON metadata.head_cid = object_ownership.cid
+        WHERE metadata.head_cid LIKE $1
+        AND object_ownership.is_admin IS TRUE
+        AND object_ownership.marked_as_deleted IS NULL
+        LIMIT $2`,
       values: [`%${cid}%`, limit],
     })
     .then((entries) => entries.rows)
@@ -111,8 +116,12 @@ const searchMetadataByName = async (query: string, limit: number) => {
 
   return db
     .query<MetadataEntry>({
-      // eslint-disable-next-line quotes
-      text: `SELECT * FROM metadata WHERE metadata->>'name' ILIKE $1 LIMIT $2`,
+      text: `SELECT DISTINCT m.* FROM metadata m
+        JOIN object_ownership oo ON m.head_cid = oo.cid
+        WHERE m.metadata->>'name' ILIKE $1
+        AND oo.is_admin IS TRUE
+        AND oo.marked_as_deleted IS NULL
+        LIMIT $2`,
       values: [`%${query}%`, limit],
     })
     .then((entries) => entries.rows)
@@ -151,8 +160,9 @@ const getRootObjects = async (
       )
       SELECT root_objects.head_cid, COUNT(*) OVER() AS total_count
       FROM root_objects
-      INNER JOIN object_ownership oo ON root_objects.head_cid = oo.cid 
-      WHERE oo.marked_as_deleted IS NULL 
+      INNER JOIN object_ownership oo ON root_objects.head_cid = oo.cid
+      WHERE oo.is_admin IS TRUE
+      AND oo.marked_as_deleted IS NULL
       GROUP BY root_objects.head_cid
       LIMIT $1 OFFSET $2`,
       values: [limit, offset],

--- a/apps/backend/src/infrastructure/repositories/objects/metadata.ts
+++ b/apps/backend/src/infrastructure/repositories/objects/metadata.ts
@@ -222,6 +222,16 @@ const getSharedRootObjectsByUser = async (
           AND oo.oauth_user_id = $2 
           AND oo.is_admin IS FALSE 
           AND oo.marked_as_deleted IS NULL 
+          -- Hide shares whose owner has removed the object globally. The
+          -- recipient's own (non-admin) row stays active, so we must also
+          -- require a still-active admin owner, mirroring the GetSharedFiles
+          -- GraphQL filter and ObjectUseCases.isObjectDeleted.
+          AND EXISTS (
+            SELECT 1 FROM object_ownership admin_oo
+            WHERE admin_oo.cid = m.root_cid
+              AND admin_oo.is_admin IS TRUE
+              AND admin_oo.marked_as_deleted IS NULL
+          )
         LIMIT $3 OFFSET $4`,
       values: [provider, userId, limit, offset],
     })

--- a/apps/backend/src/infrastructure/repositories/objects/metadata.ts
+++ b/apps/backend/src/infrastructure/repositories/objects/metadata.ts
@@ -2,6 +2,7 @@ import { OffchainMetadata } from '@autonomys/auto-dag-data'
 import { getDatabase } from '../../drivers/pg.js'
 import { PaginatedResult } from '@auto-drive/models'
 import { stringify } from '../../../shared/utils/misc.js'
+import { ownershipSQL } from './ownership.js'
 
 export interface MetadataEntry {
   root_cid: string
@@ -51,11 +52,14 @@ const searchMetadataByCID = async (
 
   return db
     .query<MetadataEntry>({
+      // Hide objects an owner has removed (moved to Trash). Removal is tracked
+      // on the root upload's ownership row, so we must resolve each match to its
+      // root before checking admin ownership — otherwise children of a removed
+      // folder (which keep vestigial active admin rows) would still surface.
+      // Mirrors ObjectUseCases.isObjectDeleted.
       text: `SELECT DISTINCT metadata.* FROM metadata
-        JOIN object_ownership ON metadata.head_cid = object_ownership.cid
         WHERE metadata.head_cid LIKE $1
-        AND object_ownership.is_admin IS TRUE
-        AND object_ownership.marked_as_deleted IS NULL
+        AND ${ownershipSQL.notRemovedByOwnerSQL('metadata.head_cid')}
         LIMIT $2`,
       values: [`%${cid}%`, limit],
     })
@@ -116,11 +120,11 @@ const searchMetadataByName = async (query: string, limit: number) => {
 
   return db
     .query<MetadataEntry>({
+      // See searchMetadataByCID: resolve each match to its root before applying
+      // the removal filter so children of a removed folder stay hidden.
       text: `SELECT DISTINCT m.* FROM metadata m
-        JOIN object_ownership oo ON m.head_cid = oo.cid
         WHERE m.metadata->>'name' ILIKE $1
-        AND oo.is_admin IS TRUE
-        AND oo.marked_as_deleted IS NULL
+        AND ${ownershipSQL.notRemovedByOwnerSQL('m.head_cid')}
         LIMIT $2`,
       values: [`%${query}%`, limit],
     })

--- a/apps/backend/src/infrastructure/repositories/objects/ownership.ts
+++ b/apps/backend/src/infrastructure/repositories/objects/ownership.ts
@@ -81,6 +81,35 @@ const getAdmins = async (cid: string): Promise<Ownership[]> => {
   return result.rows
 }
 
+/**
+ * Returns how many admin (owner) ownerships exist for a cid and how many of
+ * them are still active (not marked as deleted). Used to decide whether an
+ * object has been removed by its owner — see ObjectUseCases.isObjectDeleted.
+ */
+const getAdminOwnershipState = async (
+  cid: string,
+): Promise<{ totalAdmins: number; activeAdmins: number }> => {
+  const db = await getDatabase()
+
+  const result = await db.query<{
+    total_admins: number
+    active_admins: number
+  }>({
+    text: `SELECT
+        COUNT(*) FILTER (WHERE is_admin = true)::int AS total_admins,
+        COUNT(*) FILTER (WHERE is_admin = true AND marked_as_deleted IS NULL)::int AS active_admins
+      FROM object_ownership
+      WHERE cid = $1`,
+    values: [cid],
+  })
+
+  const row = result.rows[0]
+  return {
+    totalAdmins: Number(row?.total_admins ?? 0),
+    activeAdmins: Number(row?.active_admins ?? 0),
+  }
+}
+
 export const ownershipRepository = {
   setUserAsOwner,
   setUserAsAdmin,
@@ -88,4 +117,5 @@ export const ownershipRepository = {
   getOwnerships,
   getDeletedOwnerships,
   getAdmins,
+  getAdminOwnershipState,
 }

--- a/apps/backend/src/infrastructure/repositories/objects/ownership.ts
+++ b/apps/backend/src/infrastructure/repositories/objects/ownership.ts
@@ -82,9 +82,23 @@ const getAdmins = async (cid: string): Promise<Ownership[]> => {
 }
 
 /**
- * Returns how many admin (owner) ownerships exist for a cid and how many of
- * them are still active (not marked as deleted). Used to decide whether an
- * object has been removed by its owner — see ObjectUseCases.isObjectDeleted.
+ * Returns how many admin (owner) ownerships exist for the root object(s) that
+ * contain a cid and how many of them are still active (not marked as deleted).
+ * Used to decide whether an object has been removed by its owner — see
+ * ObjectUseCases.isObjectDeleted.
+ *
+ * Ownership/removal is tracked at the root-upload level: a folder root and a
+ * standalone file each get an admin row keyed by their own cid, and removal
+ * only marks that root row as deleted. Child files of a folder still carry
+ * their own (vestigial) active admin rows from finalization, so we must NOT
+ * inspect the requested cid's own ownership directly — that would keep a
+ * trashed folder's children downloadable. Instead we resolve the cid to the
+ * root object(s) referencing it (metadata.head_cid -> metadata.root_cid) and
+ * evaluate admin ownership of those roots. A cid that no admin-owned root
+ * references (e.g. an internal child node) yields zero admins and is never
+ * treated as deleted, so legitimate access is unaffected. Deduplicated content
+ * shared across several roots stays available as long as one such root remains
+ * active.
  */
 const getAdminOwnershipState = async (
   cid: string,
@@ -96,10 +110,12 @@ const getAdminOwnershipState = async (
     active_admins: number
   }>({
     text: `SELECT
-        COUNT(*) FILTER (WHERE is_admin = true)::int AS total_admins,
-        COUNT(*) FILTER (WHERE is_admin = true AND marked_as_deleted IS NULL)::int AS active_admins
-      FROM object_ownership
-      WHERE cid = $1`,
+        COUNT(*) FILTER (WHERE oo.is_admin = true)::int AS total_admins,
+        COUNT(*) FILTER (WHERE oo.is_admin = true AND oo.marked_as_deleted IS NULL)::int AS active_admins
+      FROM object_ownership oo
+      WHERE oo.cid IN (
+        SELECT root_cid FROM metadata WHERE head_cid = $1
+      )`,
     values: [cid],
   })
 

--- a/apps/backend/src/infrastructure/repositories/objects/ownership.ts
+++ b/apps/backend/src/infrastructure/repositories/objects/ownership.ts
@@ -126,6 +126,38 @@ const getAdminOwnershipState = async (
   }
 }
 
+/**
+ * Builds a SQL boolean expression that is TRUE when the object identified by
+ * `headCidExpr` is NOT removed by its owner, matching the semantics of
+ * ObjectUseCases.isObjectDeleted / getAdminOwnershipState.
+ *
+ * Removal is tracked per root upload: a folder root (and a standalone file)
+ * each get an admin ownership row keyed by their own cid, and removal only
+ * marks that root row as deleted. Child files of a folder keep their own
+ * (vestigial) active admin rows from finalization, so checking the object's
+ * OWN cid ownership would wrongly keep a trashed folder's children visible.
+ * Instead we resolve the head_cid to the root object(s) referencing it
+ * (metadata.head_cid -> metadata.root_cid) and evaluate admin ownership of
+ * those roots:
+ *   - no admin ownership on any root  -> visible (bool_or over empty -> NULL,
+ *     COALESCE to TRUE), e.g. internal/legacy nodes;
+ *   - at least one root with an active admin owner -> visible;
+ *   - admin owners exist but all are trashed -> hidden (removed).
+ *
+ * `headCidExpr` MUST be a trusted SQL column expression (e.g. 'metadata.head_cid'
+ * or 'om.cid'), never user-provided input.
+ */
+const notRemovedByOwnerSQL = (headCidExpr: string): string => `COALESCE((
+    SELECT bool_or(active_oo.marked_as_deleted IS NULL)
+    FROM object_ownership active_oo
+    WHERE active_oo.is_admin IS TRUE
+      AND active_oo.cid IN (
+        SELECT root_owner_meta.root_cid
+        FROM metadata root_owner_meta
+        WHERE root_owner_meta.head_cid = ${headCidExpr}
+      )
+  ), TRUE)`
+
 export const ownershipRepository = {
   setUserAsOwner,
   setUserAsAdmin,
@@ -134,4 +166,8 @@ export const ownershipRepository = {
   getDeletedOwnerships,
   getAdmins,
   getAdminOwnershipState,
+}
+
+export const ownershipSQL = {
+  notRemovedByOwnerSQL,
 }

--- a/apps/backend/src/infrastructure/repositories/s3/objectMappings.ts
+++ b/apps/backend/src/infrastructure/repositories/s3/objectMappings.ts
@@ -1,5 +1,6 @@
 import { S3ObjectListing } from '@autonomys/file-server'
 import { getDatabase } from '../../drivers/pg.js'
+import { ownershipSQL } from '../objects/ownership.js'
 
 export type { S3ObjectListing }
 
@@ -155,10 +156,10 @@ const listObjects = async (
   // as head_cid in multiple metadata rows (different root_cid values), which
   // can happen when the same content is referenced by more than one root upload.
   // Hide objects whose owner has removed them (moved to Trash), mirroring
-  // ObjectUseCases.isObjectDeleted: an object is removed once it has an admin
-  // owner but none that is still active. bool_or returns NULL when the object
-  // has no admin ownership at all (e.g. legacy mappings), so COALESCE(..., TRUE)
-  // keeps it visible in that case — same as the download/lookup gating.
+  // ObjectUseCases.isObjectDeleted: removal is tracked on the root upload's
+  // ownership row, so the mapping's cid is resolved to its root before the
+  // admin-ownership check. This keeps a removed folder's child objects hidden
+  // even though they keep vestigial active admin rows from upload finalization.
   const baseSQL = `
     SELECT
       om.key,
@@ -175,12 +176,7 @@ const listObjects = async (
     ) m ON true
     WHERE om.bucket = $1
       AND om.key LIKE $2
-      AND COALESCE((
-        SELECT bool_or(oo.marked_as_deleted IS NULL)
-        FROM object_ownership oo
-        WHERE oo.cid = om.cid
-          AND oo.is_admin IS TRUE
-      ), TRUE)
+      AND ${ownershipSQL.notRemovedByOwnerSQL('om.cid')}
   `
 
   // Escape LIKE special characters so literal occurrences in the prefix

--- a/apps/backend/src/infrastructure/repositories/s3/objectMappings.ts
+++ b/apps/backend/src/infrastructure/repositories/s3/objectMappings.ts
@@ -154,6 +154,11 @@ const listObjects = async (
   // A plain LEFT JOIN on head_cid would fan out when the same CID appears
   // as head_cid in multiple metadata rows (different root_cid values), which
   // can happen when the same content is referenced by more than one root upload.
+  // Hide objects whose owner has removed them (moved to Trash), mirroring
+  // ObjectUseCases.isObjectDeleted: an object is removed once it has an admin
+  // owner but none that is still active. bool_or returns NULL when the object
+  // has no admin ownership at all (e.g. legacy mappings), so COALESCE(..., TRUE)
+  // keeps it visible in that case — same as the download/lookup gating.
   const baseSQL = `
     SELECT
       om.key,
@@ -170,6 +175,12 @@ const listObjects = async (
     ) m ON true
     WHERE om.bucket = $1
       AND om.key LIKE $2
+      AND COALESCE((
+        SELECT bool_or(oo.marked_as_deleted IS NULL)
+        FROM object_ownership oo
+        WHERE oo.cid = om.cid
+          AND oo.is_admin IS TRUE
+      ), TRUE)
   `
 
   // Escape LIKE special characters so literal occurrences in the prefix

--- a/apps/frontend/gql/graphql.ts
+++ b/apps/frontend/gql/graphql.ts
@@ -3618,7 +3618,7 @@ export type MyUndismissedAsyncDownloadsQueryResult = Apollo.QueryResult<MyUndism
 export const GetGlobalFilesDocument = gql`
     query GetGlobalFiles($aggregateLimit: Int!, $limit: Int!, $offset: Int!, $orderBy: [metadata_roots_order_by!], $search: String) {
   metadata_roots(
-    where: {_or: [{head_cid: {_ilike: $search}}, {name: {_ilike: $search}}]}
+    where: {_and: [{_or: [{head_cid: {_ilike: $search}}, {name: {_ilike: $search}}]}, {_or: [{_not: {inner_metadata: {object_ownership: {is_admin: {_eq: true}}}}}, {inner_metadata: {object_ownership: {is_admin: {_eq: true}, marked_as_deleted: {_is_null: true}}}}]}]}
     limit: $limit
     offset: $offset
     order_by: $orderBy
@@ -3651,7 +3651,7 @@ export const GetGlobalFilesDocument = gql`
   }
   metadata_roots_aggregate(
     limit: $aggregateLimit
-    where: {_or: [{head_cid: {_ilike: $search}}, {name: {_ilike: $search}}]}
+    where: {_and: [{_or: [{head_cid: {_ilike: $search}}, {name: {_ilike: $search}}]}, {_or: [{_not: {inner_metadata: {object_ownership: {is_admin: {_eq: true}}}}}, {inner_metadata: {object_ownership: {is_admin: {_eq: true}, marked_as_deleted: {_is_null: true}}}}]}]}
   ) {
     aggregate {
       count
@@ -3699,7 +3699,7 @@ export type GetGlobalFilesQueryResult = Apollo.QueryResult<GetGlobalFilesQuery, 
 export const GetSharedFilesDocument = gql`
     query GetSharedFiles($oauthUserId: String!, $oauthProvider: String!, $limit: Int!, $offset: Int!, $orderBy: [metadata_roots_order_by!], $aggregateLimit: Int!) {
   metadata_roots(
-    where: {inner_metadata: {object_ownership: {_and: {oauth_user_id: {_eq: $oauthUserId}, oauth_provider: {_eq: $oauthProvider}, marked_as_deleted: {_is_null: true}, is_admin: {_eq: false}}}}}
+    where: {_and: [{inner_metadata: {object_ownership: {_and: {oauth_user_id: {_eq: $oauthUserId}, oauth_provider: {_eq: $oauthProvider}, marked_as_deleted: {_is_null: true}, is_admin: {_eq: false}}}}}, {inner_metadata: {object_ownership: {is_admin: {_eq: true}, marked_as_deleted: {_is_null: true}}}}]}
     limit: $limit
     offset: $offset
     order_by: $orderBy
@@ -3737,7 +3737,7 @@ export const GetSharedFilesDocument = gql`
   }
   metadata_roots_aggregate(
     limit: $aggregateLimit
-    where: {inner_metadata: {object_ownership: {_and: {oauth_user_id: {_eq: $oauthUserId}, oauth_provider: {_eq: $oauthProvider}, marked_as_deleted: {_is_null: true}, is_admin: {_eq: false}}}}}
+    where: {_and: [{inner_metadata: {object_ownership: {_and: {oauth_user_id: {_eq: $oauthUserId}, oauth_provider: {_eq: $oauthProvider}, marked_as_deleted: {_is_null: true}, is_admin: {_eq: false}}}}}, {inner_metadata: {object_ownership: {is_admin: {_eq: true}, marked_as_deleted: {_is_null: true}}}}]}
   ) {
     aggregate {
       count
@@ -3964,7 +3964,7 @@ export type GetMyFilesQueryResult = Apollo.QueryResult<GetMyFilesQuery, GetMyFil
 export const GetMetadataByHeadCidDocument = gql`
     query GetMetadataByHeadCID($headCid: String!) {
   metadata(
-    where: {_or: [{head_cid: {_ilike: $headCid}}, {name: {_ilike: $headCid}}]}
+    where: {_and: [{_or: [{head_cid: {_ilike: $headCid}}, {name: {_ilike: $headCid}}]}, {_or: [{_not: {object_ownership: {is_admin: {_eq: true}}}}, {object_ownership: {is_admin: {_eq: true}, marked_as_deleted: {_is_null: true}}}]}]}
   ) {
     head_cid
     tags
@@ -4038,7 +4038,7 @@ export type GetMetadataByHeadCidQueryResult = Apollo.QueryResult<GetMetadataByHe
 export const GetMetadataByHeadCidWithOwnershipDocument = gql`
     query GetMetadataByHeadCIDWithOwnership($headCid: String!) {
   metadata(
-    where: {_or: [{head_cid: {_ilike: $headCid}}, {name: {_ilike: $headCid}}]}
+    where: {_and: [{_or: [{head_cid: {_ilike: $headCid}}, {name: {_ilike: $headCid}}]}, {_or: [{_not: {object_ownership: {is_admin: {_eq: true}}}}, {object_ownership: {is_admin: {_eq: true}, marked_as_deleted: {_is_null: true}}}]}]}
   ) {
     head_cid
     tags
@@ -4118,7 +4118,7 @@ export const SearchGlobalMetadataByCidOrNameDocument = gql`
     query SearchGlobalMetadataByCIDOrName($search: String!, $limit: Int!) {
   metadata(
     distinct_on: root_cid
-    where: {_or: [{head_cid: {_ilike: $search}}, {name: {_ilike: $search}}]}
+    where: {_and: [{_or: [{head_cid: {_ilike: $search}}, {name: {_ilike: $search}}]}, {_or: [{_not: {object_ownership: {is_admin: {_eq: true}}}}, {object_ownership: {is_admin: {_eq: true}, marked_as_deleted: {_is_null: true}}}]}]}
     limit: $limit
   ) {
     type: metadata(path: "type")

--- a/apps/frontend/gql/graphql.ts
+++ b/apps/frontend/gql/graphql.ts
@@ -3618,7 +3618,7 @@ export type MyUndismissedAsyncDownloadsQueryResult = Apollo.QueryResult<MyUndism
 export const GetGlobalFilesDocument = gql`
     query GetGlobalFiles($aggregateLimit: Int!, $limit: Int!, $offset: Int!, $orderBy: [metadata_roots_order_by!], $search: String) {
   metadata_roots(
-    where: {_and: [{_or: [{head_cid: {_ilike: $search}}, {name: {_ilike: $search}}]}, {_or: [{_not: {inner_metadata: {object_ownership: {is_admin: {_eq: true}}}}}, {inner_metadata: {object_ownership: {is_admin: {_eq: true}, marked_as_deleted: {_is_null: true}}}}]}]}
+    where: {_and: [{_or: [{head_cid: {_ilike: $search}}, {name: {_ilike: $search}}]}, {_or: [{_not: {object_ownership: {is_admin: {_eq: true}}}}, {object_ownership: {is_admin: {_eq: true}, marked_as_deleted: {_is_null: true}}}]}]}
     limit: $limit
     offset: $offset
     order_by: $orderBy
@@ -3651,7 +3651,7 @@ export const GetGlobalFilesDocument = gql`
   }
   metadata_roots_aggregate(
     limit: $aggregateLimit
-    where: {_and: [{_or: [{head_cid: {_ilike: $search}}, {name: {_ilike: $search}}]}, {_or: [{_not: {inner_metadata: {object_ownership: {is_admin: {_eq: true}}}}}, {inner_metadata: {object_ownership: {is_admin: {_eq: true}, marked_as_deleted: {_is_null: true}}}}]}]}
+    where: {_and: [{_or: [{head_cid: {_ilike: $search}}, {name: {_ilike: $search}}]}, {_or: [{_not: {object_ownership: {is_admin: {_eq: true}}}}, {object_ownership: {is_admin: {_eq: true}, marked_as_deleted: {_is_null: true}}}]}]}
   ) {
     aggregate {
       count
@@ -3699,7 +3699,7 @@ export type GetGlobalFilesQueryResult = Apollo.QueryResult<GetGlobalFilesQuery, 
 export const GetSharedFilesDocument = gql`
     query GetSharedFiles($oauthUserId: String!, $oauthProvider: String!, $limit: Int!, $offset: Int!, $orderBy: [metadata_roots_order_by!], $aggregateLimit: Int!) {
   metadata_roots(
-    where: {_and: [{inner_metadata: {object_ownership: {_and: {oauth_user_id: {_eq: $oauthUserId}, oauth_provider: {_eq: $oauthProvider}, marked_as_deleted: {_is_null: true}, is_admin: {_eq: false}}}}}, {inner_metadata: {object_ownership: {is_admin: {_eq: true}, marked_as_deleted: {_is_null: true}}}}]}
+    where: {_and: [{inner_metadata: {object_ownership: {_and: {oauth_user_id: {_eq: $oauthUserId}, oauth_provider: {_eq: $oauthProvider}, marked_as_deleted: {_is_null: true}, is_admin: {_eq: false}}}}}, {object_ownership: {is_admin: {_eq: true}, marked_as_deleted: {_is_null: true}}}]}
     limit: $limit
     offset: $offset
     order_by: $orderBy
@@ -3737,7 +3737,7 @@ export const GetSharedFilesDocument = gql`
   }
   metadata_roots_aggregate(
     limit: $aggregateLimit
-    where: {_and: [{inner_metadata: {object_ownership: {_and: {oauth_user_id: {_eq: $oauthUserId}, oauth_provider: {_eq: $oauthProvider}, marked_as_deleted: {_is_null: true}, is_admin: {_eq: false}}}}}, {inner_metadata: {object_ownership: {is_admin: {_eq: true}, marked_as_deleted: {_is_null: true}}}}]}
+    where: {_and: [{inner_metadata: {object_ownership: {_and: {oauth_user_id: {_eq: $oauthUserId}, oauth_provider: {_eq: $oauthProvider}, marked_as_deleted: {_is_null: true}, is_admin: {_eq: false}}}}}, {object_ownership: {is_admin: {_eq: true}, marked_as_deleted: {_is_null: true}}}]}
   ) {
     aggregate {
       count
@@ -3964,7 +3964,7 @@ export type GetMyFilesQueryResult = Apollo.QueryResult<GetMyFilesQuery, GetMyFil
 export const GetMetadataByHeadCidDocument = gql`
     query GetMetadataByHeadCID($headCid: String!) {
   metadata(
-    where: {_and: [{_or: [{head_cid: {_ilike: $headCid}}, {name: {_ilike: $headCid}}]}, {_or: [{_not: {object_ownership: {is_admin: {_eq: true}}}}, {object_ownership: {is_admin: {_eq: true}, marked_as_deleted: {_is_null: true}}}]}]}
+    where: {_and: [{_or: [{head_cid: {_ilike: $headCid}}, {name: {_ilike: $headCid}}]}, {_or: [{_not: {root_metadata: {object_ownership: {is_admin: {_eq: true}}}}}, {root_metadata: {object_ownership: {is_admin: {_eq: true}, marked_as_deleted: {_is_null: true}}}}]}]}
   ) {
     head_cid
     tags
@@ -4038,7 +4038,7 @@ export type GetMetadataByHeadCidQueryResult = Apollo.QueryResult<GetMetadataByHe
 export const GetMetadataByHeadCidWithOwnershipDocument = gql`
     query GetMetadataByHeadCIDWithOwnership($headCid: String!) {
   metadata(
-    where: {_and: [{_or: [{head_cid: {_ilike: $headCid}}, {name: {_ilike: $headCid}}]}, {_or: [{_not: {object_ownership: {is_admin: {_eq: true}}}}, {object_ownership: {is_admin: {_eq: true}, marked_as_deleted: {_is_null: true}}}]}]}
+    where: {_and: [{_or: [{head_cid: {_ilike: $headCid}}, {name: {_ilike: $headCid}}]}, {_or: [{_not: {root_metadata: {object_ownership: {is_admin: {_eq: true}}}}}, {root_metadata: {object_ownership: {is_admin: {_eq: true}, marked_as_deleted: {_is_null: true}}}}]}]}
   ) {
     head_cid
     tags
@@ -4118,7 +4118,7 @@ export const SearchGlobalMetadataByCidOrNameDocument = gql`
     query SearchGlobalMetadataByCIDOrName($search: String!, $limit: Int!) {
   metadata(
     distinct_on: root_cid
-    where: {_and: [{_or: [{head_cid: {_ilike: $search}}, {name: {_ilike: $search}}]}, {_or: [{_not: {object_ownership: {is_admin: {_eq: true}}}}, {object_ownership: {is_admin: {_eq: true}, marked_as_deleted: {_is_null: true}}}]}]}
+    where: {_and: [{_or: [{head_cid: {_ilike: $search}}, {name: {_ilike: $search}}]}, {_or: [{_not: {root_metadata: {object_ownership: {is_admin: {_eq: true}}}}}, {root_metadata: {object_ownership: {is_admin: {_eq: true}, marked_as_deleted: {_is_null: true}}}}]}]}
     limit: $limit
   ) {
     type: metadata(path: "type")

--- a/apps/frontend/src/components/views/GlobalFiles/query.graphql
+++ b/apps/frontend/src/components/views/GlobalFiles/query.graphql
@@ -11,17 +11,11 @@ query GetGlobalFiles(
         { _or: [{ head_cid: { _ilike: $search } }, { name: { _ilike: $search } }] }
         {
           _or: [
+            { _not: { object_ownership: { is_admin: { _eq: true } } } }
             {
-              _not: {
-                inner_metadata: { object_ownership: { is_admin: { _eq: true } } }
-              }
-            }
-            {
-              inner_metadata: {
-                object_ownership: {
-                  is_admin: { _eq: true }
-                  marked_as_deleted: { _is_null: true }
-                }
+              object_ownership: {
+                is_admin: { _eq: true }
+                marked_as_deleted: { _is_null: true }
               }
             }
           ]
@@ -69,17 +63,11 @@ query GetGlobalFiles(
         { _or: [{ head_cid: { _ilike: $search } }, { name: { _ilike: $search } }] }
         {
           _or: [
+            { _not: { object_ownership: { is_admin: { _eq: true } } } }
             {
-              _not: {
-                inner_metadata: { object_ownership: { is_admin: { _eq: true } } }
-              }
-            }
-            {
-              inner_metadata: {
-                object_ownership: {
-                  is_admin: { _eq: true }
-                  marked_as_deleted: { _is_null: true }
-                }
+              object_ownership: {
+                is_admin: { _eq: true }
+                marked_as_deleted: { _is_null: true }
               }
             }
           ]

--- a/apps/frontend/src/components/views/GlobalFiles/query.graphql
+++ b/apps/frontend/src/components/views/GlobalFiles/query.graphql
@@ -7,7 +7,26 @@ query GetGlobalFiles(
 ) {
   metadata_roots(
     where: {
-      _or: [{ head_cid: { _ilike: $search } }, { name: { _ilike: $search } }]
+      _and: [
+        { _or: [{ head_cid: { _ilike: $search } }, { name: { _ilike: $search } }] }
+        {
+          _or: [
+            {
+              _not: {
+                inner_metadata: { object_ownership: { is_admin: { _eq: true } } }
+              }
+            }
+            {
+              inner_metadata: {
+                object_ownership: {
+                  is_admin: { _eq: true }
+                  marked_as_deleted: { _is_null: true }
+                }
+              }
+            }
+          ]
+        }
+      ]
     }
     limit: $limit
     offset: $offset
@@ -46,7 +65,26 @@ query GetGlobalFiles(
   metadata_roots_aggregate(
     limit: $aggregateLimit
     where: {
-      _or: [{ head_cid: { _ilike: $search } }, { name: { _ilike: $search } }]
+      _and: [
+        { _or: [{ head_cid: { _ilike: $search } }, { name: { _ilike: $search } }] }
+        {
+          _or: [
+            {
+              _not: {
+                inner_metadata: { object_ownership: { is_admin: { _eq: true } } }
+              }
+            }
+            {
+              inner_metadata: {
+                object_ownership: {
+                  is_admin: { _eq: true }
+                  marked_as_deleted: { _is_null: true }
+                }
+              }
+            }
+          ]
+        }
+      ]
     }
   ) {
     aggregate {

--- a/apps/frontend/src/components/views/SharedFiles/query.graphql
+++ b/apps/frontend/src/components/views/SharedFiles/query.graphql
@@ -8,16 +8,28 @@ query GetSharedFiles(
 ) {
   metadata_roots(
     where: {
-      inner_metadata: {
-        object_ownership: {
-          _and: {
-            oauth_user_id: { _eq: $oauthUserId }
-            oauth_provider: { _eq: $oauthProvider }
-            marked_as_deleted: { _is_null: true }
-            is_admin: { _eq: false }
+      _and: [
+        {
+          inner_metadata: {
+            object_ownership: {
+              _and: {
+                oauth_user_id: { _eq: $oauthUserId }
+                oauth_provider: { _eq: $oauthProvider }
+                marked_as_deleted: { _is_null: true }
+                is_admin: { _eq: false }
+              }
+            }
           }
         }
-      }
+        {
+          inner_metadata: {
+            object_ownership: {
+              is_admin: { _eq: true }
+              marked_as_deleted: { _is_null: true }
+            }
+          }
+        }
+      ]
     }
     limit: $limit
     offset: $offset
@@ -61,16 +73,28 @@ query GetSharedFiles(
   metadata_roots_aggregate(
     limit: $aggregateLimit
     where: {
-      inner_metadata: {
-        object_ownership: {
-          _and: {
-            oauth_user_id: { _eq: $oauthUserId }
-            oauth_provider: { _eq: $oauthProvider }
-            marked_as_deleted: { _is_null: true }
-            is_admin: { _eq: false }
+      _and: [
+        {
+          inner_metadata: {
+            object_ownership: {
+              _and: {
+                oauth_user_id: { _eq: $oauthUserId }
+                oauth_provider: { _eq: $oauthProvider }
+                marked_as_deleted: { _is_null: true }
+                is_admin: { _eq: false }
+              }
+            }
           }
         }
-      }
+        {
+          inner_metadata: {
+            object_ownership: {
+              is_admin: { _eq: true }
+              marked_as_deleted: { _is_null: true }
+            }
+          }
+        }
+      ]
     }
   ) {
     aggregate {

--- a/apps/frontend/src/components/views/SharedFiles/query.graphql
+++ b/apps/frontend/src/components/views/SharedFiles/query.graphql
@@ -22,11 +22,9 @@ query GetSharedFiles(
           }
         }
         {
-          inner_metadata: {
-            object_ownership: {
-              is_admin: { _eq: true }
-              marked_as_deleted: { _is_null: true }
-            }
+          object_ownership: {
+            is_admin: { _eq: true }
+            marked_as_deleted: { _is_null: true }
           }
         }
       ]
@@ -87,11 +85,9 @@ query GetSharedFiles(
           }
         }
         {
-          inner_metadata: {
-            object_ownership: {
-              is_admin: { _eq: true }
-              marked_as_deleted: { _is_null: true }
-            }
+          object_ownership: {
+            is_admin: { _eq: true }
+            marked_as_deleted: { _is_null: true }
           }
         }
       ]

--- a/apps/frontend/src/services/gql/common/query.graphql
+++ b/apps/frontend/src/services/gql/common/query.graphql
@@ -5,11 +5,13 @@ query GetMetadataByHeadCID($headCid: String!) {
         { _or: [{ head_cid: { _ilike: $headCid } }, { name: { _ilike: $headCid } }] }
         {
           _or: [
-            { _not: { object_ownership: { is_admin: { _eq: true } } } }
+            { _not: { root_metadata: { object_ownership: { is_admin: { _eq: true } } } } }
             {
-              object_ownership: {
-                is_admin: { _eq: true }
-                marked_as_deleted: { _is_null: true }
+              root_metadata: {
+                object_ownership: {
+                  is_admin: { _eq: true }
+                  marked_as_deleted: { _is_null: true }
+                }
               }
             }
           ]
@@ -64,11 +66,13 @@ query GetMetadataByHeadCIDWithOwnership($headCid: String!) {
         { _or: [{ head_cid: { _ilike: $headCid } }, { name: { _ilike: $headCid } }] }
         {
           _or: [
-            { _not: { object_ownership: { is_admin: { _eq: true } } } }
+            { _not: { root_metadata: { object_ownership: { is_admin: { _eq: true } } } } }
             {
-              object_ownership: {
-                is_admin: { _eq: true }
-                marked_as_deleted: { _is_null: true }
+              root_metadata: {
+                object_ownership: {
+                  is_admin: { _eq: true }
+                  marked_as_deleted: { _is_null: true }
+                }
               }
             }
           ]
@@ -129,11 +133,13 @@ query SearchGlobalMetadataByCIDOrName($search: String!, $limit: Int!) {
         { _or: [{ head_cid: { _ilike: $search } }, { name: { _ilike: $search } }] }
         {
           _or: [
-            { _not: { object_ownership: { is_admin: { _eq: true } } } }
+            { _not: { root_metadata: { object_ownership: { is_admin: { _eq: true } } } } }
             {
-              object_ownership: {
-                is_admin: { _eq: true }
-                marked_as_deleted: { _is_null: true }
+              root_metadata: {
+                object_ownership: {
+                  is_admin: { _eq: true }
+                  marked_as_deleted: { _is_null: true }
+                }
               }
             }
           ]

--- a/apps/frontend/src/services/gql/common/query.graphql
+++ b/apps/frontend/src/services/gql/common/query.graphql
@@ -1,7 +1,20 @@
 query GetMetadataByHeadCID($headCid: String!) {
   metadata(
     where: {
-      _or: [{ head_cid: { _ilike: $headCid } }, { name: { _ilike: $headCid } }]
+      _and: [
+        { _or: [{ head_cid: { _ilike: $headCid } }, { name: { _ilike: $headCid } }] }
+        {
+          _or: [
+            { _not: { object_ownership: { is_admin: { _eq: true } } } }
+            {
+              object_ownership: {
+                is_admin: { _eq: true }
+                marked_as_deleted: { _is_null: true }
+              }
+            }
+          ]
+        }
+      ]
     }
   ) {
     head_cid
@@ -47,7 +60,20 @@ query GetMetadataByHeadCID($headCid: String!) {
 query GetMetadataByHeadCIDWithOwnership($headCid: String!) {
   metadata(
     where: {
-      _or: [{ head_cid: { _ilike: $headCid } }, { name: { _ilike: $headCid } }]
+      _and: [
+        { _or: [{ head_cid: { _ilike: $headCid } }, { name: { _ilike: $headCid } }] }
+        {
+          _or: [
+            { _not: { object_ownership: { is_admin: { _eq: true } } } }
+            {
+              object_ownership: {
+                is_admin: { _eq: true }
+                marked_as_deleted: { _is_null: true }
+              }
+            }
+          ]
+        }
+      ]
     }
   ) {
     head_cid
@@ -99,7 +125,20 @@ query SearchGlobalMetadataByCIDOrName($search: String!, $limit: Int!) {
   metadata(
     distinct_on: root_cid
     where: {
-      _or: [{ head_cid: { _ilike: $search } }, { name: { _ilike: $search } }]
+      _and: [
+        { _or: [{ head_cid: { _ilike: $search } }, { name: { _ilike: $search } }] }
+        {
+          _or: [
+            { _not: { object_ownership: { is_admin: { _eq: true } } } }
+            {
+              object_ownership: {
+                is_admin: { _eq: true }
+                marked_as_deleted: { _is_null: true }
+              }
+            }
+          ]
+        }
+      ]
     }
     limit: $limit
   ) {

--- a/apps/hasura/metadata/databases/default/tables/metadata.yaml
+++ b/apps/hasura/metadata/databases/default/tables/metadata.yaml
@@ -30,17 +30,25 @@ select_permissions:
       # ObjectUseCases.isObjectDeleted: an object is removed once it has an admin
       # owner but none that is still active. Objects with no admin ownership at
       # all (internal/child nodes) are kept visible.
+      #
+      # Removal is tracked on the root upload's ownership row, so we evaluate the
+      # ROOT's ownership (root_metadata follows root_cid -> head_cid) rather than
+      # the row's own object_ownership. A folder child keeps a vestigial active
+      # admin row keyed by its own cid, so checking object_ownership directly
+      # would wrongly keep a removed folder's children discoverable.
       filter:
         _or:
           - _not:
+              root_metadata:
+                object_ownership:
+                  is_admin:
+                    _eq: true
+          - root_metadata:
               object_ownership:
                 is_admin:
                   _eq: true
-          - object_ownership:
-              is_admin:
-                _eq: true
-              marked_as_deleted:
-                _is_null: true
+                marked_as_deleted:
+                  _is_null: true
       allow_aggregations: true
     comment: ""
 object_relationships:

--- a/apps/hasura/metadata/databases/default/tables/metadata.yaml
+++ b/apps/hasura/metadata/databases/default/tables/metadata.yaml
@@ -12,7 +12,36 @@ select_permissions:
         - tags
         - created_at
         - updated_at
-      filter: {}
+      # Mirror the anonymous removal filter so authenticated users can't discover
+      # another owner's trashed objects by CID/name via a raw GraphQL query (the
+      # per-document filters only protect the UI). As with the anonymous role,
+      # removal is tracked on the root upload's ownership row, so we evaluate the
+      # ROOT's ownership (root_metadata follows root_cid -> head_cid) rather than
+      # the row's own object_ownership; a folder child keeps a vestigial active
+      # admin row so checking object_ownership directly would leak it.
+      #
+      # The third branch additionally keeps a user's OWN objects visible
+      # regardless of removal state, so their Trash view and own-file detail
+      # pages keep working — this is the only difference from the anonymous role.
+      filter:
+        _or:
+          - _not:
+              root_metadata:
+                object_ownership:
+                  is_admin:
+                    _eq: true
+          - root_metadata:
+              object_ownership:
+                is_admin:
+                  _eq: true
+                marked_as_deleted:
+                  _is_null: true
+          - root_metadata:
+              object_ownership:
+                oauth_provider:
+                  _eq: X-Hasura-Oauth-Provider
+                oauth_user_id:
+                  _eq: X-Hasura-Oauth-User-Id
       allow_aggregations: true
     comment: ""
   - role: anonymous

--- a/apps/hasura/metadata/databases/default/tables/metadata.yaml
+++ b/apps/hasura/metadata/databases/default/tables/metadata.yaml
@@ -25,7 +25,22 @@ select_permissions:
         - tags
         - created_at
         - updated_at
-      filter: {}
+      # Hide objects an owner has removed (moved to Trash) so they can't be
+      # discovered anonymously by CID/name, matching the REST 404 behaviour and
+      # ObjectUseCases.isObjectDeleted: an object is removed once it has an admin
+      # owner but none that is still active. Objects with no admin ownership at
+      # all (internal/child nodes) are kept visible.
+      filter:
+        _or:
+          - _not:
+              object_ownership:
+                is_admin:
+                  _eq: true
+          - object_ownership:
+              is_admin:
+                _eq: true
+              marked_as_deleted:
+                _is_null: true
       allow_aggregations: true
     comment: ""
 object_relationships:

--- a/apps/hasura/metadata/databases/default/tables/object_ownership.yaml
+++ b/apps/hasura/metadata/databases/default/tables/object_ownership.yaml
@@ -21,7 +21,14 @@ select_permissions:
         - cid
         - is_admin
         - marked_as_deleted
-      filter: {}
+      # Anonymous clients may reference is_admin / marked_as_deleted to filter
+      # public listings, but must never be able to read or enumerate ownership
+      # rows that an owner has trashed. Restricting visible rows to the active
+      # (non-deleted) ones makes any direct query for deleted rows return empty
+      # and forces the marked_as_deleted column to always read as null.
+      filter:
+        marked_as_deleted:
+          _is_null: true
       allow_aggregations: true
     comment: ""
 object_relationships:

--- a/apps/hasura/metadata/databases/default/tables/object_ownership.yaml
+++ b/apps/hasura/metadata/databases/default/tables/object_ownership.yaml
@@ -12,7 +12,22 @@ select_permissions:
         - marked_as_deleted
         - created_at
         - updated_at
-      filter: {}
+      # Enforce removal at the permission layer for authenticated users, not
+      # just via the query documents: a logged-in user must never be able to read
+      # or enumerate another owner's trashed ownership rows (incl. the
+      # marked_as_deleted column) with a raw GraphQL query. A row is visible when
+      # it is still active (needed to display ownership of public/shared objects
+      # and to drive the is_admin/marked_as_deleted filters) or when it belongs to
+      # the requesting user, so their own Trash keeps working.
+      filter:
+        _or:
+          - marked_as_deleted:
+              _is_null: true
+          - _and:
+              - oauth_provider:
+                  _eq: X-Hasura-Oauth-Provider
+              - oauth_user_id:
+                  _eq: X-Hasura-Oauth-User-Id
       allow_aggregations: true
     comment: ""
   - role: anonymous

--- a/apps/hasura/metadata/databases/default/tables/object_ownership.yaml
+++ b/apps/hasura/metadata/databases/default/tables/object_ownership.yaml
@@ -19,6 +19,8 @@ select_permissions:
     permission:
       columns:
         - cid
+        - is_admin
+        - marked_as_deleted
       filter: {}
       allow_aggregations: true
     comment: ""

--- a/apps/hasura/metadata/databases/default/tables/root_metadata.yaml
+++ b/apps/hasura/metadata/databases/default/tables/root_metadata.yaml
@@ -26,7 +26,22 @@ select_permissions:
         - tags
         - created_at
         - updated_at
-      filter: {}
+      # Mirror the metadata table: never expose roots an owner has removed
+      # (moved to Trash) to anonymous clients, so trashed objects stay out of
+      # the global explorer/search even via direct GraphQL.
+      filter:
+        _or:
+          - _not:
+              inner_metadata:
+                object_ownership:
+                  is_admin:
+                    _eq: true
+          - inner_metadata:
+              object_ownership:
+                is_admin:
+                  _eq: true
+                marked_as_deleted:
+                  _is_null: true
       allow_aggregations: true
     comment: ""
 object_relationships:

--- a/apps/hasura/metadata/databases/default/tables/root_metadata.yaml
+++ b/apps/hasura/metadata/databases/default/tables/root_metadata.yaml
@@ -13,7 +13,32 @@ select_permissions:
         - tags
         - created_at
         - updated_at
-      filter: {}
+      # Mirror the anonymous removal filter so authenticated users can't discover
+      # roots an owner has removed (moved to Trash) via a raw GraphQL query; the
+      # per-document filters only protect the UI. As with the anonymous role we
+      # evaluate the ROOT's own ownership via the object_ownership relationship
+      # (root_cid -> cid), not inner_metadata, so a removed folder (whose children
+      # keep vestigial active admin rows) stays hidden.
+      #
+      # The third branch additionally keeps a user's OWN roots visible regardless
+      # of removal state so their Trash view keeps working — the only difference
+      # from the anonymous role.
+      filter:
+        _or:
+          - _not:
+              object_ownership:
+                is_admin:
+                  _eq: true
+          - object_ownership:
+              is_admin:
+                _eq: true
+              marked_as_deleted:
+                _is_null: true
+          - object_ownership:
+              oauth_provider:
+                _eq: X-Hasura-Oauth-Provider
+              oauth_user_id:
+                _eq: X-Hasura-Oauth-User-Id
       allow_aggregations: true
     comment: ""
   - role: anonymous

--- a/apps/hasura/metadata/databases/default/tables/root_metadata.yaml
+++ b/apps/hasura/metadata/databases/default/tables/root_metadata.yaml
@@ -29,19 +29,24 @@ select_permissions:
       # Mirror the metadata table: never expose roots an owner has removed
       # (moved to Trash) to anonymous clients, so trashed objects stay out of
       # the global explorer/search even via direct GraphQL.
+      #
+      # Removal is tracked on the root upload's ownership row, so we evaluate the
+      # ROOT's own ownership via the object_ownership relationship (root_cid ->
+      # cid). The inner_metadata relationship spans every metadata row sharing
+      # the root_cid (root + children), and folder children keep vestigial active
+      # admin rows, so filtering through inner_metadata.object_ownership would
+      # wrongly keep a removed folder visible in the global explorer/search.
       filter:
         _or:
           - _not:
-              inner_metadata:
-                object_ownership:
-                  is_admin:
-                    _eq: true
-          - inner_metadata:
               object_ownership:
                 is_admin:
                   _eq: true
-                marked_as_deleted:
-                  _is_null: true
+          - object_ownership:
+              is_admin:
+                _eq: true
+              marked_as_deleted:
+                _is_null: true
       allow_aggregations: true
     comment: ""
 object_relationships:
@@ -53,4 +58,14 @@ object_relationships:
         insertion_order: null
         remote_table:
           name: metadata
+          schema: public
+array_relationships:
+  - name: object_ownership
+    using:
+      manual_configuration:
+        column_mapping:
+          root_cid: cid
+        insertion_order: null
+        remote_table:
+          name: object_ownership
           schema: public


### PR DESCRIPTION
Removing ("Remove") a file previously only set marked_as_deleted on the owner's ownership row, which hid it from "My Files" but left it fully downloadable and discoverable by CID for everyone, including anonymous callers, the S3/SDK path, and global search/explorer.

Treat an object as deleted once it has an owner moved it to trash, and enforce that consistently:

- ObjectUseCases.isObjectDeleted + ownershipRepository.getAdminOwnershipState
- authorizeDownload returns ObjectNotFound for deleted objects (covers sync, anonymous, published and S3 downloads, which all funnel through it)
- async createDownload / asyncDownload worker refuse deleted objects
- GET /:cid, /:cid/metadata, /:cid/summary return 404 for deleted objects
- global searchMetadataByCID / searchMetadataByName / getRootObjects only return objects with an active admin owner

Restoring from Trash clears marked_as_deleted, which reverses all of the above. Adds an e2e test covering the full remove/restore lifecycle.