### PR TITLE
fix(backend): hide trashed objects from S3 object-lock endpoints

### DIFF
--- a/apps/backend/__tests__/unit/core/s3.spec.ts
+++ b/apps/backend/__tests__/unit/core/s3.spec.ts
@@ -10,6 +10,7 @@ import { S3UseCases } from '../../../src/core/s3/index.js'
 import { s3ObjectMappingsRepository } from '../../../src/infrastructure/repositories/index.js'
 import { UploadsUseCases } from '../../../src/core/uploads/uploads.js'
 import { DownloadUseCase } from '../../../src/core/downloads/index.js'
+import { ObjectUseCases } from '../../../src/core/objects/object.js'
 import { UserWithOrganization } from '@auto-drive/models'
 import { ok, err } from 'neverthrow'
 import { ObjectNotFoundError } from '../../../src/errors/index.js'
@@ -505,7 +506,7 @@ describe('S3UseCases', () => {
       )
     })
 
-    it('returns true when a mapping exists', async () => {
+    it('returns true when a mapping exists and the object is not deleted', async () => {
       jest
         .spyOn(s3ObjectMappingsRepository, 'findByKey')
         .mockResolvedValue({
@@ -514,8 +515,27 @@ describe('S3UseCases', () => {
           cid: 'cid123',
           md5: null,
         } as any)
+      jest.spyOn(ObjectUseCases, 'isObjectDeleted').mockResolvedValue(false)
 
       expect(await S3UseCases.objectExists('my-bucket', 'file.txt')).toBe(true)
+    })
+
+    // A trashed object keeps its mapping row but is hidden from GET/list, so
+    // object-lock endpoints must report it as not found too.
+    it('returns false when the mapping exists but the object was removed by its owner', async () => {
+      jest
+        .spyOn(s3ObjectMappingsRepository, 'findByKey')
+        .mockResolvedValue({
+          bucket: 'my-bucket',
+          key: 'trashed.txt',
+          cid: 'cid123',
+          md5: null,
+        } as any)
+      jest.spyOn(ObjectUseCases, 'isObjectDeleted').mockResolvedValue(true)
+
+      expect(await S3UseCases.objectExists('my-bucket', 'trashed.txt')).toBe(
+        false,
+      )
     })
   })
 })

--- a/apps/backend/src/core/s3/index.ts
+++ b/apps/backend/src/core/s3/index.ts
@@ -1,5 +1,6 @@
 import { s3ObjectMappingsRepository } from '../../infrastructure/repositories/index.js'
 import { DownloadUseCase } from '../downloads/index.js'
+import { ObjectUseCases } from '../objects/object.js'
 import { err, ok, Result } from 'neverthrow'
 import { ObjectNotFoundError } from '../../errors/index.js'
 import {
@@ -246,7 +247,16 @@ const listBuckets = async (): Promise<S3BucketInfo[]> => {
 
 const objectExists = async (bucket: string, key: string): Promise<boolean> => {
   const mapping = await s3ObjectMappingsRepository.findByKey(bucket, key)
-  return mapping !== null
+  if (!mapping) {
+    return false
+  }
+
+  // The mapping row persists after an owner removes an object (moved to Trash),
+  // but GET and ListObjects treat such objects as not found via isObjectDeleted
+  // / notRemovedByOwnerSQL. Mirror that here so object-lock endpoints
+  // (GetObjectRetention / GetObjectLegalHold) don't leak retention or
+  // legal-hold metadata for keys that are otherwise reported as not found.
+  return !(await ObjectUseCases.isObjectDeleted(mapping.cid))
 }
 
 export const S3UseCases = {


### PR DESCRIPTION
objectExists only checked for an S3 mapping row, which persists after an owner removes an object (moves it to Trash). GET and ListObjects already treat such objects as not found via isObjectDeleted / notRemovedByOwnerSQL, but GetObjectRetention and GetObjectLegalHold gate on objectExists, so trashed keys could still return retention/legal-hold XML after GET/list reported NoSuchKey. Resolve the mapping's CID through isObjectDeleted so objectExists mirrors the GET/list deletion semantics.