### PR TITLE
fix(frontend): clear stale account/credit/encryption state on sign-out

### DIFF
--- a/apps/frontend/src/components/atoms/ExpiryWarningBanner.tsx
+++ b/apps/frontend/src/components/atoms/ExpiryWarningBanner.tsx
@@ -29,7 +29,13 @@ export const ExpiryWarningBanner = () => {
     enabled: !!session?.data,
   });
 
-  if (!expiringBatches || expiringBatches.length === 0) return null;
+  // Guard on the live session, not just on `expiringBatches`: disabling a
+  // query (enabled: false) stops refetching but doesn't clear previously
+  // cached/persisted `data`, so a signed-out user could otherwise still see
+  // the previous account's expiring-credits data.
+  if (!session?.data || !expiringBatches || expiringBatches.length === 0) {
+    return null;
+  }
 
   // Find the soonest expiry date across all expiring batches
   const soonestExpiry = expiringBatches.reduce<Date | null>((acc, batch) => {

--- a/apps/frontend/src/components/atoms/SessionEnsurer.tsx
+++ b/apps/frontend/src/components/atoms/SessionEnsurer.tsx
@@ -75,16 +75,28 @@ export const SessionEnsurer = ({ children }: { children: React.ReactNode }) => {
   }, [touStatusData, setTouStatus]);
 
   useEffect(() => {
+    // Disabling a query (enabled: false) stops refetching but does not clear
+    // its previously cached `data` — so once signed out, `account` may still
+    // hold the last-fetched (now stale) value. Only apply it while a session
+    // is actually present, so we don't resurrect a previous account's data.
+    if (!session?.data) {
+      setAccount(null);
+      return;
+    }
     if (account) setAccount(account);
-  }, [account, setAccount]);
+  }, [session?.data, account, setAccount]);
 
   useEffect(() => {
+    if (!session?.data) {
+      setFeatures({});
+      return;
+    }
     if (features) setFeatures(features);
-  }, [features, setFeatures]);
+  }, [session?.data, features, setFeatures]);
 
   useEffect(() => {
-    setCreditSummary(creditSummary ?? null);
-  }, [creditSummary, setCreditSummary]);
+    setCreditSummary(session?.data ? (creditSummary ?? null) : null);
+  }, [session?.data, creditSummary, setCreditSummary]);
 
   if (session === undefined) {
     // TODO: Add a loading state

--- a/apps/frontend/src/components/molecules/ProfileDropdown.tsx
+++ b/apps/frontend/src/components/molecules/ProfileDropdown.tsx
@@ -68,7 +68,7 @@ export const ProfileDropdown: React.FC = () => {
           </div>
           <div className='py-1'>
             <button
-              onClick={logOut}
+              onClick={() => logOut()}
               className='flex w-full items-center gap-2 px-4 py-2 text-left text-base text-red-600 hover:bg-background-hover dark:text-red-500'
             >
               Logout

--- a/apps/frontend/src/components/views/Profile/index.tsx
+++ b/apps/frontend/src/components/views/Profile/index.tsx
@@ -71,7 +71,7 @@ export const Profile = () => {
             <Button
               variant='lightDanger'
               className='flex items-center gap-2 text-sm'
-              onClick={logOut}
+              onClick={() => logOut()}
             >
               Log out
               <LogOut className='h-4 w-4' />

--- a/apps/frontend/src/components/views/PurchaseCredits/index.tsx
+++ b/apps/frontend/src/components/views/PurchaseCredits/index.tsx
@@ -96,10 +96,18 @@ export const PurchaseCredits = () => {
 
   // Enforce the Google gate at render: non-Google users (once auth resolves)
   // can never see beyond package selection, regardless of how `currentStep`
-  // was reached (deep-link, ?step=, back/forward). The gate modal handles the
-  // actual sign-in prompt when they try to advance.
+  // was reached (deep-link, ?step=, back/forward, or a sign-out reload that
+  // preserves `?step=` in the URL). The gate modal handles the actual
+  // sign-in prompt when they try to advance.
   const effectiveStep: PurchaseStep =
     authResolved && !isGoogleAuthed && currentStep > 1 ? 1 : currentStep;
+
+  // Fail closed while the session is still resolving: never render a step
+  // past package selection until we know whether the user is Google-authed.
+  // Without this, a step > 1 reached via URL (deep-link or a sign-out reload
+  // that keeps `?step=2` in the address bar) would briefly render unguarded,
+  // since `effectiveStep` above falls back to the raw `currentStep` pre-resolve.
+  const isVerifyingAuthForStep = !authResolved && currentStep > 1;
 
   // Act on a pending package selection, but only once the session has resolved.
   // Deferring keeps this consistent with `effectiveStep`: a still-loading
@@ -211,7 +219,11 @@ export const PurchaseCredits = () => {
         }}
         callbackUrl={authGateCallbackUrl}
       />
-      {steps.find((s) => s.id === effectiveStep)?.component}
+      {isVerifyingAuthForStep ? (
+        <div>Loading...</div>
+      ) : (
+        steps.find((s) => s.id === effectiveStep)?.component
+      )}
     </div>
   );
 };

--- a/apps/frontend/src/components/views/TouAcceptance/index.tsx
+++ b/apps/frontend/src/components/views/TouAcceptance/index.tsx
@@ -3,10 +3,10 @@
 import { useCallback, useState } from 'react';
 import { Button, Checkbox } from '@headlessui/react';
 import { CheckIcon } from 'lucide-react';
-import { signOut } from 'next-auth/react';
 import { AutonomysSymbol } from '@auto-drive/ui';
 import { TouStatus } from '@auto-drive/models';
 import { useNetwork } from '../../../contexts/network';
+import { useLogOut } from '../../../hooks/useAuth';
 
 export const TouAcceptanceInterstitial = ({
   touStatus,
@@ -18,6 +18,7 @@ export const TouAcceptanceInterstitial = ({
   const [accepted, setAccepted] = useState(false);
   const [loading, setLoading] = useState(false);
   const { api } = useNetwork();
+  const { logOut } = useLogOut();
 
   const handleAccept = useCallback(async () => {
     setLoading(true);
@@ -32,8 +33,8 @@ export const TouAcceptanceInterstitial = ({
   }, [api, onAccepted]);
 
   const handleDecline = useCallback(() => {
-    signOut({ callbackUrl: '/' });
-  }, []);
+    logOut({ callbackUrl: '/' });
+  }, [logOut]);
 
   return (
     <div className='flex h-screen w-screen flex-col items-center justify-center bg-background'>

--- a/apps/frontend/src/globalStates/encryption.ts
+++ b/apps/frontend/src/globalStates/encryption.ts
@@ -4,6 +4,7 @@ import { persist } from 'zustand/middleware';
 interface EncryptionStore {
   password: string;
   setPassword: (password: string) => void;
+  clearPassword: () => void;
 }
 
 export const useEncryptionStore = create<EncryptionStore>()(
@@ -11,6 +12,7 @@ export const useEncryptionStore = create<EncryptionStore>()(
     (set) => ({
       password: '',
       setPassword: (password) => set({ password }),
+      clearPassword: () => set({ password: '' }),
     }),
     {
       name: 'encryption-storage',

--- a/apps/frontend/src/globalStates/user.ts
+++ b/apps/frontend/src/globalStates/user.ts
@@ -9,7 +9,7 @@ interface UserStore {
   features: Record<string, boolean>;
   creditSummary: CreditSummaryResponse | null;
   setFeatures: (features: Record<string, boolean>) => void;
-  setAccount: (account: AccountInfo) => void;
+  setAccount: (account: AccountInfo | null) => void;
   setUser: (user: User | null) => void;
   setCreditSummary: (summary: CreditSummaryResponse | null) => void;
   clearUser: () => void;
@@ -27,7 +27,7 @@ export const useUserStore = create<UserStore>()(
         }),
       clearUser: () =>
         set({ user: null, account: null, creditSummary: null, features: {} }),
-      setAccount: (account: AccountInfo) =>
+      setAccount: (account: AccountInfo | null) =>
         set({
           account,
         }),

--- a/apps/frontend/src/hooks/useAuth.ts
+++ b/apps/frontend/src/hooks/useAuth.ts
@@ -76,19 +76,36 @@ export const useLogOut = () => {
   const queryClient = useQueryClient();
 
   const logOut = useCallback(
-    (options?: SignOutOptions) => {
+    async (options?: SignOutOptions) => {
       clearSessionCache();
       clearUser();
       // The default encryption password is persisted to localStorage and
       // pre-fills upload/download modals — clear it so it doesn't leak to
       // whoever uses this browser next.
       clearPassword();
-      // Drop every cached query (account/features/creditSummary/expiring
-      // batches, etc.) — otherwise the persisted (localStorage) cache keeps
-      // serving the previous account's data to `enabled: !!session` queries
-      // after sign-out, since disabling a query doesn't clear its cached data.
-      queryClient.clear();
-      nextAuthSignOut(options);
+
+      const callbackUrl = options?.callbackUrl ?? window.location.href;
+      let redirectUrl = callbackUrl;
+      try {
+        // Invalidate the session server-side (and sync next-auth's client
+        // state) BEFORE wiping the query cache. Doing this in the other
+        // order leaves the session valid while the cache is cleared, so any
+        // mounted `enabled: !!session?.data` query can immediately refetch
+        // and repopulate the very cache we're clearing.
+        const result = await nextAuthSignOut({ callbackUrl, redirect: false });
+        redirectUrl = result?.url ?? callbackUrl;
+      } finally {
+        // Drop every cached query (account/features/creditSummary/expiring
+        // batches, etc.) — otherwise the persisted (localStorage) cache keeps
+        // serving the previous account's data to `enabled: !!session` queries
+        // after sign-out, since disabling a query doesn't clear its cached data.
+        queryClient.clear();
+      }
+
+      window.location.href = redirectUrl;
+      // If the url contains a hash, the browser won't reload the page on its
+      // own — mirror next-auth's own redirect:true behavior and force it.
+      if (redirectUrl.includes('#')) window.location.reload();
     },
     [clearUser, clearPassword, queryClient],
   );

--- a/apps/frontend/src/hooks/useAuth.ts
+++ b/apps/frontend/src/hooks/useAuth.ts
@@ -1,11 +1,13 @@
 import { useConnectModal } from '@rainbow-me/rainbowkit';
 import { useCallback, useEffect, useState } from 'react';
 import { useAccount, useSignMessage } from 'wagmi';
+import { useQueryClient } from '@tanstack/react-query';
 import { getMessageToSign } from '../app/api/auth/[...nextauth]/web3';
 import { signIn as nextAuthSignIn, signOut as nextAuthSignOut } from 'next-auth/react';
 import { defaultNetworkId } from '@auto-drive/ui';
 import { clearSessionCache } from '@/utils/auth';
 import { useUserStore } from '@/globalStates/user';
+import { useEncryptionStore } from '@/globalStates/encryption';
 
 export type AuthProvider = 'google' | 'discord' | 'web3-wallet' | 'github';
 
@@ -63,14 +65,33 @@ export const useLogIn = (): UseAuth => {
   return { signIn };
 };
 
+interface SignOutOptions {
+  /** Where to land after sign-out. Defaults to next-auth's current-page behavior. */
+  callbackUrl?: string;
+}
+
 export const useLogOut = () => {
   const clearUser = useUserStore((state) => state.clearUser);
+  const clearPassword = useEncryptionStore((state) => state.clearPassword);
+  const queryClient = useQueryClient();
 
-  const logOut = useCallback(() => {
-    clearSessionCache();
-    clearUser();
-    nextAuthSignOut();
-  }, [clearUser]);
+  const logOut = useCallback(
+    (options?: SignOutOptions) => {
+      clearSessionCache();
+      clearUser();
+      // The default encryption password is persisted to localStorage and
+      // pre-fills upload/download modals — clear it so it doesn't leak to
+      // whoever uses this browser next.
+      clearPassword();
+      // Drop every cached query (account/features/creditSummary/expiring
+      // batches, etc.) — otherwise the persisted (localStorage) cache keeps
+      // serving the previous account's data to `enabled: !!session` queries
+      // after sign-out, since disabling a query doesn't clear its cached data.
+      queryClient.clear();
+      nextAuthSignOut(options);
+    },
+    [clearUser, clearPassword, queryClient],
+  );
 
   return { logOut };
 };


### PR DESCRIPTION
Signing out only reset the Zustand user store, but disabled React Query fetches (enabled: !!session) keep serving previously cached data, and the query cache itself was persisted to localStorage and never cleared. 

This left behind some of the banners that should associate with a session:
- the "credits expiring soon" banner 
- purchase-page credit cap active for signed-out users 
- allowed to briefly render the wallet-connect/payment step before the session resolved.

Also clears the persisted default encryption password on logout, and routes the ToU-decline flow through the shared logout path so it gets the same cleanup.