### PR TITLE
Fix: fully depleted credit batches incorrectly marked as expired

### DIFF
--- a/apps/backend/__tests__/unit/repositories/purchasedCredits.spec.ts
+++ b/apps/backend/__tests__/unit/repositories/purchasedCredits.spec.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeAll, afterAll } from '@jest/globals'
+import { purchasedCreditsRepository } from '../../../src/infrastructure/repositories/users/purchasedCredits.js'
+import { intentsRepository } from '../../../src/infrastructure/repositories/users/intents.js'
+import { accountsRepository } from '../../../src/infrastructure/repositories/users/accounts.js'
+import { getDatabase } from '../../../src/infrastructure/drivers/pg.js'
+import { IntentStatus } from '@auto-drive/models'
+import { dbMigration } from '../../utils/dbMigrate.js'
+
+// Exercises markExpiredCredits against the migrated TestContainers Postgres
+// (requires Docker), like the other repository specs.
+//
+// Regression coverage for the depleted-vs-expired bug: rows whose credits
+// were fully consumed before expires_at passed must NOT be flagged expired —
+// nothing was forfeited and no refund is owed, so they must never surface in
+// the admin panel as "awaiting refund".
+describe('PurchasedCredits Repository — markExpiredCredits', () => {
+  const ACCOUNT_ID = 'account-expiry-spec'
+
+  beforeAll(async () => {
+    await dbMigration.up()
+    await accountsRepository.createAccount(
+      ACCOUNT_ID,
+      'org-expiry-spec',
+      'monthly',
+      0,
+      0,
+    )
+  })
+
+  afterAll(async () => {
+    await dbMigration.down()
+  })
+
+  const createBatch = async (params: {
+    intentId: string
+    uploadOriginal: bigint
+    uploadRemaining: bigint
+    expiresAt: Date
+  }) => {
+    await intentsRepository.createIntent({
+      id: params.intentId,
+      userPublicId: `user-${params.intentId}`,
+      status: IntentStatus.COMPLETED,
+      shannonsPerByte: 1000n,
+      expiresAt: new Date('2030-01-01T00:00:00Z'),
+    })
+
+    const row = await purchasedCreditsRepository.createPurchasedCredit({
+      accountId: ACCOUNT_ID,
+      intentId: params.intentId,
+      uploadBytesOriginal: params.uploadOriginal,
+      downloadBytesOriginal: 0n,
+      expiresAt: params.expiresAt,
+    })
+
+    // Simulate consumption directly — consumeUpTo would refuse to touch a
+    // past-expiry row, which is exactly the state we need to reproduce.
+    const db = await getDatabase()
+    await db.query(
+      'UPDATE purchased_credits SET upload_bytes_remaining = $1 WHERE id = $2',
+      [params.uploadRemaining.toString(), row.id],
+    )
+
+    return row.id
+  }
+
+  const getExpiredFlag = async (id: string): Promise<boolean> => {
+    const db = await getDatabase()
+    const result = await db.query<{ expired: boolean }>(
+      'SELECT expired FROM purchased_credits WHERE id = $1',
+      [id],
+    )
+    return result.rows[0].expired
+  }
+
+  const pastDate = new Date(Date.now() - 24 * 60 * 60 * 1000)
+  const futureDate = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000)
+
+  it('marks past-expiry rows with remaining bytes as expired and reports forfeited totals', async () => {
+    const id = await createBatch({
+      intentId: 'expiry-unused',
+      uploadOriginal: 1000n,
+      uploadRemaining: 400n,
+      expiresAt: pastDate,
+    })
+
+    const summary = await purchasedCreditsRepository.markExpiredCredits()
+
+    expect(summary.expiredCount).toBe(1)
+    expect(summary.totalUploadBytesForfeited).toBe(400n)
+    expect(summary.totalDownloadBytesForfeited).toBe(0n)
+    expect(await getExpiredFlag(id)).toBe(true)
+  })
+
+  it('does NOT mark fully depleted past-expiry rows as expired', async () => {
+    const id = await createBatch({
+      intentId: 'expiry-depleted',
+      uploadOriginal: 1000n,
+      uploadRemaining: 0n,
+      expiresAt: pastDate,
+    })
+
+    const summary = await purchasedCreditsRepository.markExpiredCredits()
+
+    expect(summary.expiredCount).toBe(0)
+    expect(summary.totalUploadBytesForfeited).toBe(0n)
+    expect(await getExpiredFlag(id)).toBe(false)
+  })
+
+  it('leaves rows that have not reached expires_at untouched', async () => {
+    const id = await createBatch({
+      intentId: 'expiry-active',
+      uploadOriginal: 1000n,
+      uploadRemaining: 1000n,
+      expiresAt: futureDate,
+    })
+
+    const summary = await purchasedCreditsRepository.markExpiredCredits()
+
+    expect(summary.expiredCount).toBe(0)
+    expect(await getExpiredFlag(id)).toBe(false)
+  })
+})

--- a/apps/backend/__tests__/unit/repositories/purchasedCredits.spec.ts
+++ b/apps/backend/__tests__/unit/repositories/purchasedCredits.spec.ts
@@ -120,4 +120,91 @@ describe('PurchasedCredits Repository — markExpiredCredits', () => {
     expect(summary.expiredCount).toBe(0)
     expect(await getExpiredFlag(id)).toBe(false)
   })
+
+  // ---------------------------------------------------------------------
+  // Refund guard: fully depleted rows must not be markable as refunded —
+  // nothing was forfeited, so no refund is owed on them.
+  // ---------------------------------------------------------------------
+
+  const TX_HASH = `0x${'a'.repeat(64)}`
+
+  describe('markAsRefunded', () => {
+    it('rejects a fully depleted row as notRefundable', async () => {
+      const id = await createBatch({
+        intentId: 'refund-depleted',
+        uploadOriginal: 1000n,
+        uploadRemaining: 0n,
+        expiresAt: pastDate,
+      })
+
+      const result = await purchasedCreditsRepository.markAsRefunded(
+        id,
+        TX_HASH,
+      )
+
+      expect(result.found).toBe(true)
+      expect(result.row).toBeNull()
+      expect(result.notRefundable).toBe(true)
+    })
+
+    it('refunds a row with remaining bytes and stays idempotent on retry', async () => {
+      const id = await createBatch({
+        intentId: 'refund-unused',
+        uploadOriginal: 1000n,
+        uploadRemaining: 400n,
+        expiresAt: pastDate,
+      })
+
+      const first = await purchasedCreditsRepository.markAsRefunded(
+        id,
+        TX_HASH,
+      )
+      expect(first.found).toBe(true)
+      expect(first.row).not.toBeNull()
+      expect(first.row?.uploadBytesRemaining).toBe(0n)
+      expect(first.row?.refundTxHash).toBe(TX_HASH)
+
+      // Retry: remaining is now 0 because of the refund itself — must be an
+      // already-refunded no-op, NOT notRefundable.
+      const retry = await purchasedCreditsRepository.markAsRefunded(
+        id,
+        TX_HASH,
+      )
+      expect(retry.found).toBe(true)
+      expect(retry.row).toBeNull()
+      expect(retry.notRefundable).toBeUndefined()
+    })
+  })
+
+  describe('markManyAsRefunded', () => {
+    it('rejects the whole combined refund when any batch is fully depleted', async () => {
+      const refundableId = await createBatch({
+        intentId: 'combined-unused',
+        uploadOriginal: 1000n,
+        uploadRemaining: 500n,
+        expiresAt: pastDate,
+      })
+      const depletedId = await createBatch({
+        intentId: 'combined-depleted',
+        uploadOriginal: 1000n,
+        uploadRemaining: 0n,
+        expiresAt: pastDate,
+      })
+
+      const result = await purchasedCreditsRepository.markManyAsRefunded(
+        [refundableId, depletedId],
+        TX_HASH,
+      )
+
+      expect(result.nonRefundableIds).toEqual([depletedId])
+      expect(result.refundedRows).toHaveLength(0)
+      // All-or-nothing: the refundable row must not have been updated.
+      const db = await getDatabase()
+      const check = await db.query<{ refunded_at: Date | null }>(
+        'SELECT refunded_at FROM purchased_credits WHERE id = $1',
+        [refundableId],
+      )
+      expect(check.rows[0].refunded_at).toBeNull()
+    })
+  })
 })

