### PR TITLE
docs(s3): record decision to not implement bucket endpoints

### DIFF
--- a/apps/backend/__tests__/integration/s3-sdk/index.spec.ts
+++ b/apps/backend/__tests__/integration/s3-sdk/index.spec.ts
@@ -526,8 +526,8 @@ describe('AWS S3 - SDK', () => {
   // bucket name (parseBucketAndKey), such a request is indistinguishable from a
   // flat, default-bucket object op — the semantics the bucket-support migration
   // and legacy flat keys rely on. Bucket endpoints are therefore left
-  // unimplemented, and clients must set `no_check_bucket = true` (see
-  // docs/rclone) so they never emit CreateBucket/HeadBucket. These tests lock
+  // unimplemented, and clients must set `no_check_bucket = true` so they never
+  // emit CreateBucket/HeadBucket. These tests lock
   // that decision: a bare, slash-less PUT/HEAD/DELETE is handled as a
   // default-bucket object op, so adopting a "no-slash = bucket op" rule later is
   // a conscious, test-breaking change rather than a silent regression.
@@ -557,9 +557,20 @@ describe('AWS S3 - SDK', () => {
       expect(Buffer.from(await get.arrayBuffer())).toEqual(body)
     }, 15_000)
 
-    it('HEAD of a bare, slash-less name is HeadObject (404 when absent), not HeadBucket', async () => {
-      const res = await raw('HEAD', '/never-created-bucket-name')
-      expect(res.status).toBe(404)
+    it('HEAD of a bare, slash-less name returns default-bucket object metadata (200), not HeadBucket', async () => {
+      // A missing-name HEAD would 404 either way — HeadObject (NoSuchKey) and
+      // HeadBucket (NoSuchBucket) both return 404 — so that alone locks
+      // nothing. Instead seed a bare object and HEAD the same bare path:
+      // HeadObject answers 200 with the object's Content-Length and MD5 ETag,
+      // whereas HeadBucket returns neither, so a future "no-slash = bucket op"
+      // rule would break these assertions.
+      const body = Buffer.from('bare-head-target')
+      expect((await raw('PUT', '/bare-head-target', body)).status).toBe(200)
+
+      const head = await raw('HEAD', '/bare-head-target')
+      expect(head.status).toBe(200)
+      expect(head.headers.get('content-length')).toBe(String(body.length))
+      expect(head.headers.get('etag')).toMatch(MD5_ETAG_RE)
     }, 15_000)
 
     it('DELETE of a bare, slash-less name is DeleteObject (403 immutable), not DeleteBucket', async () => {

--- a/apps/backend/__tests__/integration/s3-sdk/index.spec.ts
+++ b/apps/backend/__tests__/integration/s3-sdk/index.spec.ts
@@ -520,6 +520,54 @@ describe('AWS S3 - SDK', () => {
     })
   })
 
+  // ── Decision lock: bucket-level ops fold into default-bucket object ops ─────
+  // A true S3 CreateBucket/DeleteBucket/HeadBucket targets a bare `/{bucket}`
+  // with no object key. Because the first path segment is folded into the
+  // bucket name (parseBucketAndKey), such a request is indistinguishable from a
+  // flat, default-bucket object op — the semantics the bucket-support migration
+  // and legacy flat keys rely on. Bucket endpoints are therefore left
+  // unimplemented, and clients must set `no_check_bucket = true` (see
+  // docs/rclone) so they never emit CreateBucket/HeadBucket. These tests lock
+  // that decision: a bare, slash-less PUT/HEAD/DELETE is handled as a
+  // default-bucket object op, so adopting a "no-slash = bucket op" rule later is
+  // a conscious, test-breaking change rather than a silent regression.
+  describe('Bucket-level ops fold into default-bucket object ops', () => {
+    const S3_BASE = `${BASE_PATH}/s3`
+    // Mirrors the raw-HTTP auth pattern above: handleS3Auth only needs a
+    // `Credential=<alphanumeric>/` and AuthManager is mocked to return `user`.
+    const AUTH =
+      'AWS4-HMAC-SHA256 Credential=buckettestkey/20200101/us-east-1/s3/aws4_request, SignedHeaders=host, Signature=deadbeef'
+    const raw = (method: string, path: string, body?: Uint8Array) =>
+      fetch(`${S3_BASE}${path}`, {
+        method,
+        headers: { Authorization: AUTH },
+        body: body as unknown as BodyInit | undefined,
+      })
+
+    it('PUT of a bare, slash-less name stores a default-bucket object (not CreateBucket)', async () => {
+      const body = Buffer.from('looks like a bucket, stored as an object')
+      const put = await raw('PUT', '/looks-like-a-bucket', body)
+      expect(put.status).toBe(200)
+      expect(put.headers.get('etag')).toMatch(MD5_ETAG_RE)
+
+      // Retrievable as the object 'looks-like-a-bucket' in the default bucket —
+      // proof the PUT was an object write, not a no-op bucket creation.
+      const get = await raw('GET', '/looks-like-a-bucket')
+      expect(get.status).toBe(200)
+      expect(Buffer.from(await get.arrayBuffer())).toEqual(body)
+    }, 15_000)
+
+    it('HEAD of a bare, slash-less name is HeadObject (404 when absent), not HeadBucket', async () => {
+      const res = await raw('HEAD', '/never-created-bucket-name')
+      expect(res.status).toBe(404)
+    }, 15_000)
+
+    it('DELETE of a bare, slash-less name is DeleteObject (403 immutable), not DeleteBucket', async () => {
+      const res = await raw('DELETE', '/looks-like-a-bucket')
+      expect(res.status).toBe(403)
+    }, 15_000)
+  })
+
   describe('ListBuckets', () => {
     it('should list all buckets', async () => {
       const command = new ListBucketsCommand({})

--- a/apps/backend/src/app/controllers/s3/http.ts
+++ b/apps/backend/src/app/controllers/s3/http.ts
@@ -25,6 +25,24 @@ type S3HandlerConfig = {
   [key: string]: (req: Request, res: Response) => Promise<void>
 }
 
+// ── Bucket-level operations are intentionally NOT implemented ────────────────
+// A true S3 CreateBucket / DeleteBucket / HeadBucket targets a bare `/{bucket}`
+// with no object key (PUT / DELETE / HEAD). This API folds the first path
+// segment into the bucket name (see parseBucketAndKey in s3.ts), so a bare,
+// slash-less path is indistinguishable from a flat, default-bucket object
+// operation — the exact semantics the bucket-support migration and every
+// legacy flat key depend on. Distinguishing the two would require a "no-slash
+// path = bucket op" routing rule that reinterprets every legacy flat-key
+// PUT/DELETE/HEAD (and would force existing objects under a `default/` prefix),
+// so bucket endpoints are deliberately left out to keep object semantics intact.
+//
+// The practical consequence: S3 clients must set `no_check_bucket = true`
+// (documented for rclone in docs/rclone) so they never emit CreateBucket or
+// HeadBucket — buckets are created implicitly on the first object write. A bare
+// PUT/DELETE/HEAD is therefore dispatched below as an ordinary object op:
+//   PUT  → PutObject       HEAD → HeadObject
+//   DELETE → DeleteObject (403, storage is immutable)
+// There is deliberately no CreateBucket / DeleteBucket / HeadBucket entry.
 const S3HandlerConfig: S3HandlerConfig = {
   GetObject: getObjectHandler,
   HeadObject: headObjectHandler,

--- a/apps/backend/src/app/controllers/s3/http.ts
+++ b/apps/backend/src/app/controllers/s3/http.ts
@@ -36,9 +36,9 @@ type S3HandlerConfig = {
 // PUT/DELETE/HEAD (and would force existing objects under a `default/` prefix),
 // so bucket endpoints are deliberately left out to keep object semantics intact.
 //
-// The practical consequence: S3 clients must set `no_check_bucket = true`
-// (documented for rclone in docs/rclone) so they never emit CreateBucket or
-// HeadBucket — buckets are created implicitly on the first object write. A bare
+// The practical consequence: S3 clients must set `no_check_bucket = true` so
+// they never emit CreateBucket or HeadBucket — buckets are created implicitly
+// on the first object write. A bare
 // PUT/DELETE/HEAD is therefore dispatched below as an ordinary object op:
 //   PUT  → PutObject       HEAD → HeadObject
 //   DELETE → DeleteObject (403, storage is immutable)

--- a/apps/backend/src/app/controllers/s3/s3.ts
+++ b/apps/backend/src/app/controllers/s3/s3.ts
@@ -31,6 +31,12 @@ const logger = createLogger('s3:controllers')
  *   'my-archive/file.txt'     → { bucket: 'my-archive', key: 'file.txt' }
  *   'my-archive/sub/file.txt' → { bucket: 'my-archive', key: 'sub/file.txt' }
  *   'file.txt'                → { bucket: 'default',    key: 'file.txt' }
+ *
+ * A bare, slash-less path therefore has no dedicated bucket-operation meaning —
+ * it is always an object in the 'default' bucket. Bucket-level endpoints
+ * (CreateBucket / DeleteBucket / HeadBucket) are intentionally unimplemented for
+ * this reason; see the decision note in http.ts. S3 clients must set
+ * `no_check_bucket = true` so they never emit those calls.
  */
 const parseBucketAndKey = (rawKey: string): { bucket: string; key: string } => {
   const slashIndex = rawKey.indexOf('/')

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -777,6 +777,8 @@ Interactive API documentation is available at `/docs` on the backend service ([m
 | PUT    | `/s3/:key?uploadId&partNumber` | Upload part        |
 | POST   | `/s3/:key?uploadId`            | Complete multipart |
 
+> **Bucket-level operations (CreateBucket / DeleteBucket / HeadBucket) are intentionally not implemented.** The first path segment is folded into the bucket name, so a bare `/{bucket}` request is indistinguishable from a flat, default-bucket object operation (the semantics the bucket-support migration and legacy flat keys rely on). Buckets are created implicitly on the first object write, and S3 clients such as rclone must set `no_check_bucket = true`. See the decision note in `apps/backend/src/app/controllers/s3/http.ts`.
+
 ---
 
 ## Related Documentation


### PR DESCRIPTION
## What & why

The S3 API folds the logical "bucket" into the first path segment of the object key (`parseBucketAndKey`). A true S3 `CreateBucket`/`DeleteBucket`/`HeadBucket` targets a bare `PUT|DELETE|HEAD /{bucket}` with **no** object key — which, under this scheme, is indistinguishable from a flat, default-bucket object operation. That flat-key behaviour is exactly what the `s3-bucket-support` migration and every legacy flat key depend on, and what the integration harness (`bucketEndpoint: true` + flat keys like `test.txt`) exercises.

This came up while implementing S3 soft-delete + copy/move for rclone compatibility. Two options were on the table:

- **(a)** Accept the `no_check_bucket` workaround and **not** implement bucket endpoints.
- **(b)** Adopt a "no-slash path = bucket operation" routing rule — which reinterprets every legacy flat-key mutation (forcing existing objects under a `default/` prefix) and requires rewriting the integration tests.

**Decision: (a).** rclone's `FsMkdir`/`FsRmdir` already pass when the remote is configured with `no_check_bucket = true` (Mkdir becomes a no-op; Rmdir on a sub-path root returns nil), so dedicated bucket endpoints are unnecessary under the mandated config. (a) keeps existing object semantics and legacy flat keys intact at zero risk; (b) changes a shipped contract for a benefit that only applies to clients ignoring the mandated config.

## Changes

This PR contains **no runtime behaviour change** — the server already behaves per (a). It makes the decision explicit and durable so it can't be silently reversed:

- **`http.ts`** — authoritative decision note directly above the handler map (where a future engineer would look to "add CreateBucket").
- **`s3.ts`** — pointer on `parseBucketAndKey`.
- **`docs/architecture.md`** — note under the S3-Compatible Endpoints table.
- **s3-sdk integration test** — locks the decision: a bare, slash-less `PUT`/`HEAD`/`DELETE` is asserted to be an object op (`PutObject`→200 + body round-trip, `HeadObject`→200 + `Content-Length`/MD5 `ETag`, `DeleteObject`→403), so adopting a "no-slash = bucket op" rule later is a conscious, test-breaking choice. (The HEAD case asserts object metadata rather than a bare 404, since a real `HeadBucket` on a missing bucket also 404s and would not break — per senior review.)

## Reviewer notes

- **Accepted trade-off:** a client that ignores `no_check_bucket` and sends a bare `PUT /{bucket}` will silently create an empty object named `{bucket}` in `default`. Closing that is option (b); it stays a documented limitation.
- The user-facing rclone docs that already mandate `no_check_bucket = true` live on the separate, still-unmerged `docs/rclone-integration` branch — consistent with this decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