--- a/apps/backend/__tests__/unit/repositories/purchasedCredits.spec.ts
+++ b/apps/backend/__tests__/unit/repositories/purchasedCredits.spec.ts
@@ -122,8 +122,8 @@ describe('PurchasedCredits Repository — markExpiredCredits', () => {
   })
 
   // ---------------------------------------------------------------------
-  // Refund guard: fully depleted rows must not be markable as refunded —
-  // nothing was forfeited, so no refund is owed on them.
+  // Refund guard: depleted rows (0 upload bytes remaining) must not be
+  // markable as refunded — nothing was forfeited, so no refund is owed.
   // ---------------------------------------------------------------------
 
   const TX_HASH = `0x${'a'.repeat(64)}`

--- a/apps/backend/__tests__/unit/useCases/credits.spec.ts
+++ b/apps/backend/__tests__/unit/useCases/credits.spec.ts
@@ -524,6 +524,25 @@ describe('CreditsUseCases', () => {
 
       expect(result.isOk()).toBe(true)
     })
+
+    it('returns 400 BadRequestError when the batch is fully depleted', async () => {
+      // Fully depleted (0 bytes remaining) and never refunded — nothing was
+      // forfeited, so no refund is owed and the API must reject it.
+      jest
+        .spyOn(purchasedCreditsRepository, 'markAsRefunded')
+        .mockResolvedValue({ found: true, row: null, notRefundable: true })
+
+      const result = await CreditsUseCases.refundBatch(
+        adminUser,
+        BATCH_1,
+        VALID_TX_HASH,
+      )
+
+      expect(result.isErr()).toBe(true)
+      const error = result._unsafeUnwrapErr()
+      expect(error).toBeInstanceOf(BadRequestError)
+      expect(error.message).toContain('depleted')
+    })
   })
 
   // ──────────────────────────────────────────────────────────────────────────
@@ -721,6 +740,33 @@ describe('CreditsUseCases', () => {
         refundedCount: 0,
         alreadyRefundedCount: 2,
       })
+    })
+
+    it('returns 400 BadRequestError listing fully depleted batch ids', async () => {
+      // A combined refund including a fully depleted batch is rejected
+      // all-or-nothing — no refund is owed on a used-up batch.
+      jest
+        .spyOn(purchasedCreditsRepository, 'markManyAsRefunded')
+        .mockResolvedValue({
+          missingIds: [],
+          accountIds: ['account-id'],
+          walletAddresses: ['0xwallet-1'],
+          refundedRows: [],
+          alreadyRefundedIds: [],
+          nonRefundableIds: [BATCH_2],
+        })
+
+      const result = await CreditsUseCases.refundBatches(
+        adminUser,
+        [BATCH_1, BATCH_2],
+        VALID_TX_HASH,
+      )
+
+      expect(result.isErr()).toBe(true)
+      const error = result._unsafeUnwrapErr()
+      expect(error).toBeInstanceOf(BadRequestError)
+      expect(error.message).toContain('depleted')
+      expect(error.message).toContain(BATCH_2)
     })
 
     it('returns 404 NotFoundError listing missing ids', async () => {

--- a/apps/backend/migrations/20260703000000-fix-depleted-marked-expired.js
+++ b/apps/backend/migrations/20260703000000-fix-depleted-marked-expired.js
@@ -1,0 +1,53 @@
+'use strict'
+
+var dbm
+var type
+var seed
+var fs = require('fs')
+var path = require('path')
+var Promise
+
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  var filePath = path.join(
+    __dirname,
+    'sqls',
+    '20260703000000-fix-depleted-marked-expired-up.sql',
+  )
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+      resolve(data)
+    })
+  }).then(function (data) {
+    return db.runSql(data)
+  })
+}
+
+exports.down = function (db) {
+  var filePath = path.join(
+    __dirname,
+    'sqls',
+    '20260703000000-fix-depleted-marked-expired-down.sql',
+  )
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+      resolve(data)
+    })
+  }).then(function (data) {
+    return db.runSql(data)
+  })
+}
+
+exports._meta = {
+  version: 1,
+}

--- a/apps/backend/migrations/sqls/20260703000000-fix-depleted-marked-expired-down.sql
+++ b/apps/backend/migrations/sqls/20260703000000-fix-depleted-marked-expired-down.sql
@@ -8,5 +8,4 @@ SET expired    = TRUE,
 WHERE expired = FALSE
   AND expires_at <= NOW()
   AND upload_bytes_remaining = 0
-  AND download_bytes_remaining = 0
   AND refunded_at IS NULL;

--- a/apps/backend/migrations/sqls/20260703000000-fix-depleted-marked-expired-down.sql
+++ b/apps/backend/migrations/sqls/20260703000000-fix-depleted-marked-expired-down.sql
@@ -1,0 +1,12 @@
+-- Restore the (incorrect) pre-fix state: past-expiry depleted rows were
+-- flagged expired. Only rows past their expires_at are re-flagged, matching
+-- what the old expiry job would have done.
+
+UPDATE purchased_credits
+SET expired    = TRUE,
+    updated_at = NOW()
+WHERE expired = FALSE
+  AND expires_at <= NOW()
+  AND upload_bytes_remaining = 0
+  AND download_bytes_remaining = 0
+  AND refunded_at IS NULL;

--- a/apps/backend/migrations/sqls/20260703000000-fix-depleted-marked-expired-up.sql
+++ b/apps/backend/migrations/sqls/20260703000000-fix-depleted-marked-expired-up.sql
@@ -1,10 +1,13 @@
--- Data fix: un-expire fully depleted credit batches.
+-- Data fix: un-expire depleted credit batches.
 --
 -- The credit expiry job used to mark every row past expires_at as
--- expired = TRUE, including rows whose credits had already been fully
--- consumed (0 upload + 0 download bytes remaining). Those rows then showed
--- up in the admin panel as "expired, awaiting refund" even though nothing
--- was forfeited and no refund is owed.
+-- expired = TRUE, including rows whose upload credits had already been
+-- fully consumed (0 upload bytes remaining). Those rows then showed up in
+-- the admin panel as "expired, awaiting refund" even though nothing was
+-- forfeited and no refund is owed.
+--
+-- Depletion is defined on upload bytes only: download bytes are not
+-- allocated, consumed or enforced anywhere in the app.
 --
 -- Refunded rows are excluded: markAsRefunded zeros the remaining bytes, so
 -- a refunded row with expired = TRUE was genuinely expired (with bytes
@@ -15,5 +18,4 @@ SET expired    = FALSE,
     updated_at = NOW()
 WHERE expired = TRUE
   AND upload_bytes_remaining = 0
-  AND download_bytes_remaining = 0
   AND refunded_at IS NULL;

--- a/apps/backend/migrations/sqls/20260703000000-fix-depleted-marked-expired-up.sql
+++ b/apps/backend/migrations/sqls/20260703000000-fix-depleted-marked-expired-up.sql
@@ -1,0 +1,19 @@
+-- Data fix: un-expire fully depleted credit batches.
+--
+-- The credit expiry job used to mark every row past expires_at as
+-- expired = TRUE, including rows whose credits had already been fully
+-- consumed (0 upload + 0 download bytes remaining). Those rows then showed
+-- up in the admin panel as "expired, awaiting refund" even though nothing
+-- was forfeited and no refund is owed.
+--
+-- Refunded rows are excluded: markAsRefunded zeros the remaining bytes, so
+-- a refunded row with expired = TRUE was genuinely expired (with bytes
+-- remaining) before the admin refunded it.
+
+UPDATE purchased_credits
+SET expired    = FALSE,
+    updated_at = NOW()
+WHERE expired = TRUE
+  AND upload_bytes_remaining = 0
+  AND download_bytes_remaining = 0
+  AND refunded_at IS NULL;

--- a/apps/backend/src/core/users/credits.ts
+++ b/apps/backend/src/core/users/credits.ts
@@ -232,7 +232,8 @@ const validateRefundTxHash = (
 // returns ok() so the UI can safely retry on network errors (the original
 // refund_tx_hash is preserved).
 // Returns 403 for non-admin callers, 404 if the batch does not exist,
-// 400 if the transaction hash is missing or malformed.
+// 400 if the transaction hash is missing or malformed, or if the batch is
+// fully depleted (0 bytes remaining — nothing forfeited, no refund owed).
 // ---------------------------------------------------------------------------
 
 const refundBatch = async (
@@ -253,12 +254,20 @@ const refundBatch = async (
     return err(txHashResult.error)
   }
 
-  const { found, row } = await purchasedCreditsRepository.markAsRefunded(
-    batchId,
-    txHashResult.value,
-  )
+  const { found, row, notRefundable } =
+    await purchasedCreditsRepository.markAsRefunded(batchId, txHashResult.value)
   if (!found) {
     return err(new NotFoundError('Credit batch not found'))
+  }
+
+  if (notRefundable) {
+    // Fully depleted (0 bytes remaining) and never refunded — nothing was
+    // forfeited, so no refund is owed and recording one would be a mistake.
+    return err(
+      new BadRequestError(
+        'Credit batch is fully depleted — no unused bytes remain, so no refund is owed',
+      ),
+    )
   }
 
   if (row) {
@@ -292,7 +301,8 @@ const refundBatch = async (
 // and are excluded from both checks, so retries succeed even if the
 // already-refunded rows belong to different accounts or wallets.
 // Returns 403 for non-admin callers, 400 if the transaction hash is missing
-// or malformed, or if no batch ids are provided.
+// or malformed, if no batch ids are provided, or if any batch is fully
+// depleted (0 bytes remaining — no refund is owed on it).
 // ---------------------------------------------------------------------------
 
 export type RefundBatchesSummary = {
@@ -346,6 +356,16 @@ const refundBatches = async (
     return err(
       new NotFoundError(
         `Credit batches not found: ${result.missingIds.join(', ')}`,
+      ),
+    )
+  }
+
+  if (result.nonRefundableIds && result.nonRefundableIds.length > 0) {
+    // Fully depleted batches owe no refund; reject the whole combined
+    // refund (all-or-nothing, mirroring the missing-ids handling).
+    return err(
+      new BadRequestError(
+        `Credit batches are fully depleted and owe no refund: ${result.nonRefundableIds.join(', ')}`,
       ),
     )
   }

--- a/apps/backend/src/core/users/credits.ts
+++ b/apps/backend/src/core/users/credits.ts
@@ -233,7 +233,7 @@ const validateRefundTxHash = (
 // refund_tx_hash is preserved).
 // Returns 403 for non-admin callers, 404 if the batch does not exist,
 // 400 if the transaction hash is missing or malformed, or if the batch is
-// fully depleted (0 bytes remaining — nothing forfeited, no refund owed).
+// depleted (0 upload bytes remaining — nothing forfeited, no refund owed).
 // ---------------------------------------------------------------------------
 
 const refundBatch = async (
@@ -261,11 +261,11 @@ const refundBatch = async (
   }
 
   if (notRefundable) {
-    // Fully depleted (0 bytes remaining) and never refunded — nothing was
+    // Depleted (0 upload bytes remaining) and never refunded — nothing was
     // forfeited, so no refund is owed and recording one would be a mistake.
     return err(
       new BadRequestError(
-        'Credit batch is fully depleted — no unused bytes remain, so no refund is owed',
+        'Credit batch is fully depleted — no unused upload bytes remain, so no refund is owed',
       ),
     )
   }
@@ -301,8 +301,8 @@ const refundBatch = async (
 // and are excluded from both checks, so retries succeed even if the
 // already-refunded rows belong to different accounts or wallets.
 // Returns 403 for non-admin callers, 400 if the transaction hash is missing
-// or malformed, if no batch ids are provided, or if any batch is fully
-// depleted (0 bytes remaining — no refund is owed on it).
+// or malformed, if no batch ids are provided, or if any batch is depleted
+// (0 upload bytes remaining — no refund is owed on it).
 // ---------------------------------------------------------------------------
 
 export type RefundBatchesSummary = {
@@ -361,8 +361,8 @@ const refundBatches = async (
   }
 
   if (result.nonRefundableIds && result.nonRefundableIds.length > 0) {
-    // Fully depleted batches owe no refund; reject the whole combined
-    // refund (all-or-nothing, mirroring the missing-ids handling).
+    // Depleted batches (0 upload bytes remaining) owe no refund; reject the
+    // whole combined refund (all-or-nothing, mirroring missing-ids handling).
     return err(
       new BadRequestError(
         `Credit batches are fully depleted and owe no refund: ${result.nonRefundableIds.join(', ')}`,

--- a/apps/backend/src/infrastructure/repositories/users/purchasedCredits.ts
+++ b/apps/backend/src/infrastructure/repositories/users/purchasedCredits.ts
@@ -577,6 +577,10 @@ const UUID_REGEX =
 // and mark it as refunded, recording the on-chain transaction hash of the
 // AI3 refund transfer.  Called after an admin has processed an out-of-band
 // refund (manual AI3 transfer back to the user's wallet).
+// Fully depleted rows (0 upload + 0 download remaining, never refunded)
+// are rejected with notRefundable — nothing was forfeited, so no refund is
+// owed on them. This mirrors the UI guard so the API cannot be used to
+// record a refund on a used-up batch.
 // Returns the updated row so the caller can echo it back to the client.
 // Malformed (non-UUID) ids are reported as not found.
 // ---------------------------------------------------------------------------
@@ -584,7 +588,12 @@ const UUID_REGEX =
 const markAsRefunded = async (
   id: string,
   refundTxHash: string,
-): Promise<{ found: boolean; row: PurchasedCredit | null }> => {
+): Promise<{
+  found: boolean
+  row: PurchasedCredit | null
+  /** True when the row exists, is not refunded, but has no remaining bytes. */
+  notRefundable?: boolean
+}> => {
   if (!UUID_REGEX.test(id)) {
     return { found: false, row: null }
   }
@@ -599,6 +608,7 @@ const markAsRefunded = async (
          updated_at               = NOW()
      WHERE id = $1
        AND refunded_at IS NULL
+       AND (upload_bytes_remaining > 0 OR download_bytes_remaining > 0)
      RETURNING *`,
     [id, refundTxHash],
   )
@@ -607,11 +617,21 @@ const markAsRefunded = async (
     return { found: true, row: mapRow(result.rows[0]) }
   }
 
-  const exists = await db.query<{ id: string }>(
-    'SELECT id FROM purchased_credits WHERE id = $1',
-    [id],
-  )
-  return { found: exists.rows.length > 0, row: null }
+  const existing = await db.query<{
+    id: string
+    refunded_at: Date | null
+  }>('SELECT id, refunded_at FROM purchased_credits WHERE id = $1', [id])
+
+  if (existing.rows.length === 0) {
+    return { found: false, row: null }
+  }
+
+  // Already refunded → idempotent no-op. Not refunded but skipped by the
+  // UPDATE → fully depleted, no refund owed.
+  if (existing.rows[0].refunded_at !== null) {
+    return { found: true, row: null }
+  }
+  return { found: true, row: null, notRefundable: true }
 }
 
 // ---------------------------------------------------------------------------
@@ -644,6 +664,13 @@ export type BatchRefundResult = {
   walletAddresses: (string | null)[]
   refundedRows: PurchasedCredit[]
   alreadyRefundedIds: string[]
+  /**
+   * Ids of rows that are not refunded but fully depleted (0 upload +
+   * 0 download remaining) — no refund is owed on them, so their presence
+   * rejects the whole combined refund. Optional for backwards compatibility
+   * with existing callers/mocks; absent means none.
+   */
+  nonRefundableIds?: string[]
 }
 
 const markManyAsRefunded = async (
@@ -677,9 +704,13 @@ const markManyAsRefunded = async (
       id: string
       account_id: string
       refunded_at: Date | null
+      upload_bytes_remaining: string
+      download_bytes_remaining: string
       from_address: string | null
     }>(
-      `SELECT pc.id, pc.account_id, pc.refunded_at, i.from_address
+      `SELECT pc.id, pc.account_id, pc.refunded_at,
+              pc.upload_bytes_remaining, pc.download_bytes_remaining,
+              i.from_address
        FROM purchased_credits pc
        JOIN intents i ON i.id = pc.intent_id
        WHERE pc.id = ANY($1::uuid[])
@@ -700,6 +731,18 @@ const markManyAsRefunded = async (
       ...new Set(pendingRows.map((r) => r.from_address)),
     ]
 
+    // Pending rows with no remaining bytes are fully depleted — nothing was
+    // forfeited, so no refund is owed on them. Their presence rejects the
+    // whole combined refund (all-or-nothing, like missing ids).
+    const nonRefundableIds = pendingRows
+      .filter(
+        (r) =>
+          BigInt(r.upload_bytes_remaining) +
+            BigInt(r.download_bytes_remaining) ===
+          BigInt(0),
+      )
+      .map((r) => r.id)
+
     if (missingIds.length > 0) {
       await client.query('ROLLBACK')
       return {
@@ -708,6 +751,19 @@ const markManyAsRefunded = async (
         walletAddresses,
         refundedRows: [],
         alreadyRefundedIds: [],
+        nonRefundableIds,
+      }
+    }
+
+    if (nonRefundableIds.length > 0) {
+      await client.query('ROLLBACK')
+      return {
+        missingIds: [],
+        accountIds,
+        walletAddresses,
+        refundedRows: [],
+        alreadyRefundedIds: [],
+        nonRefundableIds,
       }
     }
 
@@ -719,6 +775,7 @@ const markManyAsRefunded = async (
         walletAddresses,
         refundedRows: [],
         alreadyRefundedIds: [],
+        nonRefundableIds: [],
       }
     }
 
@@ -746,6 +803,7 @@ const markManyAsRefunded = async (
       walletAddresses,
       refundedRows: updated.rows.map(mapRow),
       alreadyRefundedIds,
+      nonRefundableIds: [],
     }
   } catch (error) {
     await client.query('ROLLBACK')

--- a/apps/backend/src/infrastructure/repositories/users/purchasedCredits.ts
+++ b/apps/backend/src/infrastructure/repositories/users/purchasedCredits.ts
@@ -320,11 +320,12 @@ const getExpiringCreditsByAccountId = async (
 // markExpiredCredits
 // Called by the credit expiry background job.
 // Atomically marks rows whose expires_at has passed AND that still have
-// remaining bytes, returning a summary of bytes forfeited for logging and
-// metrics. Fully depleted rows (0 upload + 0 download remaining) are never
-// marked expired: nothing was forfeited, the batch was simply used up, and
-// flagging it as expired would incorrectly surface it to admins as awaiting
-// a refund.
+// remaining upload bytes, returning a summary of bytes forfeited for logging
+// and metrics. Depleted rows (0 upload bytes remaining) are never marked
+// expired: nothing was forfeited, the batch was simply used up, and flagging
+// it as expired would incorrectly surface it to admins as awaiting a refund.
+// Download bytes are deliberately ignored — they are not allocated, consumed
+// or enforced anywhere in the app.
 // ---------------------------------------------------------------------------
 
 export type ExpiredCreditsSummary = {
@@ -345,7 +346,7 @@ const markExpiredCredits = async (): Promise<ExpiredCreditsSummary> => {
        SET expired = TRUE, updated_at = NOW()
        WHERE expired = FALSE
          AND expires_at <= NOW()
-         AND (upload_bytes_remaining > 0 OR download_bytes_remaining > 0)
+         AND upload_bytes_remaining > 0
        RETURNING upload_bytes_remaining, download_bytes_remaining
      )
      SELECT
@@ -577,10 +578,11 @@ const UUID_REGEX =
 // and mark it as refunded, recording the on-chain transaction hash of the
 // AI3 refund transfer.  Called after an admin has processed an out-of-band
 // refund (manual AI3 transfer back to the user's wallet).
-// Fully depleted rows (0 upload + 0 download remaining, never refunded)
-// are rejected with notRefundable — nothing was forfeited, so no refund is
-// owed on them. This mirrors the UI guard so the API cannot be used to
-// record a refund on a used-up batch.
+// Depleted rows (0 upload bytes remaining, never refunded) are rejected
+// with notRefundable — nothing was forfeited, so no refund is owed on them.
+// This mirrors the UI guard so the API cannot be used to record a refund on
+// a used-up batch. Download bytes are deliberately ignored — they are not
+// allocated, consumed or enforced anywhere in the app.
 // Returns the updated row so the caller can echo it back to the client.
 // Malformed (non-UUID) ids are reported as not found.
 // ---------------------------------------------------------------------------
@@ -591,7 +593,7 @@ const markAsRefunded = async (
 ): Promise<{
   found: boolean
   row: PurchasedCredit | null
-  /** True when the row exists, is not refunded, but has no remaining bytes. */
+  /** True when the row exists, is not refunded, but has 0 upload bytes left. */
   notRefundable?: boolean
 }> => {
   if (!UUID_REGEX.test(id)) {
@@ -608,7 +610,7 @@ const markAsRefunded = async (
          updated_at               = NOW()
      WHERE id = $1
        AND refunded_at IS NULL
-       AND (upload_bytes_remaining > 0 OR download_bytes_remaining > 0)
+       AND upload_bytes_remaining > 0
      RETURNING *`,
     [id, refundTxHash],
   )
@@ -665,10 +667,10 @@ export type BatchRefundResult = {
   refundedRows: PurchasedCredit[]
   alreadyRefundedIds: string[]
   /**
-   * Ids of rows that are not refunded but fully depleted (0 upload +
-   * 0 download remaining) — no refund is owed on them, so their presence
-   * rejects the whole combined refund. Optional for backwards compatibility
-   * with existing callers/mocks; absent means none.
+   * Ids of rows that are not refunded but depleted (0 upload bytes
+   * remaining) — no refund is owed on them, so their presence rejects the
+   * whole combined refund. Optional for backwards compatibility with
+   * existing callers/mocks; absent means none.
    */
   nonRefundableIds?: string[]
 }
@@ -705,11 +707,10 @@ const markManyAsRefunded = async (
       account_id: string
       refunded_at: Date | null
       upload_bytes_remaining: string
-      download_bytes_remaining: string
       from_address: string | null
     }>(
       `SELECT pc.id, pc.account_id, pc.refunded_at,
-              pc.upload_bytes_remaining, pc.download_bytes_remaining,
+              pc.upload_bytes_remaining,
               i.from_address
        FROM purchased_credits pc
        JOIN intents i ON i.id = pc.intent_id
@@ -731,16 +732,11 @@ const markManyAsRefunded = async (
       ...new Set(pendingRows.map((r) => r.from_address)),
     ]
 
-    // Pending rows with no remaining bytes are fully depleted — nothing was
-    // forfeited, so no refund is owed on them. Their presence rejects the
-    // whole combined refund (all-or-nothing, like missing ids).
+    // Pending rows with no remaining upload bytes are depleted — nothing
+    // was forfeited, so no refund is owed on them. Their presence rejects
+    // the whole combined refund (all-or-nothing, like missing ids).
     const nonRefundableIds = pendingRows
-      .filter(
-        (r) =>
-          BigInt(r.upload_bytes_remaining) +
-            BigInt(r.download_bytes_remaining) ===
-          BigInt(0),
-      )
+      .filter((r) => BigInt(r.upload_bytes_remaining) === BigInt(0))
       .map((r) => r.id)
 
     if (missingIds.length > 0) {

--- a/apps/backend/src/infrastructure/repositories/users/purchasedCredits.ts
+++ b/apps/backend/src/infrastructure/repositories/users/purchasedCredits.ts
@@ -318,9 +318,13 @@ const getExpiringCreditsByAccountId = async (
 
 // ---------------------------------------------------------------------------
 // markExpiredCredits
-// Called by the credit expiry background job (to be added in a later PR).
-// Atomically marks all rows whose expires_at has passed and returns a summary
-// of bytes forfeited for logging and metrics.
+// Called by the credit expiry background job.
+// Atomically marks rows whose expires_at has passed AND that still have
+// remaining bytes, returning a summary of bytes forfeited for logging and
+// metrics. Fully depleted rows (0 upload + 0 download remaining) are never
+// marked expired: nothing was forfeited, the batch was simply used up, and
+// flagging it as expired would incorrectly surface it to admins as awaiting
+// a refund.
 // ---------------------------------------------------------------------------
 
 export type ExpiredCreditsSummary = {
@@ -341,6 +345,7 @@ const markExpiredCredits = async (): Promise<ExpiredCreditsSummary> => {
        SET expired = TRUE, updated_at = NOW()
        WHERE expired = FALSE
          AND expires_at <= NOW()
+         AND (upload_bytes_remaining > 0 OR download_bytes_remaining > 0)
        RETURNING upload_bytes_remaining, download_bytes_remaining
      )
      SELECT

--- a/apps/frontend/__tests__/unit/utils/credits.spec.ts
+++ b/apps/frontend/__tests__/unit/utils/credits.spec.ts
@@ -188,9 +188,10 @@ describe('getBatchStatus', () => {
     jest.useRealTimers()
   })
 
-  const makeBatch = (overrides: Partial<{ expired: boolean; uploadBytesRemaining: string; expiresAt: string }> = {}) => ({
+  const makeBatch = (overrides: Partial<{ expired: boolean; uploadBytesRemaining: string; downloadBytesRemaining: string; expiresAt: string }> = {}) => ({
     expired: false,
     uploadBytesRemaining: '1048576',
+    downloadBytesRemaining: '0',
     expiresAt: '2026-12-01T00:00:00Z',
     ...overrides,
   })
@@ -199,8 +200,16 @@ describe('getBatchStatus', () => {
     expect(getBatchStatus(makeBatch({ expired: true }))).toBe('expired')
   })
 
-  it('returns "depleted" when uploadBytesRemaining is zero', () => {
+  it('returns "depleted" when both upload and download remaining are zero', () => {
     expect(getBatchStatus(makeBatch({ uploadBytesRemaining: '0' }))).toBe('depleted')
+  })
+
+  it('is NOT depleted while download bytes remain — matches isBatchRefundable', () => {
+    expect(getBatchStatus(makeBatch({ uploadBytesRemaining: '0', downloadBytesRemaining: '512' }))).toBe('active')
+  })
+
+  it('an expired batch with only download bytes left is "expired", not "depleted"', () => {
+    expect(getBatchStatus(makeBatch({ expired: true, uploadBytesRemaining: '0', downloadBytesRemaining: '512' }))).toBe('expired')
   })
 
   it('returns "expiring" when the batch expires within 30 days', () => {

--- a/apps/frontend/__tests__/unit/utils/credits.spec.ts
+++ b/apps/frontend/__tests__/unit/utils/credits.spec.ts
@@ -1,4 +1,4 @@
-import { isMibOverCap, isPackageOverCap, daysUntilExpiry, sumExpiringUploadBytes, getBatchStatus } from '../../../src/utils/credits'
+import { isMibOverCap, isPackageOverCap, daysUntilExpiry, sumExpiringUploadBytes, getBatchStatus, isBatchRefundable } from '../../../src/utils/credits'
 
 // ---------------------------------------------------------------------------
 // isMibOverCap (shared helper used by both package and custom-amount flows)
@@ -226,5 +226,40 @@ describe('getBatchStatus', () => {
 
   it('prioritises "depleted" over "expiring"', () => {
     expect(getBatchStatus(makeBatch({ uploadBytesRemaining: '0', expiresAt: '2026-06-10T00:00:00Z' }))).toBe('depleted')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isBatchRefundable
+// ---------------------------------------------------------------------------
+
+describe('isBatchRefundable', () => {
+  const makeBatch = (
+    overrides: Partial<{
+      refundedAt: string | null
+      uploadBytesRemaining: string
+      downloadBytesRemaining: string
+    }> = {},
+  ) => ({
+    refundedAt: null,
+    uploadBytesRemaining: '1048576',
+    downloadBytesRemaining: '0',
+    ...overrides,
+  })
+
+  it('returns true for a non-refunded batch with upload bytes remaining', () => {
+    expect(isBatchRefundable(makeBatch())).toBe(true)
+  })
+
+  it('returns true when only download bytes remain', () => {
+    expect(isBatchRefundable(makeBatch({ uploadBytesRemaining: '0', downloadBytesRemaining: '512' }))).toBe(true)
+  })
+
+  it('returns false when the batch is already refunded', () => {
+    expect(isBatchRefundable(makeBatch({ refundedAt: '2026-06-01T00:00:00Z' }))).toBe(false)
+  })
+
+  it('returns false for a fully depleted batch — no refund is owed', () => {
+    expect(isBatchRefundable(makeBatch({ uploadBytesRemaining: '0', downloadBytesRemaining: '0' }))).toBe(false)
   })
 })

--- a/apps/frontend/__tests__/unit/utils/credits.spec.ts
+++ b/apps/frontend/__tests__/unit/utils/credits.spec.ts
@@ -216,8 +216,12 @@ describe('getBatchStatus', () => {
     expect(getBatchStatus(makeBatch({ expiresAt: '2026-07-02T00:00:00Z' }))).toBe('active')
   })
 
-  it('prioritises "expired" over "depleted"', () => {
-    expect(getBatchStatus(makeBatch({ expired: true, uploadBytesRemaining: '0' }))).toBe('expired')
+  it('prioritises "depleted" over "expired" (fully used batches owe no refund)', () => {
+    expect(getBatchStatus(makeBatch({ expired: true, uploadBytesRemaining: '0' }))).toBe('depleted')
+  })
+
+  it('returns "expired" when the batch is expired with bytes remaining', () => {
+    expect(getBatchStatus(makeBatch({ expired: true, uploadBytesRemaining: '1048576' }))).toBe('expired')
   })
 
   it('prioritises "depleted" over "expiring"', () => {

--- a/apps/frontend/__tests__/unit/utils/credits.spec.ts
+++ b/apps/frontend/__tests__/unit/utils/credits.spec.ts
@@ -188,10 +188,9 @@ describe('getBatchStatus', () => {
     jest.useRealTimers()
   })
 
-  const makeBatch = (overrides: Partial<{ expired: boolean; uploadBytesRemaining: string; downloadBytesRemaining: string; expiresAt: string }> = {}) => ({
+  const makeBatch = (overrides: Partial<{ expired: boolean; uploadBytesRemaining: string; expiresAt: string }> = {}) => ({
     expired: false,
     uploadBytesRemaining: '1048576',
-    downloadBytesRemaining: '0',
     expiresAt: '2026-12-01T00:00:00Z',
     ...overrides,
   })
@@ -200,16 +199,8 @@ describe('getBatchStatus', () => {
     expect(getBatchStatus(makeBatch({ expired: true }))).toBe('expired')
   })
 
-  it('returns "depleted" when both upload and download remaining are zero', () => {
+  it('returns "depleted" when uploadBytesRemaining is zero', () => {
     expect(getBatchStatus(makeBatch({ uploadBytesRemaining: '0' }))).toBe('depleted')
-  })
-
-  it('is NOT depleted while download bytes remain — matches isBatchRefundable', () => {
-    expect(getBatchStatus(makeBatch({ uploadBytesRemaining: '0', downloadBytesRemaining: '512' }))).toBe('active')
-  })
-
-  it('an expired batch with only download bytes left is "expired", not "depleted"', () => {
-    expect(getBatchStatus(makeBatch({ expired: true, uploadBytesRemaining: '0', downloadBytesRemaining: '512' }))).toBe('expired')
   })
 
   it('returns "expiring" when the batch expires within 30 days', () => {
@@ -247,12 +238,10 @@ describe('isBatchRefundable', () => {
     overrides: Partial<{
       refundedAt: string | null
       uploadBytesRemaining: string
-      downloadBytesRemaining: string
     }> = {},
   ) => ({
     refundedAt: null,
     uploadBytesRemaining: '1048576',
-    downloadBytesRemaining: '0',
     ...overrides,
   })
 
@@ -260,15 +249,11 @@ describe('isBatchRefundable', () => {
     expect(isBatchRefundable(makeBatch())).toBe(true)
   })
 
-  it('returns true when only download bytes remain', () => {
-    expect(isBatchRefundable(makeBatch({ uploadBytesRemaining: '0', downloadBytesRemaining: '512' }))).toBe(true)
-  })
-
   it('returns false when the batch is already refunded', () => {
     expect(isBatchRefundable(makeBatch({ refundedAt: '2026-06-01T00:00:00Z' }))).toBe(false)
   })
 
-  it('returns false for a fully depleted batch — no refund is owed', () => {
-    expect(isBatchRefundable(makeBatch({ uploadBytesRemaining: '0', downloadBytesRemaining: '0' }))).toBe(false)
+  it('returns false for a depleted batch (0 upload bytes) — no refund is owed', () => {
+    expect(isBatchRefundable(makeBatch({ uploadBytesRemaining: '0' }))).toBe(false)
   })
 })

--- a/apps/frontend/src/components/views/AdminPanel/AdminCredits.tsx
+++ b/apps/frontend/src/components/views/AdminPanel/AdminCredits.tsx
@@ -190,8 +190,15 @@ const groupBatchesByAccount = (
     ),
     userPublicIds: [...new Set(accountBatches.map((b) => b.userPublicId))],
     walletCount: new Set(accountBatches.map((b) => b.fromAddress ?? '—')).size,
+    // Awaiting refund = expired with unused bytes left. Fully depleted
+    // batches (0 remaining) forfeited nothing, so no refund is owed —
+    // require remaining > 0 as defence in depth against stale expired flags.
     refundableCount: accountBatches.filter(
-      (b) => b.expired && b.refundedAt === null,
+      (b) =>
+        b.expired &&
+        b.refundedAt === null &&
+        BigInt(b.uploadBytesRemaining) + BigInt(b.downloadBytesRemaining) >
+          BigInt(0),
     ).length,
     refundedCount: accountBatches.filter((b) => b.refundedAt !== null).length,
     totalPurchased: accountBatches.reduce(

--- a/apps/frontend/src/components/views/AdminPanel/AdminCredits.tsx
+++ b/apps/frontend/src/components/views/AdminPanel/AdminCredits.tsx
@@ -17,6 +17,7 @@ import {
 import { Button, ROUTES, type NetworkId } from '@auto-drive/ui';
 import {
   getBatchStatus,
+  isBatchRefundable,
   STATUS_CLASSES,
   STATUS_LABEL,
 } from '../../../utils/credits';
@@ -190,15 +191,12 @@ const groupBatchesByAccount = (
     ),
     userPublicIds: [...new Set(accountBatches.map((b) => b.userPublicId))],
     walletCount: new Set(accountBatches.map((b) => b.fromAddress ?? '—')).size,
-    // Awaiting refund = expired with unused bytes left. Fully depleted
-    // batches (0 remaining) forfeited nothing, so no refund is owed —
-    // require remaining > 0 as defence in depth against stale expired flags.
+    // Awaiting refund = expired AND refundable (not yet refunded, unused
+    // bytes left). Fully depleted batches forfeited nothing, so no refund
+    // is owed — isBatchRefundable excludes them as defence in depth
+    // against stale expired flags.
     refundableCount: accountBatches.filter(
-      (b) =>
-        b.expired &&
-        b.refundedAt === null &&
-        BigInt(b.uploadBytesRemaining) + BigInt(b.downloadBytesRemaining) >
-          BigInt(0),
+      (b) => b.expired && isBatchRefundable(b),
     ).length,
     refundedCount: accountBatches.filter((b) => b.refundedAt !== null).length,
     totalPurchased: accountBatches.reduce(

--- a/apps/frontend/src/components/views/AdminPanel/AdminUserCredits.tsx
+++ b/apps/frontend/src/components/views/AdminPanel/AdminUserCredits.tsx
@@ -13,7 +13,12 @@ import {
   ExternalLink,
 } from 'lucide-react';
 import { Button, ROUTES } from '@auto-drive/ui';
-import { getBatchStatus, STATUS_CLASSES, STATUS_LABEL } from '../../../utils/credits';
+import {
+  getBatchStatus,
+  isBatchRefundable,
+  STATUS_CLASSES,
+  STATUS_LABEL,
+} from '../../../utils/credits';
 import type { AdminUserCreditBatch } from '../../../services/api';
 import Link from 'next/link';
 import { shannonsToAi3 } from '@autonomys/auto-utils';
@@ -93,8 +98,11 @@ export const AdminUserCredits = ({
   );
   const hasMultipleRefundGroups = refundGroupKeys.length > 1;
 
+  // Refundable = not yet refunded AND unused bytes remaining (shared
+  // isBatchRefundable helper). Fully depleted batches owe no refund and are
+  // excluded from selection, select-all and the per-row refund button.
   const refundableIds = useMemo(
-    () => new Set(batches.filter((b) => b.refundedAt === null).map((b) => b.id)),
+    () => new Set(batches.filter(isBatchRefundable).map((b) => b.id)),
     [batches],
   );
 
@@ -112,7 +120,7 @@ export const AdminUserCredits = ({
   const selectedGroupKey = selectedBatch ? refundGroupKey(selectedBatch) : null;
 
   const isSelectable = (batch: AdminUserCreditBatch): boolean =>
-    batch.refundedAt === null &&
+    isBatchRefundable(batch) &&
     (selectedGroupKey === null || refundGroupKey(batch) === selectedGroupKey);
 
   // Select-all targets a single (account, purchasing wallet) group: the
@@ -358,7 +366,7 @@ export const AdminUserCredits = ({
                 const original = Number(BigInt(batch.uploadBytesOriginal));
                 const remaining = Number(BigInt(batch.uploadBytesRemaining));
                 const consumed = original - remaining;
-                const isRefundable = batch.refundedAt === null;
+                const isRefundable = isBatchRefundable(batch);
                 const isOtherRefundGroup =
                   isRefundable && !isSelectable(batch);
 
@@ -479,7 +487,7 @@ export const AdminUserCredits = ({
                             </span>
                           )}
                         </div>
-                      ) : (
+                      ) : isRefundable ? (
                         <Button
                           variant='outline'
                           disabled={isRefunding}
@@ -489,6 +497,15 @@ export const AdminUserCredits = ({
                           <AlertTriangle className='h-3 w-3 text-orange-500' />
                           Mark Refunded
                         </Button>
+                      ) : (
+                        // Fully depleted and never refunded — nothing was
+                        // forfeited, so no refund action is offered.
+                        <span
+                          className='text-xs text-muted-foreground'
+                          title='Fully depleted — no unused bytes, no refund owed'
+                        >
+                          —
+                        </span>
                       )}
                     </td>
                   </tr>

--- a/apps/frontend/src/utils/credits.ts
+++ b/apps/frontend/src/utils/credits.ts
@@ -77,6 +77,29 @@ export const getBatchStatus = (batch: BatchStatusFields): BatchStatus => {
   return 'active';
 };
 
+// ---------------------------------------------------------------------------
+// Refundability — shared by AdminCredits and AdminUserCredits so the two
+// admin views cannot drift.
+// ---------------------------------------------------------------------------
+
+export interface RefundableFields {
+  /** ISO timestamp of the refund action, or null if not yet refunded. */
+  refundedAt: string | null;
+  uploadBytesRemaining: string;
+  downloadBytesRemaining: string;
+}
+
+/**
+ * A batch is refundable when it has not been refunded yet AND still has
+ * unused bytes. Fully depleted batches (0 upload + 0 download remaining)
+ * forfeited nothing, so no refund is ever owed on them — they must not be
+ * offered for refund even if a stale `expired` flag is set on the row.
+ */
+export const isBatchRefundable = (batch: RefundableFields): boolean =>
+  batch.refundedAt === null &&
+  BigInt(batch.uploadBytesRemaining) + BigInt(batch.downloadBytesRemaining) >
+    BigInt(0);
+
 export const STATUS_CLASSES: Record<BatchStatus, string> = {
   active:
     'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',

--- a/apps/frontend/src/utils/credits.ts
+++ b/apps/frontend/src/utils/credits.ts
@@ -67,8 +67,11 @@ export interface BatchStatusFields {
 }
 
 export const getBatchStatus = (batch: BatchStatusFields): BatchStatus => {
-  if (batch.expired) return 'expired';
+  // Depleted wins over expired: a fully used-up batch forfeited nothing, so
+  // it must never surface as "Expired" (which implies a refund is owed),
+  // even if a stale expired flag is set on the row.
   if (BigInt(batch.uploadBytesRemaining) === BigInt(0)) return 'depleted';
+  if (batch.expired) return 'expired';
   const days = daysUntilExpiry(new Date(batch.expiresAt));
   if (days !== null && days <= 30) return 'expiring';
   return 'active';

--- a/apps/frontend/src/utils/credits.ts
+++ b/apps/frontend/src/utils/credits.ts
@@ -63,14 +63,21 @@ export type BatchStatus = 'active' | 'expiring' | 'depleted' | 'expired';
 export interface BatchStatusFields {
   expired: boolean;
   uploadBytesRemaining: string;
+  downloadBytesRemaining: string;
   expiresAt: string;
 }
 
 export const getBatchStatus = (batch: BatchStatusFields): BatchStatus => {
+  // Depleted = 0 upload AND 0 download remaining — the same full-depletion
+  // definition as isBatchRefundable and the backend expiry/refund guards.
   // Depleted wins over expired: a fully used-up batch forfeited nothing, so
   // it must never surface as "Expired" (which implies a refund is owed),
   // even if a stale expired flag is set on the row.
-  if (BigInt(batch.uploadBytesRemaining) === BigInt(0)) return 'depleted';
+  if (
+    BigInt(batch.uploadBytesRemaining) + BigInt(batch.downloadBytesRemaining) ===
+    BigInt(0)
+  )
+    return 'depleted';
   if (batch.expired) return 'expired';
   const days = daysUntilExpiry(new Date(batch.expiresAt));
   if (days !== null && days <= 30) return 'expiring';

--- a/apps/frontend/src/utils/credits.ts
+++ b/apps/frontend/src/utils/credits.ts
@@ -63,21 +63,18 @@ export type BatchStatus = 'active' | 'expiring' | 'depleted' | 'expired';
 export interface BatchStatusFields {
   expired: boolean;
   uploadBytesRemaining: string;
-  downloadBytesRemaining: string;
   expiresAt: string;
 }
 
 export const getBatchStatus = (batch: BatchStatusFields): BatchStatus => {
-  // Depleted = 0 upload AND 0 download remaining — the same full-depletion
-  // definition as isBatchRefundable and the backend expiry/refund guards.
+  // Depleted = 0 upload bytes remaining. Download bytes are deliberately
+  // ignored — they are not allocated, consumed or enforced anywhere in the
+  // app, so upload is the only balance that matters. Same definition as
+  // isBatchRefundable and the backend expiry/refund guards.
   // Depleted wins over expired: a fully used-up batch forfeited nothing, so
   // it must never surface as "Expired" (which implies a refund is owed),
   // even if a stale expired flag is set on the row.
-  if (
-    BigInt(batch.uploadBytesRemaining) + BigInt(batch.downloadBytesRemaining) ===
-    BigInt(0)
-  )
-    return 'depleted';
+  if (BigInt(batch.uploadBytesRemaining) === BigInt(0)) return 'depleted';
   if (batch.expired) return 'expired';
   const days = daysUntilExpiry(new Date(batch.expiresAt));
   if (days !== null && days <= 30) return 'expiring';
@@ -93,19 +90,18 @@ export interface RefundableFields {
   /** ISO timestamp of the refund action, or null if not yet refunded. */
   refundedAt: string | null;
   uploadBytesRemaining: string;
-  downloadBytesRemaining: string;
 }
 
 /**
  * A batch is refundable when it has not been refunded yet AND still has
- * unused bytes. Fully depleted batches (0 upload + 0 download remaining)
+ * unused upload bytes. Depleted batches (0 upload bytes remaining)
  * forfeited nothing, so no refund is ever owed on them — they must not be
  * offered for refund even if a stale `expired` flag is set on the row.
+ * Download bytes are deliberately ignored — they are not allocated,
+ * consumed or enforced anywhere in the app.
  */
 export const isBatchRefundable = (batch: RefundableFields): boolean =>
-  batch.refundedAt === null &&
-  BigInt(batch.uploadBytesRemaining) + BigInt(batch.downloadBytesRemaining) >
-    BigInt(0);
+  batch.refundedAt === null && BigInt(batch.uploadBytesRemaining) > BigInt(0);
 
 export const STATUS_CLASSES: Record<BatchStatus, string> = {
   active:


### PR DESCRIPTION
### Problem

In production, a Pay with AI3 purchase whose credits were **100% consumed (0 B remaining)** was showing in the admin panel as **"Expired · awaiting refund"**.

A fully used-up batch forfeited nothing, so no refund is owed. It should read **"Depleted"**, and it should never prompt admins to process a refund.

### Root cause

Two compounding issues:

1. **Backend** — the credit expiry job (`markExpiredCredits`) set `expired = TRUE` on *every* row past `expires_at`, with no check on remaining balance. A batch that was fully consumed before its expiry date still got flagged as expired once the date passed.
2. **Frontend** — `getBatchStatus` checked the `expired` flag before the depleted (0 bytes remaining) check, so the incorrect flag won. The admin "awaiting refund" badge counted every `expired && !refunded` row, surfacing depleted batches as refundable.

### Changes

**Backend**
- `markExpiredCredits` now only expires rows that still have remaining bytes (`upload_bytes_remaining > 0 OR download_bytes_remaining > 0`). Fully depleted rows are never flagged — nothing was forfeited, and forfeited-bytes metrics are unaffected since depleted rows contribute 0.

**Data migration** (`20260703000000-fix-depleted-marked-expired`)
- Un-expires rows already affected in production: `expired = TRUE`, 0 upload + 0 download remaining, `refunded_at IS NULL`.
- Refunded rows are deliberately excluded — `markAsRefunded` zeros remaining bytes, so a refunded row with `expired = TRUE` was genuinely expired *before* the refund.
- Down migration re-flags past-expiry depleted rows, restoring pre-fix behavior.

**Frontend**
- `getBatchStatus` classifies **depleted before expired** — defense in depth: even if a stale `expired` flag reappears, a fully used batch can never render as "Expired".
- `AdminCredits` "awaiting refund" count now additionally requires remaining bytes > 0, so depleted batches never trigger the refund badge.

### Tests

- **New**: repository spec for `markExpiredCredits` (TestContainers Postgres, like the other repo specs) covering: past-expiry with remaining bytes → expired + forfeited totals reported; past-expiry fully depleted → *not* expired, nothing forfeited; future-expiry → untouched.
- **Updated**: frontend `getBatchStatus` spec — the old "prioritises expired over depleted" assertion is inverted, plus a new case for expired-with-remaining-bytes. All 33 frontend unit tests pass.
