### PR TITLE
feat(s3): scope the S3 key namespace per user

### DIFF
--- a/apps/backend/__tests__/e2e/objects/objectRemoval.spec.ts
+++ b/apps/backend/__tests__/e2e/objects/objectRemoval.spec.ts
@@ -146,7 +146,7 @@ describe('Object removal', () => {
 
     it('is listed and retrievable over the S3 API (rclone/aws-cli)', async () => {
       expect(await listS3Keys(owner)).toContain(S3_KEY)
-      const getResult = await S3UseCases.getObject({
+      const getResult = await S3UseCases.getObject(owner, {
         Bucket: S3_BUCKET,
         Key: S3_KEY,
       })
@@ -241,7 +241,7 @@ describe('Object removal', () => {
 
     it('is hidden from S3 listing and not retrievable over S3', async () => {
       expect(await listS3Keys(owner)).not.toContain(S3_KEY)
-      const getResult = await S3UseCases.getObject({
+      const getResult = await S3UseCases.getObject(owner, {
         Bucket: S3_BUCKET,
         Key: S3_KEY,
       })
@@ -307,7 +307,7 @@ describe('Object removal', () => {
 
     it('is listed and retrievable over the S3 API again', async () => {
       expect(await listS3Keys(owner)).toContain(S3_KEY)
-      const getResult = await S3UseCases.getObject({
+      const getResult = await S3UseCases.getObject(owner, {
         Bucket: S3_BUCKET,
         Key: S3_KEY,
       })

--- a/apps/backend/__tests__/e2e/objects/objectRemoval.spec.ts
+++ b/apps/backend/__tests__/e2e/objects/objectRemoval.spec.ts
@@ -25,8 +25,11 @@ const S3_KEY = 'dir/removed.txt'
 
 const FOLDER_S3_BUCKET = 'folder-removal-bucket'
 
-const listS3Keys = async (bucket: string = S3_BUCKET): Promise<string[]> => {
-  const result = await S3UseCases.listObjects({
+const listS3Keys = async (
+  user: UserWithOrganization,
+  bucket: string = S3_BUCKET,
+): Promise<string[]> => {
+  const result = await S3UseCases.listObjects(user, {
     bucket,
     prefix: '',
     delimiter: null,
@@ -68,6 +71,8 @@ describe('Object removal', () => {
     // (list + get) honours removal/restore in lockstep with the file, without
     // adding a second object that would perturb the global/owner listings.
     await s3ObjectMappingsRepository.createMapping(
+      owner.oauthProvider,
+      owner.oauthUserId,
       S3_BUCKET,
       S3_KEY,
       fileCid,
@@ -140,7 +145,7 @@ describe('Object removal', () => {
     })
 
     it('is listed and retrievable over the S3 API (rclone/aws-cli)', async () => {
-      expect(await listS3Keys()).toContain(S3_KEY)
+      expect(await listS3Keys(owner)).toContain(S3_KEY)
       const getResult = await S3UseCases.getObject({
         Bucket: S3_BUCKET,
         Key: S3_KEY,
@@ -235,7 +240,7 @@ describe('Object removal', () => {
     })
 
     it('is hidden from S3 listing and not retrievable over S3', async () => {
-      expect(await listS3Keys()).not.toContain(S3_KEY)
+      expect(await listS3Keys(owner)).not.toContain(S3_KEY)
       const getResult = await S3UseCases.getObject({
         Bucket: S3_BUCKET,
         Key: S3_KEY,
@@ -301,7 +306,7 @@ describe('Object removal', () => {
     })
 
     it('is listed and retrievable over the S3 API again', async () => {
-      expect(await listS3Keys()).toContain(S3_KEY)
+      expect(await listS3Keys(owner)).toContain(S3_KEY)
       const getResult = await S3UseCases.getObject({
         Bucket: S3_BUCKET,
         Key: S3_KEY,
@@ -354,6 +359,8 @@ describe('Folder removal hides child files', () => {
       const key = `folder/${name}`
       childKeys[key] = cid
       await s3ObjectMappingsRepository.createMapping(
+        owner.oauthProvider,
+        owner.oauthUserId,
         FOLDER_S3_BUCKET,
         key,
         cid,
@@ -400,7 +407,7 @@ describe('Folder removal hides child files', () => {
   })
 
   it('children are listed over the S3 API while available', async () => {
-    const keys = await listS3Keys(FOLDER_S3_BUCKET)
+    const keys = await listS3Keys(owner, FOLDER_S3_BUCKET)
     for (const key of childKeyList()) {
       expect(keys).toContain(key)
     }
@@ -469,7 +476,7 @@ describe('Folder removal hides child files', () => {
     })
 
     it('hides every child from the S3 listing', async () => {
-      const keys = await listS3Keys(FOLDER_S3_BUCKET)
+      const keys = await listS3Keys(owner, FOLDER_S3_BUCKET)
       for (const key of childKeyList()) {
         expect(keys).not.toContain(key)
       }
@@ -509,7 +516,7 @@ describe('Folder removal hides child files', () => {
     })
 
     it('lists every child over the S3 API again', async () => {
-      const keys = await listS3Keys(FOLDER_S3_BUCKET)
+      const keys = await listS3Keys(owner, FOLDER_S3_BUCKET)
       for (const key of childKeyList()) {
         expect(keys).toContain(key)
       }

--- a/apps/backend/__tests__/integration/s3-sdk/index.spec.ts
+++ b/apps/backend/__tests__/integration/s3-sdk/index.spec.ts
@@ -1222,4 +1222,75 @@ describe('AWS S3 - SDK', () => {
       expect(got).toEqual(Buffer.concat([part1, part2]))
     }, 30_000)
   })
+
+  // The S3 namespace is scoped per user: (owner, bucket, key). Two users can
+  // each own the same (bucket, key) with no contention — the first-writer-wins
+  // squatting / 403 behaviour of a global namespace is gone — and neither can
+  // see or affect the other's key.
+  describe('Per-user namespace isolation', () => {
+    // The suite's `s3Client` authenticates as `user`; clientB uses a second key
+    // that resolves to a second user.
+    const userBKey = 'b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0'
+    let userB: typeof user
+    let clientB: S3Client
+    const IsoKey = 'iso-test/shared.txt'
+
+    beforeAll(async () => {
+      userB = createMockUser()
+      await AccountsUseCases.getOrCreateAccount(userB)
+      // Resolve the API key to distinct principals so A and B are separate.
+      jest
+        .spyOn(AuthManager, 'getUserFromAccessToken')
+        .mockImplementation((key) => Promise.resolve(key === userBKey ? userB : user))
+      clientB = new S3Client({
+        region: 'us-east-1',
+        endpoint: `${BASE_PATH}/s3`,
+        credentials: { accessKeyId: userBKey, secretAccessKey: '' },
+        bucketEndpoint: true,
+      })
+    })
+
+    afterAll(() => {
+      // Restore the single-user mock for any later suites.
+      jest.spyOn(AuthManager, 'getUserFromAccessToken').mockResolvedValue(user)
+    })
+
+    it('two users can own the same (bucket, key) independently', async () => {
+      await s3Client.send(
+        new PutObjectCommand({ Bucket, Key: IsoKey, Body: Buffer.from('A owns this') }),
+      )
+      await clientB.send(
+        new PutObjectCommand({ Bucket, Key: IsoKey, Body: Buffer.from('B owns a different thing') }),
+      )
+
+      const aGet = await s3Client.send(
+        new GetObjectCommand({ Bucket, Key: IsoKey }),
+      )
+      const bGet = await clientB.send(
+        new GetObjectCommand({ Bucket, Key: IsoKey }),
+      )
+      expect(Buffer.from(await aGet.Body!.transformToByteArray()).toString()).toBe(
+        'A owns this',
+      )
+      expect(Buffer.from(await bGet.Body!.transformToByteArray()).toString()).toBe(
+        'B owns a different thing',
+      )
+    })
+
+    it('one user deleting their key does not affect the other', async () => {
+      await s3Client.send(new DeleteObjectCommand({ Bucket, Key: IsoKey }))
+
+      // A's key is gone…
+      await expect(
+        s3Client.send(new GetObjectCommand({ Bucket, Key: IsoKey })),
+      ).rejects.toMatchObject({ $metadata: { httpStatusCode: 404 } })
+      // …but B's identically-named key is untouched.
+      const bGet = await clientB.send(
+        new GetObjectCommand({ Bucket, Key: IsoKey }),
+      )
+      expect(Buffer.from(await bGet.Body!.transformToByteArray()).toString()).toBe(
+        'B owns a different thing',
+      )
+    })
+  })
 })

--- a/apps/backend/__tests__/integration/s3-sdk/index.spec.ts
+++ b/apps/backend/__tests__/integration/s3-sdk/index.spec.ts
@@ -1239,9 +1239,13 @@ describe('AWS S3 - SDK', () => {
       userB = createMockUser()
       await AccountsUseCases.getOrCreateAccount(userB)
       // Resolve the API key to distinct principals so A and B are separate.
+      // handleAuth calls getUserFromAccessToken(provider, accessToken); the
+      // access token is the SigV4 access-key id, so key off the second arg.
       jest
         .spyOn(AuthManager, 'getUserFromAccessToken')
-        .mockImplementation((key) => Promise.resolve(key === userBKey ? userB : user))
+        .mockImplementation((_provider, accessToken) =>
+          Promise.resolve(accessToken === userBKey ? userB : user),
+        )
       clientB = new S3Client({
         region: 'us-east-1',
         endpoint: `${BASE_PATH}/s3`,

--- a/apps/backend/__tests__/unit/core/s3.spec.ts
+++ b/apps/backend/__tests__/unit/core/s3.spec.ts
@@ -7,10 +7,7 @@ import {
   afterEach,
 } from '@jest/globals'
 import { S3UseCases } from '../../../src/core/s3/index.js'
-import {
-  ownershipRepository,
-  s3ObjectMappingsRepository,
-} from '../../../src/infrastructure/repositories/index.js'
+import { s3ObjectMappingsRepository } from '../../../src/infrastructure/repositories/index.js'
 import { UploadsUseCases } from '../../../src/core/uploads/uploads.js'
 import { DownloadUseCase } from '../../../src/core/downloads/index.js'
 import { ObjectUseCases } from '../../../src/core/objects/object.js'
@@ -27,6 +24,8 @@ const MULTIPART_MD5_RE = /^[a-f0-9]{32}-\d+$/
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 describe('S3UseCases', () => {
+  // The S3 namespace is per user; the use cases pass this user's identity into
+  // every scoped repository call. 'google'/'user1' is the caller throughout.
   const mockUser: UserWithOrganization = {
     id: 'user1',
     publicId: 'pub1',
@@ -36,23 +35,22 @@ describe('S3UseCases', () => {
     oauthUserId: 'user1',
   } as any
 
-  // An ownership row for mockUser (the S3 uploader), used to satisfy
-  // deleteObject's owner gate.
-  const ownerRow = {
-    cid: 'cid123',
-    oauth_provider: 'google',
-    oauth_user_id: 'user1',
-    is_admin: true,
-    marked_as_deleted: null,
-  } as any
+  const mapping = (over: Record<string, unknown> = {}) =>
+    ({
+      bucket: 'my-bucket',
+      key: 'file.txt',
+      cid: 'cid123',
+      md5: null,
+      mtime: null,
+      ownerOauthProvider: 'google',
+      ownerOauthUserId: 'user1',
+      createdAt: new Date(0),
+      updatedAt: new Date(0),
+      ...over,
+    }) as any
 
   beforeEach(() => {
     jest.clearAllMocks()
-    // Default: the destination key is unowned/new, so the pre-finalize
-    // cross-owner check is a no-op. Tests that exercise the guard override this.
-    jest
-      .spyOn(s3ObjectMappingsRepository, 'getMappingOwner')
-      .mockResolvedValue(null)
   })
 
   afterEach(() => {
@@ -60,38 +58,31 @@ describe('S3UseCases', () => {
   })
 
   describe('getObject', () => {
-    it('should return error when object mapping not found', async () => {
-      jest
+    it('returns an error when the caller has no such key', async () => {
+      const findSpy = jest
         .spyOn(s3ObjectMappingsRepository, 'findByKey')
         .mockResolvedValue(null)
 
-      const result = await S3UseCases.getObject({
+      const result = await S3UseCases.getObject(mockUser, {
         Bucket: 'my-bucket',
-        Key: 'nonexistent/file.txt',
+        Key: 'nope.txt',
       } as any)
 
       expect(result.isErr()).toBe(true)
       expect(result._unsafeUnwrapErr()).toBeInstanceOf(ObjectNotFoundError)
+      // Lookup is scoped to the caller.
+      expect(findSpy).toHaveBeenCalledWith('google', 'user1', 'my-bucket', 'nope.txt')
     })
 
-    it('should return error from download use case', async () => {
-      const mapping = {
-        bucket: 'my-bucket',
-        key: 'file.txt',
-        cid: 'cid123',
-        md5: 'abc123',
-      }
+    it('propagates a download error', async () => {
       jest
         .spyOn(s3ObjectMappingsRepository, 'findByKey')
-        .mockResolvedValue(mapping as any)
-
+        .mockResolvedValue(mapping({ md5: 'abc123' }))
       jest
         .spyOn(DownloadUseCase, 'downloadObjectByAnonymous')
-        .mockResolvedValue(
-          err(new ObjectNotFoundError('Download failed')) as any,
-        )
+        .mockResolvedValue(err(new ObjectNotFoundError('Download failed')) as any)
 
-      const result = await S3UseCases.getObject({
+      const result = await S3UseCases.getObject(mockUser, {
         Bucket: 'my-bucket',
         Key: 'file.txt',
       } as any)
@@ -99,24 +90,15 @@ describe('S3UseCases', () => {
       expect(result.isErr()).toBe(true)
     })
 
-    it('should return download result with cid and etag', async () => {
-      const mapping = {
-        bucket: 'my-bucket',
-        key: 'file.txt',
-        cid: 'cid123',
-        md5: 'abc123def456abc123def456abc123de',
-      }
-      const mockReadable = { read: jest.fn() }
-
+    it('returns the download result with cid and MD5 etag', async () => {
       jest
         .spyOn(s3ObjectMappingsRepository, 'findByKey')
-        .mockResolvedValue(mapping as any)
-
+        .mockResolvedValue(mapping({ md5: 'abc123def456abc123def456abc123de' }))
       jest
         .spyOn(DownloadUseCase, 'downloadObjectByAnonymous')
-        .mockResolvedValue(ok(mockReadable) as any)
+        .mockResolvedValue(ok({ read: jest.fn() }) as any)
 
-      const result = await S3UseCases.getObject({
+      const result = await S3UseCases.getObject(mockUser, {
         Bucket: 'my-bucket',
         Key: 'file.txt',
       } as any)
@@ -128,23 +110,15 @@ describe('S3UseCases', () => {
       )
     })
 
-    it('should return null etag for legacy objects without md5', async () => {
-      const mapping = {
-        bucket: 'my-bucket',
-        key: 'file.txt',
-        cid: 'cid123',
-        md5: null,
-      }
-
+    it('returns a null etag for legacy objects without md5', async () => {
       jest
         .spyOn(s3ObjectMappingsRepository, 'findByKey')
-        .mockResolvedValue(mapping as any)
-
+        .mockResolvedValue(mapping({ md5: null }))
       jest
         .spyOn(DownloadUseCase, 'downloadObjectByAnonymous')
         .mockResolvedValue(ok({} as any) as any)
 
-      const result = await S3UseCases.getObject({
+      const result = await S3UseCases.getObject(mockUser, {
         Bucket: 'my-bucket',
         Key: 'file.txt',
       } as any)
@@ -153,22 +127,15 @@ describe('S3UseCases', () => {
       expect(result._unsafeUnwrap().etag).toBeNull()
     })
 
-    it('should pass byte range to download use case', async () => {
-      const mapping = {
-        bucket: 'my-bucket',
-        key: 'file.txt',
-        cid: 'cid123',
-        md5: null,
-      }
+    it('passes the byte range to the download use case', async () => {
       const downloadSpy = jest
         .spyOn(DownloadUseCase, 'downloadObjectByAnonymous')
         .mockResolvedValue(ok({} as any) as any)
-
       jest
         .spyOn(s3ObjectMappingsRepository, 'findByKey')
-        .mockResolvedValue(mapping as any)
+        .mockResolvedValue(mapping())
 
-      await S3UseCases.getObject({
+      await S3UseCases.getObject(mockUser, {
         Bucket: 'my-bucket',
         Key: 'file.txt',
         Range: [100, 200],
@@ -182,8 +149,8 @@ describe('S3UseCases', () => {
   })
 
   describe('createMultipartUpload', () => {
-    it('should create multipart upload', async () => {
-      const createSpy = jest
+    it('creates the upload; stashes no mtime when none is supplied', async () => {
+      jest
         .spyOn(UploadsUseCases, 'createFileUpload')
         .mockResolvedValue({ id: 'upload123' } as any)
       const mtimeSpy = jest.spyOn(
@@ -198,8 +165,6 @@ describe('S3UseCases', () => {
       } as any)
 
       expect(result.isOk()).toBe(true)
-      expect(createSpy).toHaveBeenCalled()
-      // No mtime supplied → nothing stashed.
       expect(mtimeSpy).not.toHaveBeenCalled()
     })
 
@@ -222,7 +187,7 @@ describe('S3UseCases', () => {
   })
 
   describe('uploadPart', () => {
-    it('should upload part and return MD5 ETag', async () => {
+    it('uploads the part and returns its MD5 ETag', async () => {
       jest
         .spyOn(UploadsUseCases, 'uploadChunk')
         .mockResolvedValue(ok({} as any) as any)
@@ -241,20 +206,13 @@ describe('S3UseCases', () => {
   })
 
   describe('completeMultipartUpload', () => {
-    it('should complete multipart upload and return composite ETag', async () => {
+    it('completes the upload, persists the composite ETag + stashed mtime under the caller', async () => {
       const completeSpy = jest
         .spyOn(UploadsUseCases, 'completeUpload')
         .mockResolvedValue('cid123')
-
       const mappingSpy = jest
         .spyOn(s3ObjectMappingsRepository, 'createMapping')
-        .mockResolvedValue({
-          bucket: 'my-bucket',
-          key: 'file.txt',
-          cid: 'cid123',
-          md5: null,
-        } as any)
-      // mtime stashed at CreateMultipartUpload; persisted then cleared here.
+        .mockResolvedValue(mapping())
       jest
         .spyOn(s3ObjectMappingsRepository, 'getMultipartMtime')
         .mockResolvedValue('1620000000.5')
@@ -274,91 +232,38 @@ describe('S3UseCases', () => {
 
       expect(result.isOk()).toBe(true)
       expect(completeSpy).toHaveBeenCalledWith(mockUser, 'upload123')
-      // Composite ETag: "<md5>-N" format
       expect(result._unsafeUnwrap().ETag).toMatch(MULTIPART_ETAG_RE)
       expect(result._unsafeUnwrap().Cid).toBe('cid123')
-      // Args after the md5: mtime (stashed), then the owner (uploading user).
+      // createMapping is owner-scoped: (owner, owner, bucket, key, cid, md5, mtime).
       expect(mappingSpy).toHaveBeenCalledWith(
+        'google',
+        'user1',
         'my-bucket',
         'file.txt',
         'cid123',
         expect.stringMatching(MULTIPART_MD5_RE),
         '1620000000.5',
-        'google',
-        'user1',
       )
       expect(clearMtimeSpy).toHaveBeenCalledWith('upload123')
-    })
-
-    it('rejects completing onto a key owned by another user (Forbidden)', async () => {
-      jest.spyOn(UploadsUseCases, 'completeUpload').mockResolvedValue('cid123')
-      jest
-        .spyOn(s3ObjectMappingsRepository, 'getMultipartMtime')
-        .mockResolvedValue(null)
-      jest
-        .spyOn(s3ObjectMappingsRepository, 'deleteMultipartMtime')
-        .mockResolvedValue(undefined)
-      // Cross-owner conflict → the guarded upsert returns null.
-      jest
-        .spyOn(s3ObjectMappingsRepository, 'createMapping')
-        .mockResolvedValue(null)
-
-      const result = await S3UseCases.completeMultipartUpload(mockUser, {
-        Bucket: 'my-bucket',
-        Key: 'victim.txt',
-        UploadId: 'upload123',
-        Parts: [{ PartNumber: 1, ETag: '"aabbccdd11223344aabbccdd11223344"' }],
-      } as any)
-
-      expect(result.isErr()).toBe(true)
-      expect(result._unsafeUnwrapErr()).toBeInstanceOf(ForbiddenError)
-    })
-
-    it('rejects a cross-owner key BEFORE finalizing (completeUpload not called)', async () => {
-      // Destination key is owned by someone else → the pre-finalize guard must
-      // reject before completeUpload runs, so no ownership/credits are applied
-      // and a retry cannot re-finalize.
-      jest
-        .spyOn(s3ObjectMappingsRepository, 'getMappingOwner')
-        .mockResolvedValue({
-          ownerOauthProvider: 'google',
-          ownerOauthUserId: 'someone-else',
-        })
-      const completeSpy = jest.spyOn(UploadsUseCases, 'completeUpload')
-
-      const result = await S3UseCases.completeMultipartUpload(mockUser, {
-        Bucket: 'my-bucket',
-        Key: 'victim.txt',
-        UploadId: 'upload123',
-        Parts: [{ PartNumber: 1, ETag: '"aabbccdd11223344aabbccdd11223344"' }],
-      } as any)
-
-      expect(result.isErr()).toBe(true)
-      expect(result._unsafeUnwrapErr()).toBeInstanceOf(ForbiddenError)
-      expect(completeSpy).not.toHaveBeenCalled()
     })
   })
 
   describe('putObject', () => {
-    it('should put object and return MD5 ETag with CID', async () => {
+    const setupPut = () => {
       jest
         .spyOn(UploadsUseCases, 'createFileUpload')
         .mockResolvedValue({ id: 'upload123' } as any)
-
       jest
         .spyOn(UploadsUseCases, 'uploadChunk')
         .mockResolvedValue(ok({} as any) as any)
-
       jest.spyOn(UploadsUseCases, 'completeUpload').mockResolvedValue('cid123')
+    }
 
+    it('puts the object and returns the MD5 ETag + CID', async () => {
+      setupPut()
       jest
         .spyOn(s3ObjectMappingsRepository, 'createMapping')
-        .mockResolvedValue({
-          bucket: 'my-bucket',
-          key: 'file.txt',
-          cid: 'cid123',
-          md5: 'd41d8cd98f00b204e9800998ecf8427e',
-        } as any)
+        .mockResolvedValue(mapping({ md5: 'd41d8cd98f00b204e9800998ecf8427e' }))
 
       const result = await S3UseCases.putObject(mockUser, {
         Bucket: 'my-bucket',
@@ -372,25 +277,17 @@ describe('S3UseCases', () => {
       expect(result._unsafeUnwrap().Cid).toBe('cid123')
     })
 
-    it('should extract filename from path', async () => {
+    it('extracts the filename from the key path', async () => {
       const createSpy = jest
         .spyOn(UploadsUseCases, 'createFileUpload')
         .mockResolvedValue({ id: 'upload123' } as any)
-
       jest
         .spyOn(UploadsUseCases, 'uploadChunk')
         .mockResolvedValue(ok({} as any) as any)
-
       jest.spyOn(UploadsUseCases, 'completeUpload').mockResolvedValue('cid123')
-
       jest
         .spyOn(s3ObjectMappingsRepository, 'createMapping')
-        .mockResolvedValue({
-          bucket: 'my-bucket',
-          key: 'path/file.txt',
-          cid: 'cid123',
-          md5: null,
-        } as any)
+        .mockResolvedValue(mapping())
 
       await S3UseCases.putObject(mockUser, {
         Bucket: 'my-bucket',
@@ -408,25 +305,17 @@ describe('S3UseCases', () => {
       )
     })
 
-    it('should handle upload chunk errors', async () => {
+    it('surfaces an upload-chunk error', async () => {
       jest
         .spyOn(UploadsUseCases, 'createFileUpload')
         .mockResolvedValue({ id: 'upload123' } as any)
-
       jest
         .spyOn(UploadsUseCases, 'uploadChunk')
         .mockRejectedValue(new Error('Upload failed'))
-
       jest.spyOn(UploadsUseCases, 'completeUpload').mockResolvedValue('cid123')
-
       jest
         .spyOn(s3ObjectMappingsRepository, 'createMapping')
-        .mockResolvedValue({
-          bucket: 'my-bucket',
-          key: 'file.txt',
-          cid: 'cid123',
-          md5: null,
-        } as any)
+        .mockResolvedValue(mapping())
 
       const result = await S3UseCases.putObject(mockUser, {
         Bucket: 'my-bucket',
@@ -437,91 +326,28 @@ describe('S3UseCases', () => {
       expect(result.isErr()).toBe(true)
     })
 
-    it('should pass MD5 to createMapping', async () => {
-      jest
-        .spyOn(UploadsUseCases, 'createFileUpload')
-        .mockResolvedValue({ id: 'upload123' } as any)
-
-      jest
-        .spyOn(UploadsUseCases, 'uploadChunk')
-        .mockResolvedValue(ok({} as any) as any)
-
-      jest.spyOn(UploadsUseCases, 'completeUpload').mockResolvedValue('cid123')
-
+    it('creates the mapping under the caller with the body MD5 and mtime', async () => {
+      setupPut()
       const mappingSpy = jest
         .spyOn(s3ObjectMappingsRepository, 'createMapping')
-        .mockResolvedValue({
-          bucket: 'my-bucket',
-          key: 'file.txt',
-          cid: 'cid123',
-          md5: null,
-        } as any)
+        .mockResolvedValue(mapping())
 
-      const body = Buffer.from('Hello, world!')
       await S3UseCases.putObject(mockUser, {
         Bucket: 'my-bucket',
         Key: 'file.txt',
-        Body: body,
+        Body: Buffer.from('Hello, world!'),
       } as any)
 
-      // MD5 of "Hello, world!" — verified with: echo -n "Hello, world!" | md5.
-      // Args after the md5: mtime (null — none supplied), then the owner.
+      // MD5 of "Hello, world!"; owner-scoped (owner, owner, bucket, key, cid, md5, mtime).
       expect(mappingSpy).toHaveBeenCalledWith(
+        'google',
+        'user1',
         'my-bucket',
         'file.txt',
         'cid123',
         '6cd3556deb0da54bca060b4c39479839',
         null,
-        'google',
-        'user1',
       )
-    })
-
-    it('rejects overwriting a key owned by another user (Forbidden)', async () => {
-      jest
-        .spyOn(UploadsUseCases, 'createFileUpload')
-        .mockResolvedValue({ id: 'upload123' } as any)
-      jest
-        .spyOn(UploadsUseCases, 'uploadChunk')
-        .mockResolvedValue(ok({} as any) as any)
-      jest.spyOn(UploadsUseCases, 'completeUpload').mockResolvedValue('cid123')
-      // Cross-owner conflict → the guarded upsert returns null.
-      jest
-        .spyOn(s3ObjectMappingsRepository, 'createMapping')
-        .mockResolvedValue(null)
-
-      const result = await S3UseCases.putObject(mockUser, {
-        Bucket: 'my-bucket',
-        Key: 'victim.txt',
-        Body: Buffer.from('data'),
-      } as any)
-
-      expect(result.isErr()).toBe(true)
-      expect(result._unsafeUnwrapErr()).toBeInstanceOf(ForbiddenError)
-    })
-
-    it('rejects a cross-owner key BEFORE uploading (no createFileUpload/finalize)', async () => {
-      // Destination key is owned by someone else → reject before creating the
-      // upload or finalizing, so nothing is uploaded/charged.
-      jest
-        .spyOn(s3ObjectMappingsRepository, 'getMappingOwner')
-        .mockResolvedValue({
-          ownerOauthProvider: 'google',
-          ownerOauthUserId: 'someone-else',
-        })
-      const createUploadSpy = jest.spyOn(UploadsUseCases, 'createFileUpload')
-      const completeSpy = jest.spyOn(UploadsUseCases, 'completeUpload')
-
-      const result = await S3UseCases.putObject(mockUser, {
-        Bucket: 'my-bucket',
-        Key: 'victim.txt',
-        Body: Buffer.from('data'),
-      } as any)
-
-      expect(result.isErr()).toBe(true)
-      expect(result._unsafeUnwrapErr()).toBeInstanceOf(ForbiddenError)
-      expect(createUploadSpy).not.toHaveBeenCalled()
-      expect(completeSpy).not.toHaveBeenCalled()
     })
   })
 
@@ -539,29 +365,17 @@ describe('S3UseCases', () => {
       md5: null,
     })
 
-    it('advances continuation token past a folded CommonPrefix when the DB batch is exhausted inside one prefix group', async () => {
-      // Regression test for Cursor Bugbot finding on PR #696 / #709.
-      //
-      // Scenario: maxKeys=2, delimiter='/', and a single virtual directory
-      // ('big/') contains more keys than fit in one DB batch.  Every fetched
-      // row folds into the same CommonPrefix, so the in-loop maxKeys cap is
-      // never hit and the loop exhausts the batch with isTruncated=false.
-      // The fallback branch must then set the continuation token to a value
-      // that sorts *after* every key in 'big/' — otherwise the next page
-      // re-scans the rest of that directory and emits 'big/' again.
+    it('scopes the listing to the caller and advances the token past a folded CommonPrefix', async () => {
       const maxKeys = 2
       const dbLimit = DELIMITER_DB_LIMIT(maxKeys)
-
-      // Fill the entire DB batch with keys that all fold into 'big/'.
       const fullBatch = Array.from({ length: dbLimit }, (_, i) =>
         makeListing(`big/${String(i).padStart(6, '0')}`),
       )
-
-      jest
+      const listSpy = jest
         .spyOn(s3ObjectMappingsRepository, 'listObjects')
         .mockResolvedValue(fullBatch as any)
 
-      const result = await S3UseCases.listObjects({
+      const result = await S3UseCases.listObjects(mockUser, {
         bucket: 'my-bucket',
         prefix: '',
         delimiter: '/',
@@ -569,39 +383,38 @@ describe('S3UseCases', () => {
         continuationToken: null,
       })
 
+      // Scoped to the caller: (owner, owner, bucket, prefix, token, dbLimit).
+      expect(listSpy).toHaveBeenCalledWith(
+        'google',
+        'user1',
+        'my-bucket',
+        '',
+        null,
+        dbLimit,
+      )
       expect(result.commonPrefixes).toEqual(['big/'])
       expect(result.objects).toEqual([])
       expect(result.isTruncated).toBe(true)
-      // Token must start with the folded prefix and sort strictly after every
-      // key inside it.  `￿` (U+FFFF) is the sentinel chosen for this purpose.
       expect(result.nextContinuationToken).toBe('big/￿')
-      // Sanity: the token sorts after the last key we returned in the batch.
       expect(
         result.nextContinuationToken! > fullBatch[fullBatch.length - 1].key,
       ).toBe(true)
     })
 
     it('uses the raw last key as the token when the last scanned key did not fold into a prefix', async () => {
-      // If the DB batch is full but the last key has no delimiter occurrence
-      // after the prefix, there's no CommonPrefix to skip past — fall back to
-      // the raw last key, which is the safe pre-fix behaviour.
       const maxKeys = 2
       const dbLimit = DELIMITER_DB_LIMIT(maxKeys)
-
-      // Pad the batch with folded entries, but make the LAST one a top-level
-      // key with no delimiter after the prefix.
       const batch = [
         ...Array.from({ length: dbLimit - 1 }, (_, i) =>
           makeListing(`folder/${String(i).padStart(6, '0')}`),
         ),
         makeListing('zzz-top-level'),
       ]
-
       jest
         .spyOn(s3ObjectMappingsRepository, 'listObjects')
         .mockResolvedValue(batch as any)
 
-      const result = await S3UseCases.listObjects({
+      const result = await S3UseCases.listObjects(mockUser, {
         bucket: 'my-bucket',
         prefix: '',
         delimiter: '/',
@@ -610,28 +423,21 @@ describe('S3UseCases', () => {
       })
 
       expect(result.isTruncated).toBe(true)
-      // The last key doesn't fold into a CommonPrefix, so the token stays as
-      // the raw key — no sentinel needed.
       expect(result.nextContinuationToken).toBe('zzz-top-level')
     })
 
     it('uses the raw last key as the token when no delimiter is set', async () => {
-      // Without a delimiter, the dbLimit is maxKeys + 1, and there are no
-      // CommonPrefixes to repeat — the safe fallback is just the last key.
       const maxKeys = 2
-      const dbLimit = maxKeys + 1 // = 3
-
       const batch = [
         makeListing('a.txt'),
         makeListing('b.txt'),
         makeListing('c.txt'),
       ]
-
       jest
         .spyOn(s3ObjectMappingsRepository, 'listObjects')
         .mockResolvedValue(batch as any)
 
-      const result = await S3UseCases.listObjects({
+      const result = await S3UseCases.listObjects(mockUser, {
         bucket: 'my-bucket',
         prefix: '',
         delimiter: null,
@@ -639,87 +445,17 @@ describe('S3UseCases', () => {
         continuationToken: null,
       })
 
-      // maxKeys=2 ⇒ first two keys returned, third triggers truncation in
-      // buildListResult (not the fallback), token = key just returned.
       expect(result.objects.map((o) => o.key)).toEqual(['a.txt', 'b.txt'])
       expect(result.isTruncated).toBe(true)
       expect(result.nextContinuationToken).toBe('b.txt')
-      // dbLimit branch shouldn't have triggered, so no sentinel appended.
-      expect(batch.length).toBe(dbLimit)
-    })
-  })
-
-  describe('objectExists', () => {
-    it('returns false when no mapping exists', async () => {
-      jest
-        .spyOn(s3ObjectMappingsRepository, 'findByKey')
-        .mockResolvedValue(null)
-
-      expect(await S3UseCases.objectExists('my-bucket', 'missing.txt')).toBe(
-        false,
-      )
-    })
-
-    it('returns true when a mapping exists and the object is not deleted', async () => {
-      jest
-        .spyOn(s3ObjectMappingsRepository, 'findByKey')
-        .mockResolvedValue({
-          bucket: 'my-bucket',
-          key: 'file.txt',
-          cid: 'cid123',
-          md5: null,
-        } as any)
-      jest.spyOn(ObjectUseCases, 'isObjectDeleted').mockResolvedValue(false)
-
-      expect(await S3UseCases.objectExists('my-bucket', 'file.txt')).toBe(true)
-    })
-
-    // A trashed object keeps its mapping row but is hidden from GET/list, so
-    // object-lock endpoints must report it as not found too.
-    it('returns false when the mapping exists but the object was removed by its owner', async () => {
-      jest
-        .spyOn(s3ObjectMappingsRepository, 'findByKey')
-        .mockResolvedValue({
-          bucket: 'my-bucket',
-          key: 'trashed.txt',
-          cid: 'cid123',
-          md5: null,
-        } as any)
-      jest.spyOn(ObjectUseCases, 'isObjectDeleted').mockResolvedValue(true)
-
-      expect(await S3UseCases.objectExists('my-bucket', 'trashed.txt')).toBe(
-        false,
-      )
     })
   })
 
   describe('deleteObject', () => {
-    // Legacy mapping (no recorded owner) → the delete gate falls back to the
-    // per-CID admin check.
-    const activeMapping = {
-      bucket: 'my-bucket',
-      key: 'file.txt',
-      cid: 'cid123',
-      md5: null,
-      mtime: null,
-      ownerOauthProvider: null,
-      ownerOauthUserId: null,
-    } as any
-
-    // Modern mapping owned by mockUser → gated on the per-mapping owner.
-    const ownedMapping = {
-      ...activeMapping,
-      ownerOauthProvider: 'google',
-      ownerOauthUserId: 'user1',
-    } as any
-
-    it('trashes the object then hides the mapping when it was the last reference', async () => {
+    it('trashes the object then hides the key when it was the caller’s last reference', async () => {
       jest
         .spyOn(s3ObjectMappingsRepository, 'findByKey')
-        .mockResolvedValue(activeMapping)
-      jest
-        .spyOn(ownershipRepository, 'getOwnerships')
-        .mockResolvedValue([ownerRow])
+        .mockResolvedValue(mapping())
       jest
         .spyOn(s3ObjectMappingsRepository, 'countActiveMappingsByCid')
         .mockResolvedValue(1)
@@ -737,20 +473,20 @@ describe('S3UseCases', () => {
       )
 
       expect(result.isOk()).toBe(true)
-      // Last active mapping → propagate to Trash, then hide the key.
       expect(markSpy).toHaveBeenCalledWith(mockUser, 'cid123')
-      expect(softDeleteSpy).toHaveBeenCalledWith('my-bucket', 'file.txt')
+      expect(softDeleteSpy).toHaveBeenCalledWith(
+        'google',
+        'user1',
+        'my-bucket',
+        'file.txt',
+      )
     })
 
-    it('does not trash the object when another S3 key still references it', async () => {
+    it('does not trash the object when the caller still has another key for it', async () => {
       jest
         .spyOn(s3ObjectMappingsRepository, 'findByKey')
-        .mockResolvedValue({ ...activeMapping, key: 'copy.txt' })
-      jest
-        .spyOn(ownershipRepository, 'getOwnerships')
-        .mockResolvedValue([ownerRow])
-      // Before-hide count = 2 (this + sibling); after-hide re-check = 1 (sibling
-      // still active), so the race guard does not trash.
+        .mockResolvedValue(mapping({ key: 'copy.txt' }))
+      // before-hide = 2, after-hide re-check = 1 (sibling still active).
       jest
         .spyOn(s3ObjectMappingsRepository, 'countActiveMappingsByCid')
         .mockResolvedValueOnce(2)
@@ -758,7 +494,7 @@ describe('S3UseCases', () => {
       const markSpy = jest
         .spyOn(ObjectUseCases, 'markAsDeleted')
         .mockResolvedValue(ok(undefined))
-      const softDeleteSpy = jest
+      jest
         .spyOn(s3ObjectMappingsRepository, 'softDeleteMapping')
         .mockResolvedValue({ cid: 'cid123' })
 
@@ -769,21 +505,13 @@ describe('S3UseCases', () => {
       )
 
       expect(result.isOk()).toBe(true)
-      // A sibling key (e.g. the move source) keeps the content live.
       expect(markSpy).not.toHaveBeenCalled()
-      expect(softDeleteSpy).toHaveBeenCalledWith('my-bucket', 'copy.txt')
     })
 
     it('trashes via the race guard when a concurrent delete removed the sibling', async () => {
       jest
         .spyOn(s3ObjectMappingsRepository, 'findByKey')
-        .mockResolvedValue({ ...activeMapping, key: 'k2.txt' })
-      jest
-        .spyOn(ownershipRepository, 'getOwnerships')
-        .mockResolvedValue([ownerRow])
-      // Before-hide count = 2 (a concurrent delete's key still looked active),
-      // but the after-hide re-check sees 0 → this delete emptied the content and
-      // must trash the object.
+        .mockResolvedValue(mapping({ key: 'k2.txt' }))
       jest
         .spyOn(s3ObjectMappingsRepository, 'countActiveMappingsByCid')
         .mockResolvedValueOnce(2)
@@ -791,84 +519,28 @@ describe('S3UseCases', () => {
       const markSpy = jest
         .spyOn(ObjectUseCases, 'markAsDeleted')
         .mockResolvedValue(ok(undefined))
-      const softDeleteSpy = jest
+      jest
         .spyOn(s3ObjectMappingsRepository, 'softDeleteMapping')
         .mockResolvedValue({ cid: 'cid123' })
 
       const result = await S3UseCases.deleteObject(mockUser, 'my-bucket', 'k2.txt')
 
       expect(result.isOk()).toBe(true)
-      expect(softDeleteSpy).toHaveBeenCalledWith('my-bucket', 'k2.txt')
-      // Race guard caught the emptied content and moved it to Trash.
       expect(markSpy).toHaveBeenCalledWith(mockUser, 'cid123')
     })
 
-    it('is a no-op when the key is absent or already deleted', async () => {
+    it('is a no-op when the caller has no such key', async () => {
       jest.spyOn(s3ObjectMappingsRepository, 'findByKey').mockResolvedValue(null)
-      const ownSpy = jest.spyOn(ownershipRepository, 'getOwnerships')
       const softDeleteSpy = jest.spyOn(
         s3ObjectMappingsRepository,
         'softDeleteMapping',
       )
+      const markSpy = jest.spyOn(ObjectUseCases, 'markAsDeleted')
 
       const result = await S3UseCases.deleteObject(
         mockUser,
         'my-bucket',
         'missing.txt',
-      )
-
-      expect(result.isOk()).toBe(true)
-      expect(ownSpy).not.toHaveBeenCalled()
-      expect(softDeleteSpy).not.toHaveBeenCalled()
-    })
-
-    it('does not hide the key when the caller does not own the content', async () => {
-      jest
-        .spyOn(s3ObjectMappingsRepository, 'findByKey')
-        .mockResolvedValue(activeMapping)
-      // Owned (admin) by someone else.
-      jest
-        .spyOn(ownershipRepository, 'getOwnerships')
-        .mockResolvedValue([
-          { ...ownerRow, oauth_user_id: 'someone-else' },
-        ])
-      const softDeleteSpy = jest.spyOn(
-        s3ObjectMappingsRepository,
-        'softDeleteMapping',
-      )
-      const markSpy = jest.spyOn(ObjectUseCases, 'markAsDeleted')
-
-      const result = await S3UseCases.deleteObject(
-        mockUser,
-        'my-bucket',
-        'file.txt',
-      )
-
-      // Idempotent success, but the non-owner cannot hide the key.
-      expect(result.isOk()).toBe(true)
-      expect(softDeleteSpy).not.toHaveBeenCalled()
-      expect(markSpy).not.toHaveBeenCalled()
-    })
-
-    it('does not hide the key for a shared (non-admin) recipient', async () => {
-      jest
-        .spyOn(s3ObjectMappingsRepository, 'findByKey')
-        .mockResolvedValue(activeMapping)
-      // The caller is an active owner, but a VIEWER (share recipient), not the
-      // admin owner — they must not be able to hide the key for everyone.
-      jest
-        .spyOn(ownershipRepository, 'getOwnerships')
-        .mockResolvedValue([{ ...ownerRow, is_admin: false }])
-      const softDeleteSpy = jest.spyOn(
-        s3ObjectMappingsRepository,
-        'softDeleteMapping',
-      )
-      const markSpy = jest.spyOn(ObjectUseCases, 'markAsDeleted')
-
-      const result = await S3UseCases.deleteObject(
-        mockUser,
-        'my-bucket',
-        'file.txt',
       )
 
       expect(result.isOk()).toBe(true)
@@ -879,10 +551,7 @@ describe('S3UseCases', () => {
     it('still succeeds when moving the object to Trash fails', async () => {
       jest
         .spyOn(s3ObjectMappingsRepository, 'findByKey')
-        .mockResolvedValue(activeMapping)
-      jest
-        .spyOn(ownershipRepository, 'getOwnerships')
-        .mockResolvedValue([ownerRow])
+        .mockResolvedValue(mapping())
       jest
         .spyOn(s3ObjectMappingsRepository, 'countActiveMappingsByCid')
         .mockResolvedValue(1)
@@ -899,98 +568,32 @@ describe('S3UseCases', () => {
         'file.txt',
       )
 
-      // The key is still hidden; a Trash-propagation failure must not fail the
-      // S3 DeleteObject.
       expect(result.isOk()).toBe(true)
-      expect(softDeleteSpy).toHaveBeenCalledWith('my-bucket', 'file.txt')
-    })
-
-    it('gates on the per-mapping owner (no per-CID lookup) and scopes the count', async () => {
-      jest
-        .spyOn(s3ObjectMappingsRepository, 'findByKey')
-        .mockResolvedValue(ownedMapping)
-      const getOwnershipsSpy = jest.spyOn(ownershipRepository, 'getOwnerships')
-      const countSpy = jest
-        .spyOn(s3ObjectMappingsRepository, 'countActiveMappingsByCid')
-        .mockResolvedValue(1)
-      const markSpy = jest
-        .spyOn(ObjectUseCases, 'markAsDeleted')
-        .mockResolvedValue(ok(undefined))
-      const softDeleteSpy = jest
-        .spyOn(s3ObjectMappingsRepository, 'softDeleteMapping')
-        .mockResolvedValue({ cid: 'cid123' })
-
-      const result = await S3UseCases.deleteObject(
-        mockUser,
-        'my-bucket',
-        'file.txt',
-      )
-
-      expect(result.isOk()).toBe(true)
-      // Owner is known from the mapping → no CID-ownership lookup needed.
-      expect(getOwnershipsSpy).not.toHaveBeenCalled()
-      // The "last key" count is scoped to the caller, not the whole CID.
-      expect(countSpy).toHaveBeenCalledWith('cid123', 'google', 'user1')
-      expect(markSpy).toHaveBeenCalledWith(mockUser, 'cid123')
-      expect(softDeleteSpy).toHaveBeenCalledWith('my-bucket', 'file.txt')
-    })
-
-    it('refuses to hide another user’s key even from a dedup co-owner of the CID', async () => {
-      // The mapping belongs to someone else; the caller (mockUser) may well be
-      // an admin owner of the same CID via dedup, but that must NOT let them
-      // hide this key. The per-mapping owner check never consults CID ownership.
-      jest
-        .spyOn(s3ObjectMappingsRepository, 'findByKey')
-        .mockResolvedValue({ ...ownedMapping, ownerOauthUserId: 'someone-else' })
-      const getOwnershipsSpy = jest.spyOn(ownershipRepository, 'getOwnerships')
-      const softDeleteSpy = jest.spyOn(
-        s3ObjectMappingsRepository,
-        'softDeleteMapping',
-      )
-      const markSpy = jest.spyOn(ObjectUseCases, 'markAsDeleted')
-
-      const result = await S3UseCases.deleteObject(
-        mockUser,
-        'my-bucket',
-        'file.txt',
-      )
-
-      expect(result.isOk()).toBe(true)
-      expect(getOwnershipsSpy).not.toHaveBeenCalled()
-      expect(softDeleteSpy).not.toHaveBeenCalled()
-      expect(markSpy).not.toHaveBeenCalled()
+      expect(softDeleteSpy).toHaveBeenCalled()
     })
   })
 
   describe('copyObject', () => {
-    const source = {
+    const source = mapping({
       bucket: 'src',
       key: 'a.txt',
       cid: 'srccid',
       md5: 'd41d8cd98f00b204e9800998ecf8427e',
-      mtime: null,
-      createdAt: new Date(0),
-      updatedAt: new Date(0),
-    }
+    })
 
     beforeEach(() => {
-      // Happy-path defaults: caller is the active admin owner and the source is
-      // readable.
-      jest
-        .spyOn(ownershipRepository, 'getOwnerships')
-        .mockResolvedValue([ownerRow])
       jest
         .spyOn(ObjectUseCases, 'authorizeDownload')
         .mockResolvedValue(ok(undefined))
     })
 
-    it('remaps the destination to the source cid (no ownership re-grant)', async () => {
-      jest
+    it('remaps the destination to the source cid in the caller’s namespace', async () => {
+      const findSpy = jest
         .spyOn(s3ObjectMappingsRepository, 'findByKey')
-        .mockResolvedValue(source as any)
+        .mockResolvedValue(source)
       const createSpy = jest
         .spyOn(s3ObjectMappingsRepository, 'createMapping')
-        .mockResolvedValue({ ...source, updatedAt: new Date(1000) } as any)
+        .mockResolvedValue({ ...source, updatedAt: new Date(1000) })
 
       const result = await S3UseCases.copyObject(mockUser, {
         SourceBucket: 'src',
@@ -1002,23 +605,21 @@ describe('S3UseCases', () => {
       expect(result.isOk()).toBe(true)
       expect(result._unsafeUnwrap().Cid).toBe('srccid')
       expect(result._unsafeUnwrap().ETag).toMatch(MD5_ETAG_RE)
-      // Destination points at the SAME cid + md5 as the source, owned by the
-      // copier (args after md5: mtime, owner provider, owner user id).
+      // Source lookup + destination creation are both scoped to the caller.
+      expect(findSpy).toHaveBeenCalledWith('google', 'user1', 'src', 'a.txt')
       expect(createSpy).toHaveBeenCalledWith(
+        'google',
+        'user1',
         'dst',
         'b.txt',
         'srccid',
         source.md5,
         null,
-        'google',
-        'user1',
       )
     })
 
-    it('returns a not-found error when the source is missing (NoSuchKey)', async () => {
-      jest
-        .spyOn(s3ObjectMappingsRepository, 'findByKey')
-        .mockResolvedValue(null)
+    it('returns a not-found error when the caller has no such source key', async () => {
+      jest.spyOn(s3ObjectMappingsRepository, 'findByKey').mockResolvedValue(null)
 
       const result = await S3UseCases.copyObject(mockUser, {
         SourceBucket: 'src',
@@ -1031,121 +632,12 @@ describe('S3UseCases', () => {
       expect(result._unsafeUnwrapErr()).toBeInstanceOf(ObjectNotFoundError)
     })
 
-    it('refuses to copy a source the caller does not own (NoSuchKey, no mapping)', async () => {
-      jest
-        .spyOn(s3ObjectMappingsRepository, 'findByKey')
-        .mockResolvedValue(source as any)
-      // Owned (admin) by a different user.
-      jest
-        .spyOn(ownershipRepository, 'getOwnerships')
-        .mockResolvedValue([{ ...ownerRow, oauth_user_id: 'someone-else' }])
-      const createSpy = jest.spyOn(
-        s3ObjectMappingsRepository,
-        'createMapping',
-      )
-
-      const result = await S3UseCases.copyObject(mockUser, {
-        SourceBucket: 'src',
-        SourceKey: 'a.txt',
-        Bucket: 'dst',
-        Key: 'b.txt',
-      })
-
-      expect(result.isErr()).toBe(true)
-      expect(result._unsafeUnwrapErr()).toBeInstanceOf(ObjectNotFoundError)
-      // A non-owner can't acquire the CID via copy.
-      expect(createSpy).not.toHaveBeenCalled()
-    })
-
-    it('refuses to copy for a shared (non-admin) recipient', async () => {
-      jest
-        .spyOn(s3ObjectMappingsRepository, 'findByKey')
-        .mockResolvedValue(source as any)
-      // Caller is an active owner, but only a VIEWER (share recipient).
-      jest
-        .spyOn(ownershipRepository, 'getOwnerships')
-        .mockResolvedValue([{ ...ownerRow, is_admin: false }])
-      const createSpy = jest.spyOn(
-        s3ObjectMappingsRepository,
-        'createMapping',
-      )
-
-      const result = await S3UseCases.copyObject(mockUser, {
-        SourceBucket: 'src',
-        SourceKey: 'a.txt',
-        Bucket: 'dst',
-        Key: 'b.txt',
-      })
-
-      expect(result.isErr()).toBe(true)
-      expect(createSpy).not.toHaveBeenCalled()
-    })
-
-    it('gates the source on its per-mapping owner without a CID lookup', async () => {
-      // Modern source owned by the caller → authorized via the mapping owner;
-      // the per-CID ownership lookup is not consulted (matches deleteObject).
-      jest.spyOn(s3ObjectMappingsRepository, 'findByKey').mockResolvedValue({
-        ...source,
-        ownerOauthProvider: 'google',
-        ownerOauthUserId: 'user1',
-      } as any)
-      const getOwnershipsSpy = jest.spyOn(ownershipRepository, 'getOwnerships')
-      jest
-        .spyOn(s3ObjectMappingsRepository, 'createMapping')
-        .mockResolvedValue({ ...source, updatedAt: new Date(1000) } as any)
-
-      const result = await S3UseCases.copyObject(mockUser, {
-        SourceBucket: 'src',
-        SourceKey: 'a.txt',
-        Bucket: 'dst',
-        Key: 'b.txt',
-      })
-
-      expect(result.isOk()).toBe(true)
-      expect(getOwnershipsSpy).not.toHaveBeenCalled()
-    })
-
-    it('refuses to copy from a source key owned by another user (dedup co-owner)', async () => {
-      // The source key belongs to someone else. The caller may co-own the CID
-      // via dedup (identical bytes), but must NOT be able to use another user's
-      // key as a copy source — mirrors deleteObject's per-mapping-owner gate.
-      jest.spyOn(s3ObjectMappingsRepository, 'findByKey').mockResolvedValue({
-        ...source,
-        ownerOauthProvider: 'google',
-        ownerOauthUserId: 'someone-else',
-      } as any)
-      const getOwnershipsSpy = jest.spyOn(ownershipRepository, 'getOwnerships')
-      const createSpy = jest.spyOn(
-        s3ObjectMappingsRepository,
-        'createMapping',
-      )
-
-      const result = await S3UseCases.copyObject(mockUser, {
-        SourceBucket: 'src',
-        SourceKey: 'a.txt',
-        Bucket: 'dst',
-        Key: 'b.txt',
-      })
-
-      expect(result.isErr()).toBe(true)
-      expect(result._unsafeUnwrapErr()).toBeInstanceOf(ObjectNotFoundError)
-      // Modern source → owner from the mapping; no CID-ownership lookup, and no
-      // destination mapping created.
-      expect(getOwnershipsSpy).not.toHaveBeenCalled()
-      expect(createSpy).not.toHaveBeenCalled()
-    })
-
     it('refuses to copy a source that is not downloadable (removed/banned)', async () => {
-      jest
-        .spyOn(s3ObjectMappingsRepository, 'findByKey')
-        .mockResolvedValue(source as any)
+      jest.spyOn(s3ObjectMappingsRepository, 'findByKey').mockResolvedValue(source)
       jest
         .spyOn(ObjectUseCases, 'authorizeDownload')
         .mockResolvedValue(err(new ObjectNotFoundError('Object not found')))
-      const createSpy = jest.spyOn(
-        s3ObjectMappingsRepository,
-        'createMapping',
-      )
+      const createSpy = jest.spyOn(s3ObjectMappingsRepository, 'createMapping')
 
       const result = await S3UseCases.copyObject(mockUser, {
         SourceBucket: 'src',
@@ -1155,18 +647,16 @@ describe('S3UseCases', () => {
       })
 
       expect(result.isErr()).toBe(true)
-      expect(result._unsafeUnwrapErr()).toBeInstanceOf(ObjectNotFoundError)
-      // No destination mapping is created for an unreadable source.
       expect(createSpy).not.toHaveBeenCalled()
     })
 
-    it('inherits the source mtime when no override is provided', async () => {
+    it('inherits the source mtime when no override is given', async () => {
       jest
         .spyOn(s3ObjectMappingsRepository, 'findByKey')
-        .mockResolvedValue({ ...source, mtime: '111.5' } as any)
+        .mockResolvedValue(mapping({ ...source, mtime: '111.5' }))
       const createSpy = jest
         .spyOn(s3ObjectMappingsRepository, 'createMapping')
-        .mockResolvedValue({ ...source, updatedAt: new Date(1000) } as any)
+        .mockResolvedValue({ ...source, updatedAt: new Date(1000) })
 
       await S3UseCases.copyObject(mockUser, {
         SourceBucket: 'src',
@@ -1176,23 +666,23 @@ describe('S3UseCases', () => {
       })
 
       expect(createSpy).toHaveBeenCalledWith(
+        'google',
+        'user1',
         'dst',
         'b.txt',
         'srccid',
         source.md5,
         '111.5',
-        'google',
-        'user1',
       )
     })
 
     it('applies an mtime override on the destination (SetModTime)', async () => {
       jest
         .spyOn(s3ObjectMappingsRepository, 'findByKey')
-        .mockResolvedValue({ ...source, mtime: '111.5' } as any)
+        .mockResolvedValue(mapping({ ...source, mtime: '111.5' }))
       const createSpy = jest
         .spyOn(s3ObjectMappingsRepository, 'createMapping')
-        .mockResolvedValue({ ...source, updatedAt: new Date(1000) } as any)
+        .mockResolvedValue({ ...source, updatedAt: new Date(1000) })
 
       await S3UseCases.copyObject(mockUser, {
         SourceBucket: 'src',
@@ -1203,26 +693,23 @@ describe('S3UseCases', () => {
       })
 
       expect(createSpy).toHaveBeenCalledWith(
+        'google',
+        'user1',
         'dst',
         'b.txt',
         'srccid',
         source.md5,
         '222.9',
-        'google',
-        'user1',
       )
     })
 
     it('clears the destination mtime when an explicit null is given (REPLACE, no mtime)', async () => {
-      // A metadata-REPLACE copy with no x-amz-meta-mtime resolves to Mtime: null
-      // in the controller; the use case must write null (clear), not inherit the
-      // source's mtime.
       jest
         .spyOn(s3ObjectMappingsRepository, 'findByKey')
-        .mockResolvedValue({ ...source, mtime: '111.5' } as any)
+        .mockResolvedValue(mapping({ ...source, mtime: '111.5' }))
       const createSpy = jest
         .spyOn(s3ObjectMappingsRepository, 'createMapping')
-        .mockResolvedValue({ ...source, updatedAt: new Date(1000) } as any)
+        .mockResolvedValue({ ...source, updatedAt: new Date(1000) })
 
       await S3UseCases.copyObject(mockUser, {
         SourceBucket: 'src',
@@ -1233,23 +720,23 @@ describe('S3UseCases', () => {
       })
 
       expect(createSpy).toHaveBeenCalledWith(
+        'google',
+        'user1',
         'dst',
         'b.txt',
         'srccid',
         source.md5,
         null,
-        'google',
-        'user1',
       )
     })
 
     it('falls back to the CID as ETag for legacy objects without md5', async () => {
       jest
         .spyOn(s3ObjectMappingsRepository, 'findByKey')
-        .mockResolvedValue({ ...source, md5: null } as any)
+        .mockResolvedValue(mapping({ ...source, md5: null }))
       jest
         .spyOn(s3ObjectMappingsRepository, 'createMapping')
-        .mockResolvedValue({ ...source, md5: null, updatedAt: new Date() } as any)
+        .mockResolvedValue(mapping({ ...source, md5: null, updatedAt: new Date() }))
 
       const result = await S3UseCases.copyObject(mockUser, {
         SourceBucket: 'src',
@@ -1259,27 +746,6 @@ describe('S3UseCases', () => {
       })
 
       expect(result._unsafeUnwrap().ETag).toBe('"srccid"')
-    })
-
-    it('rejects copying onto a destination key owned by another user (Forbidden)', async () => {
-      jest
-        .spyOn(s3ObjectMappingsRepository, 'findByKey')
-        .mockResolvedValue(source as any)
-      // Caller owns the source (beforeEach getOwnerships → ownerRow); the
-      // destination key is owned by someone else → guarded upsert returns null.
-      jest
-        .spyOn(s3ObjectMappingsRepository, 'createMapping')
-        .mockResolvedValue(null)
-
-      const result = await S3UseCases.copyObject(mockUser, {
-        SourceBucket: 'src',
-        SourceKey: 'a.txt',
-        Bucket: 'dst',
-        Key: 'victim.txt',
-      })
-
-      expect(result.isErr()).toBe(true)
-      expect(result._unsafeUnwrapErr()).toBeInstanceOf(ForbiddenError)
     })
   })
 
@@ -1292,10 +758,7 @@ describe('S3UseCases', () => {
         .spyOn(s3ObjectMappingsRepository, 'deleteMultipartMtime')
         .mockResolvedValue(undefined)
 
-      const result = await S3UseCases.abortMultipartUpload(
-        mockUser,
-        'upload123',
-      )
+      const result = await S3UseCases.abortMultipartUpload(mockUser, 'upload123')
 
       expect(result.isOk()).toBe(true)
       expect(abortSpy).toHaveBeenCalledWith(mockUser, 'upload123')
@@ -1315,7 +778,6 @@ describe('S3UseCases', () => {
 
       expect(result.isErr()).toBe(true)
       expect(result._unsafeUnwrapErr()).toBeInstanceOf(ObjectNotFoundError)
-      // A failed abort must not drop another upload's stashed mtime.
       expect(clearMtimeSpy).not.toHaveBeenCalled()
     })
 
@@ -1326,9 +788,40 @@ describe('S3UseCases', () => {
 
       const result = await S3UseCases.abortMultipartUpload(mockUser, 'other')
 
-      // The controller maps ForbiddenError → 403 AccessDenied (not 500).
       expect(result.isErr()).toBe(true)
       expect(result._unsafeUnwrapErr()).toBeInstanceOf(ForbiddenError)
+    })
+  })
+
+  describe('objectExists', () => {
+    it('returns false when the caller has no such mapping', async () => {
+      jest.spyOn(s3ObjectMappingsRepository, 'findByKey').mockResolvedValue(null)
+
+      expect(
+        await S3UseCases.objectExists(mockUser, 'my-bucket', 'missing.txt'),
+      ).toBe(false)
+    })
+
+    it('returns true when the mapping exists and the object is not removed', async () => {
+      jest
+        .spyOn(s3ObjectMappingsRepository, 'findByKey')
+        .mockResolvedValue(mapping())
+      jest.spyOn(ObjectUseCases, 'isObjectDeleted').mockResolvedValue(false)
+
+      expect(await S3UseCases.objectExists(mockUser, 'my-bucket', 'file.txt')).toBe(
+        true,
+      )
+    })
+
+    it('returns false when the object was removed by its owner (Trash)', async () => {
+      jest
+        .spyOn(s3ObjectMappingsRepository, 'findByKey')
+        .mockResolvedValue(mapping({ key: 'trashed.txt' }))
+      jest.spyOn(ObjectUseCases, 'isObjectDeleted').mockResolvedValue(true)
+
+      expect(
+        await S3UseCases.objectExists(mockUser, 'my-bucket', 'trashed.txt'),
+      ).toBe(false)
     })
   })
 })

--- a/apps/backend/migrations/20260710000000-s3-per-user-namespace.js
+++ b/apps/backend/migrations/20260710000000-s3-per-user-namespace.js
@@ -1,0 +1,51 @@
+'use strict'
+
+var dbm
+var type
+var seed
+var fs = require('fs')
+var path = require('path')
+var Promise
+
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  var filePath = path.join(
+    __dirname,
+    'sqls',
+    '20260710000000-s3-per-user-namespace-up.sql',
+  )
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      resolve(data)
+    })
+  }).then(function (data) {
+    return db.runSql(data)
+  })
+}
+
+exports.down = function (db) {
+  var filePath = path.join(
+    __dirname,
+    'sqls',
+    '20260710000000-s3-per-user-namespace-down.sql',
+  )
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      resolve(data)
+    })
+  }).then(function (data) {
+    return db.runSql(data)
+  })
+}
+
+exports._meta = {
+  version: 1,
+}

--- a/apps/backend/migrations/sqls/20260710000000-s3-per-user-namespace-down.sql
+++ b/apps/backend/migrations/sqls/20260710000000-s3-per-user-namespace-down.sql
@@ -1,0 +1,14 @@
+-- Revert to the global (bucket, key) primary key.
+--
+-- Best-effort: this FAILS if any (bucket, key) is owned by more than one user —
+-- which is expected once the per-user namespace is in use (that's the whole
+-- point of the forward migration). To roll back after adoption, an operator must
+-- first resolve those collisions manually (e.g. keep one owner's row per
+-- (bucket, key)); there is no unambiguous automatic choice.
+ALTER TABLE "S3".object_mappings DROP CONSTRAINT object_mappings_pkey;
+
+ALTER TABLE "S3".object_mappings
+  ALTER COLUMN owner_oauth_provider DROP NOT NULL,
+  ALTER COLUMN owner_oauth_user_id DROP NOT NULL;
+
+ALTER TABLE "S3".object_mappings ADD PRIMARY KEY (bucket, "key");

--- a/apps/backend/migrations/sqls/20260710000000-s3-per-user-namespace-down.sql
+++ b/apps/backend/migrations/sqls/20260710000000-s3-per-user-namespace-down.sql
@@ -1,11 +1,24 @@
 -- Revert to the global (bucket, key) primary key.
 --
--- Best-effort: this FAILS if any (bucket, key) is owned by more than one user —
--- which is expected once the per-user namespace is in use (that's the whole
--- point of the forward migration). To roll back after adoption, an operator must
--- first resolve those collisions manually (e.g. keep one owner's row per
--- (bucket, key)); there is no unambiguous automatic choice.
-ALTER TABLE "S3".object_mappings DROP CONSTRAINT object_mappings_pkey;
+-- The forward migration deliberately lets multiple owners hold the same
+-- (bucket, key). Restoring a UNIQUE (bucket, key) primary key therefore has to
+-- first collapse those back to a single row: we keep the most-recently-updated
+-- row per (bucket, key) and drop the rest. This is LOSSY by nature — rolling
+-- back after the per-user namespace has been used discards every non-winning
+-- owner's row — but it is done automatically, and deterministically, so the
+-- rollback always completes instead of erroring out on the very data the
+-- forward migration was designed to allow. (It also keeps the test-suite's
+-- per-suite down/up reset from breaking on cross-owner fixtures.)
+ALTER TABLE "S3".object_mappings DROP CONSTRAINT IF EXISTS object_mappings_pkey;
+
+-- Keep exactly one row per (bucket, key): the most recently updated, with ctid
+-- as a stable tie-breaker. Everything else with a colliding (bucket, key) goes.
+DELETE FROM "S3".object_mappings
+WHERE ctid NOT IN (
+  SELECT DISTINCT ON (bucket, "key") ctid
+  FROM "S3".object_mappings
+  ORDER BY bucket, "key", updated_at DESC, ctid DESC
+);
 
 ALTER TABLE "S3".object_mappings
   ALTER COLUMN owner_oauth_provider DROP NOT NULL,

--- a/apps/backend/migrations/sqls/20260710000000-s3-per-user-namespace-up.sql
+++ b/apps/backend/migrations/sqls/20260710000000-s3-per-user-namespace-up.sql
@@ -40,7 +40,9 @@ END $$;
 
 -- Drop the (bucket, key) uniqueness FIRST, so duplicating a NULL-owner row to
 -- multiple admin owners (same bucket/key, different owner) does not violate it.
-ALTER TABLE "S3".object_mappings DROP CONSTRAINT object_mappings_pkey;
+-- IF EXISTS keeps re-application idempotent (the down migration re-adds this PK,
+-- so an up/down/up cycle must not trip over an already-dropped constraint).
+ALTER TABLE "S3".object_mappings DROP CONSTRAINT IF EXISTS object_mappings_pkey;
 
 -- Duplicate each remaining NULL-owner mapping to every admin owner of its CID.
 INSERT INTO "S3".object_mappings

--- a/apps/backend/migrations/sqls/20260710000000-s3-per-user-namespace-up.sql
+++ b/apps/backend/migrations/sqls/20260710000000-s3-per-user-namespace-up.sql
@@ -1,0 +1,65 @@
+-- Scope the S3 key namespace per user.
+--
+-- Change the mapping identity from the global (bucket, key) to
+-- (owner, bucket, key). This removes cross-user contention over shared key names
+-- entirely: two users can each own "default/test.txt", every read/write is
+-- scoped to the caller, and the guard machinery that refereed the shared
+-- namespace (cross-owner delete/copy gates, guarded upserts, pre-finalize
+-- checks) becomes unnecessary.
+--
+-- Legacy rows: an earlier migration on this branch backfilled owner for every
+-- CID with a single admin owner. The only NULL-owner rows left are ambiguous —
+-- a CID with several admin owners (cross-user dedup on the same key). We
+-- DUPLICATE those to every admin owner rather than guess one: guessing risks
+-- 404ing the real user's key (their sync breaks with no self-service recovery),
+-- whereas a surprise duplicate is a key the user can simply soft-delete. Gaining
+-- clutter beats losing access. (Expected NULL-owner count in production: zero —
+-- worth confirming with a COUNT(*) pre-flight.)
+
+-- Fail loud on rows we cannot attribute: a NULL-owner mapping whose CID has NO
+-- admin owner has no one to duplicate to, so the DELETE below would silently
+-- drop the key. Abort and let an operator resolve it instead of losing data.
+DO $$
+DECLARE
+  orphan_count INT;
+BEGIN
+  SELECT COUNT(*) INTO orphan_count
+  FROM "S3".object_mappings om
+  WHERE om.owner_oauth_user_id IS NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM object_ownership oo
+      WHERE oo.cid = om.cid AND oo.is_admin = true
+    );
+  IF orphan_count > 0 THEN
+    RAISE EXCEPTION
+      'Cannot scope S3 namespace per user: % NULL-owner mapping(s) have no admin '
+      'owner to attribute them to. Resolve these rows manually before migrating.',
+      orphan_count;
+  END IF;
+END $$;
+
+-- Drop the (bucket, key) uniqueness FIRST, so duplicating a NULL-owner row to
+-- multiple admin owners (same bucket/key, different owner) does not violate it.
+ALTER TABLE "S3".object_mappings DROP CONSTRAINT object_mappings_pkey;
+
+-- Duplicate each remaining NULL-owner mapping to every admin owner of its CID.
+INSERT INTO "S3".object_mappings
+  (bucket, "key", cid, md5, mtime, deleted_at, created_at, updated_at,
+   owner_oauth_provider, owner_oauth_user_id)
+SELECT om.bucket, om."key", om.cid, om.md5, om.mtime, om.deleted_at,
+       om.created_at, om.updated_at, oo.oauth_provider, oo.oauth_user_id
+FROM "S3".object_mappings om
+JOIN object_ownership oo ON oo.cid = om.cid AND oo.is_admin = true
+WHERE om.owner_oauth_user_id IS NULL;
+
+-- Remove the now-superseded NULL-owner originals.
+DELETE FROM "S3".object_mappings WHERE owner_oauth_user_id IS NULL;
+
+-- Owner is now part of the identity.
+ALTER TABLE "S3".object_mappings
+  ALTER COLUMN owner_oauth_provider SET NOT NULL,
+  ALTER COLUMN owner_oauth_user_id SET NOT NULL;
+
+-- The new per-user primary key.
+ALTER TABLE "S3".object_mappings
+  ADD PRIMARY KEY (owner_oauth_provider, owner_oauth_user_id, bucket, "key");

--- a/apps/backend/src/app/controllers/s3/s3.ts
+++ b/apps/backend/src/app/controllers/s3/s3.ts
@@ -194,7 +194,7 @@ export const listBucketsHandler = async (req: Request, res: Response) => {
   const user = await handleS3Auth(req, res)
   if (!user) return
 
-  const buckets = await S3UseCases.listBuckets()
+  const buckets = await S3UseCases.listBuckets(user)
   sendXML(res, 'ListAllMyBucketsResult', {
     Buckets: {
       Bucket: buckets.map((b) => ({
@@ -211,7 +211,7 @@ export const getObjectHandler = async (req: Request, res: Response) => {
 
   const { bucket, key } = parseBucketAndKey(req.params.key)
   const byteRange = getByteRange(req)
-  const downloadResult = await S3UseCases.getObject({
+  const downloadResult = await S3UseCases.getObject(user, {
     Key: key,
     Range: byteRange,
     Bucket: bucket,
@@ -264,7 +264,7 @@ export const headObjectHandler = async (req: Request, res: Response) => {
 
   const { bucket, key } = parseBucketAndKey(req.params.key)
   const byteRange = getByteRange(req)
-  const downloadResult = await S3UseCases.getObject({
+  const downloadResult = await S3UseCases.getObject(user, {
     Key: key,
     Range: byteRange,
     Bucket: bucket,
@@ -339,16 +339,6 @@ const sendNoSuchKey = (res: Response, key: string) => {
   })
 }
 
-// S3 error responses must be XML on this API surface (the AWS SDK / rclone parse
-// the <Error> body), so a 403 is sent as XML AccessDenied rather than via
-// handleError, which emits JSON.
-const sendAccessDenied = (res: Response, message: string) => {
-  sendXML(res.status(403), 'Error', {
-    Code: 'AccessDenied',
-    Message: message,
-  })
-}
-
 export const getObjectRetentionHandler = async (
   req: Request,
   res: Response,
@@ -356,7 +346,7 @@ export const getObjectRetentionHandler = async (
   const user = await handleS3Auth(req, res)
   if (!user) return
   const { bucket, key } = parseBucketAndKey(req.params.key)
-  if (!(await S3UseCases.objectExists(bucket, key))) {
+  if (!(await S3UseCases.objectExists(user, bucket, key))) {
     sendNoSuchKey(res, key)
     return
   }
@@ -374,7 +364,7 @@ export const getObjectLegalHoldHandler = async (
   const user = await handleS3Auth(req, res)
   if (!user) return
   const { bucket, key } = parseBucketAndKey(req.params.key)
-  if (!(await S3UseCases.objectExists(bucket, key))) {
+  if (!(await S3UseCases.objectExists(user, bucket, key))) {
     sendNoSuchKey(res, key)
     return
   }
@@ -490,11 +480,6 @@ export const completeMultipartUploadHandler = async (
   })
 
   if (result.isErr()) {
-    // Cross-owner key guard → S3 XML AccessDenied (not JSON via handleError).
-    if (result.error instanceof ForbiddenError) {
-      sendAccessDenied(res, result.error.message)
-      return
-    }
     handleError(result.error, res)
     return
   }
@@ -535,7 +520,7 @@ export const listObjectsV2Handler = async (req: Request, res: Response) => {
     (req.query['continuation-token'] as string) ?? null
   const encodingType = (req.query['encoding-type'] as string) ?? null
 
-  const result = await S3UseCases.listObjects({
+  const result = await S3UseCases.listObjects(user, {
     bucket,
     prefix,
     delimiter,
@@ -622,11 +607,6 @@ export const putObjectHandler = async (req: Request, res: Response) => {
   })
 
   if (result.isErr()) {
-    // Cross-owner key guard → S3 XML AccessDenied (not JSON via handleError).
-    if (result.error instanceof ForbiddenError) {
-      sendAccessDenied(res, result.error.message)
-      return
-    }
     handleError(result.error, res)
     return
   }
@@ -692,12 +672,7 @@ export const copyObjectHandler = async (req: Request, res: Response) => {
   })
 
   if (result.isErr()) {
-    if (result.error instanceof ForbiddenError) {
-      // Destination key is owned by another user.
-      sendAccessDenied(res, result.error.message)
-      return
-    }
-    // Missing copy source → NoSuchKey, per S3.
+    // Source key not found in the caller's namespace → NoSuchKey, per S3.
     sendNoSuchKey(res, source.key)
     return
   }

--- a/apps/backend/src/core/objects/object.ts
+++ b/apps/backend/src/core/objects/object.ts
@@ -372,9 +372,9 @@ const restoreObject = async (
   // object back to its S3 name too (scoped to the executor so a dedup co-owner's
   // keys aren't touched; no-op when there are none).
   await s3ObjectMappingsRepository.restoreMappingsByCid(
-    cid,
     executor.oauthProvider,
     executor.oauthUserId,
+    cid,
     trashedAt,
   )
   logger.info('Object restored successfully (cid=%s)', cid)

--- a/apps/backend/src/core/s3/index.ts
+++ b/apps/backend/src/core/s3/index.ts
@@ -1,7 +1,4 @@
-import {
-  ownershipRepository,
-  s3ObjectMappingsRepository,
-} from '../../infrastructure/repositories/index.js'
+import { s3ObjectMappingsRepository } from '../../infrastructure/repositories/index.js'
 import { DownloadUseCase } from '../downloads/index.js'
 import { ObjectUseCases } from '../objects/object.js'
 import { err, ok, Result } from 'neverthrow'
@@ -93,11 +90,20 @@ import { S3BucketInfo } from '../../infrastructure/repositories/s3/objectMapping
 
 const logger = createLogger('useCases:s3')
 
+// The S3 key namespace is scoped per user: (owner, bucket, key) is the mapping
+// identity, so every read/write below is scoped to the requesting user. There is
+// no cross-user contention over a shared (bucket, key), hence no ownership gates,
+// guarded upserts, or pre-finalize checks — the scoped findByKey/createMapping IS
+// the boundary. The user's identity comes from handleS3Auth in the HTTP layer.
+
 const listObjects = async (
+  user: UserWithOrganization,
   params: ListObjectsParams,
 ): Promise<ListObjectsResult> => {
   const dbLimit = computeListObjectsDbLimit(params.maxKeys, params.delimiter)
   const allMatching = await s3ObjectMappingsRepository.listObjects(
+    user.oauthProvider,
+    user.oauthUserId,
     params.bucket,
     params.prefix,
     params.continuationToken,
@@ -122,9 +128,12 @@ type GetObjectUseCaseResult = GetObjectCommandResult & {
 }
 
 const getObject = async (
+  user: UserWithOrganization,
   params: GetObjectCommandParams,
 ): Promise<Result<GetObjectUseCaseResult, ObjectNotFoundError>> => {
   const mapping = await s3ObjectMappingsRepository.findByKey(
+    user.oauthProvider,
+    user.oauthUserId,
     params.Bucket,
     params.Key,
   )
@@ -202,46 +211,10 @@ const uploadPart = async (
   })
 }
 
-/**
- * True when the destination (bucket, key) already exists and is owned by a
- * DIFFERENT user. Checked BEFORE finalizing an upload so a cross-owner write is
- * rejected without finalizing the object or charging credits; the guarded
- * createMapping upsert remains the atomic backstop for the check-then-write
- * race. Uses getMappingOwner (not findByKey) so a soft-deleted key still counts
- * as owned by its user.
- */
-const destinationOwnedByAnother = async (
-  user: UserWithOrganization,
-  bucket: string,
-  key: string,
-): Promise<boolean> => {
-  const owner = await s3ObjectMappingsRepository.getMappingOwner(bucket, key)
-  return (
-    owner != null &&
-    owner.ownerOauthUserId != null &&
-    (owner.ownerOauthProvider !== user.oauthProvider ||
-      owner.ownerOauthUserId !== user.oauthUserId)
-  )
-}
-
 const completeMultipartUpload = async (
   user: UserWithOrganization,
   params: CompleteMultipartUploadParams,
-): Promise<
-  Result<CompleteMultipartUploadResult, ObjectNotFoundError | ForbiddenError>
-> => {
-  // Reject a cross-owner destination BEFORE finalizing: completeUpload applies
-  // ownership/credits (registerInteraction), so finalizing first and rejecting
-  // at createMapping would leave a finalized-but-unmapped object and let a retry
-  // re-finalize/re-charge.
-  if (await destinationOwnedByAnother(user, params.Bucket, params.Key)) {
-    return err(
-      new ForbiddenError(
-        `Key ${params.Bucket}/${params.Key} is owned by another user`,
-      ),
-    )
-  }
-
+): Promise<Result<CompleteMultipartUploadResult, ObjectNotFoundError>> => {
   const cid = await UploadsUseCases.completeUpload(user, params.UploadId)
 
   // Compute the composite multipart ETag from the per-part MD5s the client
@@ -264,23 +237,15 @@ const completeMultipartUpload = async (
   )
 
   const mapping = await s3ObjectMappingsRepository.createMapping(
+    user.oauthProvider,
+    user.oauthUserId,
     params.Bucket,
     params.Key,
     cid,
     md5ForStorage,
     mtime,
-    user.oauthProvider,
-    user.oauthUserId,
   )
   await s3ObjectMappingsRepository.deleteMultipartMtime(params.UploadId)
-  // null → the key is owned by another user; refuse to overwrite/steal it.
-  if (!mapping) {
-    return err(
-      new ForbiddenError(
-        `Key ${params.Bucket}/${params.Key} is owned by another user`,
-      ),
-    )
-  }
   logger.debug(
     'Created mapping: bucket=(%s) key=(%s) -> cid=(%s) etag=(%s)',
     mapping.bucket,
@@ -300,19 +265,8 @@ const completeMultipartUpload = async (
 const putObject = async (
   user: UserWithOrganization,
   params: PutObjectParams,
-): Promise<Result<PutObjectResult, ObjectNotFoundError | ForbiddenError>> => {
+): Promise<Result<PutObjectResult, ObjectNotFoundError>> => {
   const name = params.Key.split('/').pop()!
-
-  // Reject a cross-owner destination BEFORE creating/uploading anything, so a
-  // doomed write neither finalizes an object (ownership/credits) nor leaves a
-  // finalized-but-unmapped object; createMapping's guard is the atomic backstop.
-  if (await destinationOwnedByAnother(user, params.Bucket, params.Key)) {
-    return err(
-      new ForbiddenError(
-        `Key ${params.Bucket}/${params.Key} is owned by another user`,
-      ),
-    )
-  }
 
   // Compute MD5 before upload so we have it ready for storage.
   const md5 = md5Hex(params.Body)
@@ -337,22 +291,14 @@ const putObject = async (
   const cid = await UploadsUseCases.completeUpload(user, upload.id)
 
   const mapping = await s3ObjectMappingsRepository.createMapping(
+    user.oauthProvider,
+    user.oauthUserId,
     params.Bucket,
     params.Key,
     cid,
     md5,
     params.Mtime ?? null,
-    user.oauthProvider,
-    user.oauthUserId,
   )
-  // null → the key is owned by another user; refuse to overwrite/steal it.
-  if (!mapping) {
-    return err(
-      new ForbiddenError(
-        `Key ${params.Bucket}/${params.Key} is owned by another user`,
-      ),
-    )
-  }
   logger.debug(
     'Created mapping: bucket=(%s) key=(%s) -> cid=(%s) etag=(%s)',
     mapping.bucket,
@@ -365,62 +311,31 @@ const putObject = async (
 }
 
 /**
- * S3 DeleteObject — soft-delete the (bucket, key) mapping. The content is never
- * removed from the Autonomys DSN; only the S3 name is hidden. Always resolves to
- * success (S3 returns 204 whether or not the key existed).
+ * S3 DeleteObject — soft-delete the caller's (bucket, key) mapping. The content
+ * is never removed from the Autonomys DSN; only the S3 name is hidden. Always
+ * resolves to success (S3 returns 204 whether or not the key existed).
  *
- * Because a server-side copy/move only remaps `key -> same cid`, deletion is
- * tracked at the mapping level so that `move = copy + delete-source` keeps the
- * destination live. On top of that, when the deleted key was the LAST active S3
- * mapping for its content, the object is also moved to the owner's web-app Trash
- * (ObjectUseCases.markAsDeleted) so an rclone delete is reflected in the UI and
- * stays recoverable there — the "unified with UI Trash" behaviour.
+ * The lookup is scoped to the caller, so a key that isn't theirs simply isn't
+ * found (no cross-user authorization needed). When the deleted key was the
+ * caller's LAST active mapping for its content, the object is also moved to
+ * their web-app Trash (markAsDeleted) so an rclone delete is reflected in the UI
+ * and stays recoverable — the "unified with UI Trash" behaviour.
  */
 const deleteObject = async (
   user: UserWithOrganization,
   bucket: string,
   key: string,
 ): Promise<Result<void, never>> => {
-  const mapping = await s3ObjectMappingsRepository.findByKey(bucket, key)
+  const mapping = await s3ObjectMappingsRepository.findByKey(
+    user.oauthProvider,
+    user.oauthUserId,
+    bucket,
+    key,
+  )
 
-  // Key absent or already soft-deleted: nothing to do. DeleteObject is
-  // idempotent and returns success regardless (S3 returns 204 either way).
+  // Not the caller's key (absent or already soft-deleted): nothing to do.
+  // DeleteObject is idempotent and returns success regardless.
   if (!mapping) {
-    return ok()
-  }
-
-  // Authorization: only the KEY's owner may hide it. The S3 namespace is shared
-  // across API keys and, because storage is content-addressed, several users can
-  // be admin owners of the same CID (dedup of identical content) — so a per-CID
-  // check would let a dedup co-owner hide another user's key. Modern mappings
-  // record their creator (owner columns), so gate on that. A legacy mapping with
-  // no recorded owner falls back to the per-CID admin check (its historical
-  // behaviour). An unauthorized caller is a no-op (still 204, for idempotency).
-  const hasOwner =
-    mapping.ownerOauthProvider != null && mapping.ownerOauthUserId != null
-
-  let authorized: boolean
-  if (hasOwner) {
-    authorized =
-      mapping.ownerOauthProvider === user.oauthProvider &&
-      mapping.ownerOauthUserId === user.oauthUserId
-  } else {
-    const owners = await ownershipRepository.getOwnerships(mapping.cid)
-    authorized = owners.some(
-      (o) =>
-        o.is_admin &&
-        o.oauth_provider === user.oauthProvider &&
-        o.oauth_user_id === user.oauthUserId,
-    )
-  }
-  if (!authorized) {
-    logger.warn(
-      'Ignoring DeleteObject from non-owner (bucket=%s key=%s cid=%s user=%s)',
-      bucket,
-      key,
-      mapping.cid,
-      user.oauthUserId,
-    )
     return ok()
   }
 
@@ -437,18 +352,15 @@ const deleteObject = async (
     }
   }
 
-  // Count the caller's OWN active keys for this content — owner-scoped for a
-  // modern mapping so a dedup co-owner's keys don't affect the "last key" Trash
-  // decision; per-CID for a legacy mapping. Includes the still-active mapping
-  // being deleted, so <= 1 means this is the caller's last key for the content.
+  // Is this the caller's last active key for the content? The count is scoped to
+  // the caller, and includes the still-active mapping being deleted, so <= 1
+  // means it's their last one.
   const countActive = () =>
-    hasOwner
-      ? s3ObjectMappingsRepository.countActiveMappingsByCid(
-          mapping.cid,
-          user.oauthProvider,
-          user.oauthUserId,
-        )
-      : s3ObjectMappingsRepository.countActiveMappingsByCid(mapping.cid)
+    s3ObjectMappingsRepository.countActiveMappingsByCid(
+      user.oauthProvider,
+      user.oauthUserId,
+      mapping.cid,
+    )
 
   const activeBefore = await countActive()
   const isLastKey = activeBefore <= 1
@@ -460,16 +372,20 @@ const deleteObject = async (
     await trashObject()
   }
 
-  await s3ObjectMappingsRepository.softDeleteMapping(bucket, key)
+  await s3ObjectMappingsRepository.softDeleteMapping(
+    user.oauthProvider,
+    user.oauthUserId,
+    bucket,
+    key,
+  )
 
   if (!isLastKey) {
     // Race guard: between the count above and this hide, a concurrent
-    // DeleteObject may have removed the sibling last key. Re-check now that ours
-    // is hidden; if no active mapping remains, this delete is the one that
-    // emptied the content and must move it to Trash — otherwise two concurrent
-    // last-key deletes could both skip it and leave the object active in the UI
-    // with no visible S3 keys. (If both reach here, markAsDeleted is effectively
-    // idempotent: the second is a harmless no-op.)
+    // DeleteObject (same user, e.g. rclone --transfers) may have removed the
+    // sibling last key. Re-check now that ours is hidden; if none of the
+    // caller's keys remain, this delete emptied the content and must move it to
+    // Trash. (If two concurrent deletes both reach here, markAsDeleted is
+    // effectively idempotent: the second is a harmless no-op.)
     const activeAfter = await countActive()
     if (activeAfter === 0) {
       await trashObject()
@@ -481,11 +397,12 @@ const deleteObject = async (
 }
 
 /**
- * S3 CopyObject — copy source (bucket, key) to a destination key. In
- * content-addressed storage this is a cheap remap: the destination mapping
+ * S3 CopyObject — copy the caller's source (bucket, key) to a destination key.
+ * In content-addressed storage this is a cheap remap: the destination mapping
  * points at the source's cid, with no data transfer. This is what makes rclone
  * server-side copy and move work (rclone implements Move as Copy + Remove).
  *
+ * The source lookup is scoped to the caller, so you can only copy your own keys.
  * mtime: with the default COPY metadata directive the destination inherits the
  * source mtime; when the client sends an x-amz-meta-mtime (metadata REPLACE, as
  * rclone's SetModTime does by copying an object onto itself) that value wins.
@@ -493,8 +410,10 @@ const deleteObject = async (
 const copyObject = async (
   user: UserWithOrganization,
   params: CopyObjectParams,
-): Promise<Result<CopyObjectResult, ObjectNotFoundError | ForbiddenError>> => {
+): Promise<Result<CopyObjectResult, ObjectNotFoundError>> => {
   const source = await s3ObjectMappingsRepository.findByKey(
+    user.oauthProvider,
+    user.oauthUserId,
     params.SourceBucket,
     params.SourceKey,
   )
@@ -506,50 +425,9 @@ const copyObject = async (
     )
   }
 
-  // Ownership gate on the SOURCE KEY, mirroring deleteObject: only the source
-  // mapping's owner may copy from it. Gating on the source's per-mapping owner
-  // (not merely CID ownership) keeps copy consistent with delete — with
-  // content-addressed dedup a co-owner of the CID must not be able to use
-  // another user's (bucket, key) as a copy source. A legacy source mapping with
-  // no recorded owner falls back to the per-CID admin check. A copy grants NO
-  // new ownership: the caller already owns the source content, so the
-  // destination (created below, owned by the caller) is theirs without a
-  // re-grant. Don't reveal the source's existence to a non-owner.
-  const sourceHasOwner =
-    source.ownerOauthProvider != null && source.ownerOauthUserId != null
-
-  let authorizedSource: boolean
-  if (sourceHasOwner) {
-    authorizedSource =
-      source.ownerOauthProvider === user.oauthProvider &&
-      source.ownerOauthUserId === user.oauthUserId
-  } else {
-    const owners = await ownershipRepository.getOwnerships(source.cid)
-    authorizedSource = owners.some(
-      (o) =>
-        o.is_admin &&
-        o.oauth_provider === user.oauthProvider &&
-        o.oauth_user_id === user.oauthUserId,
-    )
-  }
-  if (!authorizedSource) {
-    logger.warn(
-      'Ignoring CopyObject from non-owner of source (src=%s/%s cid=%s user=%s)',
-      params.SourceBucket,
-      params.SourceKey,
-      source.cid,
-      user.oauthUserId,
-    )
-    return err(
-      new ObjectNotFoundError(
-        `Object ${params.SourceBucket}/${params.SourceKey} not found`,
-      ),
-    )
-  }
-
-  // Even for the owner, don't copy a source that isn't actually readable (banned
-  // or otherwise blocked) into a new key that would then 404/451 on read. Treat
-  // as NoSuchKey.
+  // Don't copy a source that isn't actually readable (owner-removed via the web
+  // app, banned, or otherwise blocked) into a new key that would then 404/451 on
+  // read. Treat as NoSuchKey.
   const authorized = await ObjectUseCases.authorizeDownload(source.cid)
   if (authorized.isErr()) {
     return err(
@@ -561,24 +439,16 @@ const copyObject = async (
 
   const mtime = params.Mtime !== undefined ? params.Mtime : source.mtime
 
-  // The destination key is created (owned) by the copier.
+  // The destination key is created in the caller's namespace.
   const mapping = await s3ObjectMappingsRepository.createMapping(
+    user.oauthProvider,
+    user.oauthUserId,
     params.Bucket,
     params.Key,
     source.cid,
     source.md5,
     mtime,
-    user.oauthProvider,
-    user.oauthUserId,
   )
-  // null → the destination key is owned by another user; refuse to overwrite it.
-  if (!mapping) {
-    return err(
-      new ForbiddenError(
-        `Key ${params.Bucket}/${params.Key} is owned by another user`,
-      ),
-    )
-  }
 
   logger.debug(
     'Copied S3 mapping: %s/%s -> %s/%s (cid=%s)',
@@ -610,21 +480,34 @@ const abortMultipartUpload = async (
   return result
 }
 
-const listBuckets = async (): Promise<S3BucketInfo[]> => {
-  return s3ObjectMappingsRepository.listBuckets()
+const listBuckets = async (
+  user: UserWithOrganization,
+): Promise<S3BucketInfo[]> => {
+  return s3ObjectMappingsRepository.listBuckets(
+    user.oauthProvider,
+    user.oauthUserId,
+  )
 }
 
-const objectExists = async (bucket: string, key: string): Promise<boolean> => {
-  const mapping = await s3ObjectMappingsRepository.findByKey(bucket, key)
+const objectExists = async (
+  user: UserWithOrganization,
+  bucket: string,
+  key: string,
+): Promise<boolean> => {
+  const mapping = await s3ObjectMappingsRepository.findByKey(
+    user.oauthProvider,
+    user.oauthUserId,
+    bucket,
+    key,
+  )
   if (!mapping) {
     return false
   }
 
-  // The mapping row persists after an owner removes an object (moved to Trash),
-  // but GET and ListObjects treat such objects as not found via isObjectDeleted
-  // / notRemovedByOwnerSQL. Mirror that here so object-lock endpoints
-  // (GetObjectRetention / GetObjectLegalHold) don't leak retention or
-  // legal-hold metadata for keys that are otherwise reported as not found.
+  // A mapping the owner has since removed via the web app (moved to Trash) is
+  // treated as not found by GET and ListObjects (notRemovedByOwnerSQL /
+  // isObjectDeleted). Mirror that here so the object-lock endpoints
+  // (GetObjectRetention / GetObjectLegalHold) don't report on a hidden key.
   return !(await ObjectUseCases.isObjectDeleted(mapping.cid))
 }
 

--- a/apps/backend/src/infrastructure/repositories/s3/objectMappings.ts
+++ b/apps/backend/src/infrastructure/repositories/s3/objectMappings.ts
@@ -17,13 +17,12 @@ export interface S3KeyMapping {
    */
   mtime: string | null
   /**
-   * The user who created (last wrote) this key mapping — the only principal
-   * allowed to soft-delete it. null for legacy rows created before the owner
-   * column existed and for rows the backfill left ambiguous (a CID with several
-   * admin owners); those fall back to the per-CID admin check.
+   * The user who owns this key. Part of the mapping's identity: the S3 namespace
+   * is scoped per user — (owner, bucket, key) is unique — so users never contend
+   * over a shared (bucket, key) and every read/write is scoped to the caller.
    */
-  ownerOauthProvider: string | null
-  ownerOauthUserId: string | null
+  ownerOauthProvider: string
+  ownerOauthUserId: string
   createdAt: Date
   updatedAt: Date
 }
@@ -56,71 +55,62 @@ const mapDBToDomain = (db: S3KeyMappingDB): S3KeyMapping => ({
   cid: db.cid,
   md5: db.md5 ?? null,
   mtime: db.mtime ?? null,
-  ownerOauthProvider: db.owner_oauth_provider ?? null,
-  ownerOauthUserId: db.owner_oauth_user_id ?? null,
+  ownerOauthProvider: db.owner_oauth_provider,
+  ownerOauthUserId: db.owner_oauth_user_id,
   createdAt: db.created_at,
   updatedAt: db.updated_at,
 })
 
 const createMapping = async (
+  ownerOauthProvider: string,
+  ownerOauthUserId: string,
   bucket: string,
   s3Key: string,
   cid: string,
   md5: string | null = null,
   mtime: string | null = null,
-  ownerOauthProvider: string | null = null,
-  ownerOauthUserId: string | null = null,
-): Promise<S3KeyMapping | null> => {
+): Promise<S3KeyMapping> => {
   const db = await getDatabase()
 
-  // ON CONFLICT resets deleted_at to NULL so a PutObject to a previously
-  // soft-deleted key resurrects it — matching S3's "PUT after DELETE re-creates
-  // the object" semantics (and TestObjectUpdate, which overwrites in place).
-  //
-  // The DO UPDATE is GUARDED: because (bucket, key) is a global namespace shared
-  // across API keys, an unguarded upsert would let any writer overwrite — and
-  // take ownership of — another user's key. The WHERE only permits the update
-  // when the existing row is unowned (legacy) or already owned by the writer;
-  // the owner is then preserved (or claimed if it was NULL), never reassigned to
-  // a different user. A conflict on a key owned by SOMEONE ELSE updates nothing
-  // and RETURNING yields no row (→ null), so the caller can reject the write.
+  // Plain upsert keyed on (owner, bucket, key): a user can only ever hit their
+  // OWN row, so there is no cross-user contention to guard against. ON CONFLICT
+  // resets deleted_at to NULL so a PutObject to a previously soft-deleted key
+  // resurrects it — S3's "PUT after DELETE re-creates the object" (and
+  // TestObjectUpdate, which overwrites in place).
   const result = await db.query<S3KeyMappingDB>({
     text: `
       INSERT INTO "S3".object_mappings
-      (bucket, "key", cid, md5, mtime, owner_oauth_provider, owner_oauth_user_id)
+      (owner_oauth_provider, owner_oauth_user_id, bucket, "key", cid, md5, mtime)
       VALUES ($1, $2, $3, $4, $5, $6, $7)
-      ON CONFLICT (bucket, "key") DO UPDATE
-        SET cid = $3, md5 = $4, mtime = $5, deleted_at = NULL, updated_at = NOW(),
-            owner_oauth_provider = COALESCE(object_mappings.owner_oauth_provider, $6),
-            owner_oauth_user_id = COALESCE(object_mappings.owner_oauth_user_id, $7)
-        WHERE object_mappings.owner_oauth_user_id IS NULL
-           OR (object_mappings.owner_oauth_provider = $6
-               AND object_mappings.owner_oauth_user_id = $7)
+      ON CONFLICT (owner_oauth_provider, owner_oauth_user_id, bucket, "key")
+        DO UPDATE SET cid = $5, md5 = $6, mtime = $7,
+          deleted_at = NULL, updated_at = NOW()
       RETURNING *
     `,
-    values: [bucket, s3Key, cid, md5, mtime, ownerOauthProvider, ownerOauthUserId],
+    values: [ownerOauthProvider, ownerOauthUserId, bucket, s3Key, cid, md5, mtime],
   })
 
-  // null → the key exists and is owned by a different user (guarded update was a
-  // no-op); the caller must reject the write rather than steal the key.
-  return result.rows.map(mapDBToDomain)[0] ?? null
+  return result.rows.map(mapDBToDomain)[0]
 }
 
 const findByKey = async (
+  ownerOauthProvider: string,
+  ownerOauthUserId: string,
   bucket: string,
   s3Key: string,
 ): Promise<S3KeyMapping | null> => {
   const db = await getDatabase()
 
-  // Soft-deleted mappings read as "not found": GET / HEAD / CopyObject source
-  // lookups and objectExists all go through findByKey, so a deleted key returns
-  // 404 / NoSuchKey everywhere without a per-caller filter.
+  // Scoped to the caller's own namespace. Soft-deleted mappings read as "not
+  // found": GET / HEAD / CopyObject source lookups and objectExists all go
+  // through findByKey, so a deleted key returns 404 / NoSuchKey everywhere.
   const result = await db.query<S3KeyMappingDB>({
     text: `
       SELECT * FROM "S3".object_mappings
-      WHERE bucket = $1 AND "key" = $2 AND deleted_at IS NULL
+      WHERE owner_oauth_provider = $1 AND owner_oauth_user_id = $2
+        AND bucket = $3 AND "key" = $4 AND deleted_at IS NULL
     `,
-    values: [bucket, s3Key],
+    values: [ownerOauthProvider, ownerOauthUserId, bucket, s3Key],
   })
 
   if (result.rows.length === 0) {
@@ -131,49 +121,16 @@ const findByKey = async (
 }
 
 /**
- * Read just the recorded owner of a (bucket, key), regardless of soft-delete
- * state (unlike findByKey, which hides deleted rows). Used to reject a write to
- * another user's key BEFORE finalizing the upload — a soft-deleted key still
- * belongs to its owner and must not be claimed. Returns null when no row exists.
- */
-const getMappingOwner = async (
-  bucket: string,
-  s3Key: string,
-): Promise<{
-  ownerOauthProvider: string | null
-  ownerOauthUserId: string | null
-} | null> => {
-  const db = await getDatabase()
-
-  const result = await db.query<{
-    owner_oauth_provider: string | null
-    owner_oauth_user_id: string | null
-  }>({
-    text: `
-      SELECT owner_oauth_provider, owner_oauth_user_id
-      FROM "S3".object_mappings
-      WHERE bucket = $1 AND "key" = $2
-    `,
-    values: [bucket, s3Key],
-  })
-
-  const row = result.rows[0]
-  if (!row) return null
-  return {
-    ownerOauthProvider: row.owner_oauth_provider ?? null,
-    ownerOauthUserId: row.owner_oauth_user_id ?? null,
-  }
-}
-
-/**
- * Soft-delete a single (bucket, key) mapping (S3 DeleteObject). Sets deleted_at
- * so the key is hidden from every read path; the underlying content is never
- * removed from the DSN. Idempotent: deleting an already-deleted or non-existent
- * key is a no-op (S3 DeleteObject succeeds regardless). Returns the cid of the
- * row it just soft-deleted, or null if there was no active row — the caller uses
- * this to decide whether to also move the underlying object to the UI Trash.
+ * Soft-delete a single (owner, bucket, key) mapping (S3 DeleteObject). Sets
+ * deleted_at so the key is hidden from every read path; the underlying content
+ * is never removed from the DSN. Idempotent: deleting an already-deleted or
+ * non-existent key is a no-op (S3 DeleteObject succeeds regardless). Returns the
+ * cid of the row it just soft-deleted, or null if there was no active row — the
+ * caller uses this to decide whether to also move the object to the UI Trash.
  */
 const softDeleteMapping = async (
+  ownerOauthProvider: string,
+  ownerOauthUserId: string,
   bucket: string,
   s3Key: string,
 ): Promise<{ cid: string } | null> => {
@@ -183,25 +140,21 @@ const softDeleteMapping = async (
     text: `
       UPDATE "S3".object_mappings
       SET deleted_at = NOW(), updated_at = NOW()
-      WHERE bucket = $1 AND "key" = $2 AND deleted_at IS NULL
+      WHERE owner_oauth_provider = $1 AND owner_oauth_user_id = $2
+        AND bucket = $3 AND "key" = $4 AND deleted_at IS NULL
       RETURNING cid
     `,
-    values: [bucket, s3Key],
+    values: [ownerOauthProvider, ownerOauthUserId, bucket, s3Key],
   })
 
   return result.rows[0] ?? null
 }
 
 /**
- * Clear the soft-delete flag on mappings pointing at a cid. Called when the
- * underlying object is restored from the web-app Trash so that S3 keys hidden by
- * a DeleteObject reappear too — the reverse of deleteObject's propagation to the
- * Trash, keeping the S3 namespace and the UI in sync ("unified with UI Trash").
- *
- * Scoped to the restorer's OWN keys (owner columns): with dedup a different
- * user may hold keys to the same cid, and restoring this owner's object must
- * not un-hide theirs. Legacy keys with no recorded owner are not matched here
- * (they can be brought back by re-uploading to the key).
+ * Clear the soft-delete flag on the caller's mappings pointing at a cid. Called
+ * when the underlying object is restored from the web-app Trash so that S3 keys
+ * hidden by a DeleteObject reappear too — the reverse of deleteObject's
+ * propagation to the Trash, keeping the S3 namespace and the UI in sync.
  *
  * When `since` is given, only keys soft-deleted at/after that instant are
  * restored. deleteObject stamps the object's Trash time (ownership) BEFORE it
@@ -210,9 +163,9 @@ const softDeleteMapping = async (
  * brings back what this trash removed, not every alias that ever pointed here.
  */
 const restoreMappingsByCid = async (
-  cid: string,
   ownerOauthProvider: string,
   ownerOauthUserId: string,
+  cid: string,
   since: Date | null = null,
 ): Promise<void> => {
   const db = await getDatabase()
@@ -220,82 +173,71 @@ const restoreMappingsByCid = async (
   const base = `
     UPDATE "S3".object_mappings
     SET deleted_at = NULL, updated_at = NOW()
-    WHERE cid = $1 AND deleted_at IS NOT NULL
-      AND owner_oauth_provider = $2 AND owner_oauth_user_id = $3
+    WHERE owner_oauth_provider = $1 AND owner_oauth_user_id = $2
+      AND cid = $3 AND deleted_at IS NOT NULL
   `
 
   if (since) {
     await db.query({
       text: base + ' AND deleted_at >= $4',
-      values: [cid, ownerOauthProvider, ownerOauthUserId, since],
+      values: [ownerOauthProvider, ownerOauthUserId, cid, since],
     })
     return
   }
 
   await db.query({
     text: base,
-    values: [cid, ownerOauthProvider, ownerOauthUserId],
+    values: [ownerOauthProvider, ownerOauthUserId, cid],
   })
 }
 
 /**
- * Count active (non-soft-deleted) mappings pointing at a cid. Used after a
- * DeleteObject to decide whether any S3 key still references the content before
- * propagating the removal to the web-app Trash.
- *
- * When an owner is given, only that owner's active keys are counted — with
- * content-addressed dedup a different user may hold keys to the same cid, and
- * their keys must not affect this owner's "last key → move to my Trash"
- * decision. Called without an owner (legacy mappings with no recorded owner) it
- * counts all active keys for the cid.
+ * Count the caller's active (non-soft-deleted) mappings pointing at a cid. Used
+ * after a DeleteObject to decide whether any of the owner's S3 keys still
+ * references the content before moving the object to their Trash. Scoped to the
+ * owner: with content-addressed dedup another user may hold keys to the same
+ * cid, and their keys must not affect this owner's "last key" decision.
  */
 const countActiveMappingsByCid = async (
+  ownerOauthProvider: string,
+  ownerOauthUserId: string,
   cid: string,
-  ownerOauthProvider: string | null = null,
-  ownerOauthUserId: string | null = null,
 ): Promise<number> => {
   const db = await getDatabase()
 
-  const scoped = ownerOauthProvider != null && ownerOauthUserId != null
-  const result = await db.query<{ count: string }>(
-    scoped
-      ? {
-          text: `
-            SELECT COUNT(*)::text AS count
-            FROM "S3".object_mappings
-            WHERE cid = $1 AND deleted_at IS NULL
-              AND owner_oauth_provider = $2 AND owner_oauth_user_id = $3
-          `,
-          values: [cid, ownerOauthProvider, ownerOauthUserId],
-        }
-      : {
-          text: `
-            SELECT COUNT(*)::text AS count
-            FROM "S3".object_mappings
-            WHERE cid = $1 AND deleted_at IS NULL
-          `,
-          values: [cid],
-        },
-  )
+  const result = await db.query<{ count: string }>({
+    text: `
+      SELECT COUNT(*)::text AS count
+      FROM "S3".object_mappings
+      WHERE owner_oauth_provider = $1 AND owner_oauth_user_id = $2
+        AND cid = $3 AND deleted_at IS NULL
+    `,
+    values: [ownerOauthProvider, ownerOauthUserId, cid],
+  })
 
   return Number(result.rows[0]?.count ?? 0)
 }
 
-const listBuckets = async (): Promise<S3BucketInfo[]> => {
+const listBuckets = async (
+  ownerOauthProvider: string,
+  ownerOauthUserId: string,
+): Promise<S3BucketInfo[]> => {
   const db = await getDatabase()
 
-  // Only surface buckets that still have at least one visible object, mirroring
-  // the ListObjectsV2 visibility rules: exclude soft-deleted mappings and
-  // objects the owner has removed. A fully-purged bucket disappears.
+  // The caller's buckets only, and only those with at least one visible object
+  // (mirroring ListObjectsV2: exclude soft-deleted mappings and objects the
+  // owner removed via the web app). A fully-purged bucket disappears.
   const result = await db.query<S3BucketInfoDB>({
     text: `
       SELECT om.bucket AS bucket, MIN(om.created_at) AS created_at
       FROM "S3".object_mappings om
-      WHERE om.deleted_at IS NULL
+      WHERE om.owner_oauth_provider = $1 AND om.owner_oauth_user_id = $2
+        AND om.deleted_at IS NULL
         AND ${ownershipSQL.notRemovedByOwnerSQL('om.cid')}
       GROUP BY om.bucket
       ORDER BY om.bucket
     `,
+    values: [ownerOauthProvider, ownerOauthUserId],
   })
 
   return result.rows.map((row) => ({
@@ -307,7 +249,8 @@ const listBuckets = async (): Promise<S3BucketInfo[]> => {
 // ── Multipart upload mtime staging ────────────────────────────────────────
 // rclone sends x-amz-meta-mtime on CreateMultipartUpload but not on Complete,
 // and the mapping is only created at completion — so the mtime is stashed by
-// upload id here and read back in completeMultipartUpload.
+// upload id here and read back in completeMultipartUpload. Keyed by the (unique)
+// upload id, so no owner scoping is needed.
 
 const setMultipartMtime = async (
   uploadId: string,
@@ -344,6 +287,8 @@ const deleteMultipartMtime = async (uploadId: string): Promise<void> => {
 }
 
 const listObjects = async (
+  ownerOauthProvider: string,
+  ownerOauthUserId: string,
   bucket: string,
   prefix: string,
   continuationToken: string | null,
@@ -351,15 +296,11 @@ const listObjects = async (
 ): Promise<S3ObjectListing[]> => {
   const db = await getDatabase()
 
-  // LATERAL subquery picks at most one metadata row per object mapping.
-  // A plain LEFT JOIN on head_cid would fan out when the same CID appears
-  // as head_cid in multiple metadata rows (different root_cid values), which
-  // can happen when the same content is referenced by more than one root upload.
-  // Hide objects whose owner has removed them (moved to Trash), mirroring
-  // ObjectUseCases.isObjectDeleted: removal is tracked on the root upload's
-  // ownership row, so the mapping's cid is resolved to its root before the
-  // admin-ownership check. This keeps a removed folder's child objects hidden
-  // even though they keep vestigial active admin rows from upload finalization.
+  // Scoped to the caller's namespace. LATERAL subquery picks at most one
+  // metadata row per object mapping. A plain LEFT JOIN on head_cid would fan out
+  // when the same CID appears as head_cid in multiple metadata rows (different
+  // root_cid values). notRemovedByOwnerSQL also hides objects the owner removed
+  // via the web app (Trash), keeping the S3 listing consistent with the UI.
   const baseSQL = `
     SELECT
       om.key,
@@ -374,8 +315,10 @@ const listObjects = async (
       WHERE head_cid = om.cid
       LIMIT 1
     ) m ON true
-    WHERE om.bucket = $1
-      AND om.key LIKE $2
+    WHERE om.owner_oauth_provider = $1
+      AND om.owner_oauth_user_id = $2
+      AND om.bucket = $3
+      AND om.key LIKE $4
       AND om.deleted_at IS NULL
       AND ${ownershipSQL.notRemovedByOwnerSQL('om.cid')}
   `
@@ -391,11 +334,24 @@ const listObjects = async (
   let text: string
   let values: unknown[]
   if (continuationToken) {
-    text = baseSQL + ' AND om.key > $3 ORDER BY om.key LIMIT $4'
-    values = [bucket, `${escapedPrefix}%`, continuationToken, limit]
+    text = baseSQL + ' AND om.key > $5 ORDER BY om.key LIMIT $6'
+    values = [
+      ownerOauthProvider,
+      ownerOauthUserId,
+      bucket,
+      `${escapedPrefix}%`,
+      continuationToken,
+      limit,
+    ]
   } else {
-    text = baseSQL + ' ORDER BY om.key LIMIT $3'
-    values = [bucket, `${escapedPrefix}%`, limit]
+    text = baseSQL + ' ORDER BY om.key LIMIT $5'
+    values = [
+      ownerOauthProvider,
+      ownerOauthUserId,
+      bucket,
+      `${escapedPrefix}%`,
+      limit,
+    ]
   }
 
   const result = await db.query<{
@@ -418,7 +374,6 @@ const listObjects = async (
 export const s3ObjectMappingsRepository = {
   createMapping,
   findByKey,
-  getMappingOwner,
   softDeleteMapping,
   restoreMappingsByCid,
   countActiveMappingsByCid,


### PR DESCRIPTION
Stacked on #778 (base branch `feat/s3-soft-delete-rclone`).

This implements the **per-user S3 namespace** proposed by @jim-counter in their review of #778 — the diagnosis and the design are theirs, not mine. Issue #781, which they opened, sequences this same owner-scoped mapping migration alongside the WORM/versioning work; this PR delivers the namespace half of it (with a couple of safety tweaks to the migration SQL, called out below).

## The diagnosis (credit: @jim-counter)

Reviewing #778, @jim-counter pointed out that nearly every hard problem in it — the dedup co-owner gates on delete/copy, the guarded upsert + null-return protocol, `destinationOwnedByAnother`, the cross-owner `AccessDenied` paths, the finalize-before-guard reorder — existed only to referee contention over a single global `(bucket, key)` namespace shared by every user. All of them are symptoms of one root cause: the namespace had no owner dimension while everything layered on top of it did.

## The proposal

Make the mapping identity **`(owner, bucket, key)`** — real S3's model, where bucket namespaces live inside an account. Contention becomes impossible, the guard machinery deletes itself, and the first-writer-wins squatting UX (a second user PUTting `default/test.txt` gets 403; soft-delete never releases the name) disappears. This PR implements exactly that — **net ~480 fewer lines** (+579 / −1061).

## Behaviour

- Two users can each own `default/test.txt` independently — no squatting, no 403-on-collision.
- Every S3 read/write is scoped to the caller (`GET`/`HEAD`/`ListObjectsV2`/`ListBuckets` too, so a user only sees their own keys). **Public sharing by CID (download API) is unaffected.**

## Removed (unreachable once per-user)

Guarded `ON CONFLICT` upsert + null protocol → plain owner-scoped upsert; `destinationOwnedByAnother` + both pre-finalize checks; the owner-vs-CID gate branching in `deleteObject`/`copyObject` (scoped `findByKey` is the boundary); `getMappingOwner`; the dual scoped/unscoped `countActiveMappingsByCid`; the `ForbiddenError → AccessDenied` branches for put/complete/copy. `AbortMultipartUpload` keeps its cross-user 403 (uploads aren't namespaced by key).

## Migration

Swaps the PK to `(owner_oauth_provider, owner_oauth_user_id, bucket, key)`. Remaining NULL-owner legacy rows (multi-admin dedup) are **duplicated** to every admin owner — losing a user's key is worse than surprise clutter they can soft-delete.

Three hardening changes over the SQL sketched in the proposal:
1. **Drop the old PK *before* the duplication INSERT** — inserting duplicate `(bucket, key)` rows while that PK is still enforced would fail.
2. **Fail loud** (`RAISE EXCEPTION`) on NULL-owner rows whose CID has no admin owner, instead of silently dropping them in the `DELETE`.
3. **A reversible `down`** — the forward migration deliberately allows multiple owners per `(bucket, key)`, so the rollback first collapses duplicates (keeping the most-recently-updated row) before restoring the `(bucket, key)` PK, and uses `DROP CONSTRAINT IF EXISTS` for idempotency. Lossy but deterministic, so a rollback — and the test suite's per-suite `down`/`up` reset — never errors on the very data the forward migration was built to allow.

Expected NULL-owner count in production is ~0 (single-admin CIDs were backfilled in #778); a pre-flight `COUNT(*)` confirms whether the legacy path is even exercised.

## Tests

- Unit suite rewritten around the scoped use cases (the cross-owner guard tests are gone; scoping is asserted via the owner args passed to the repo) — **34 passing, Docker-free**.
- Integration test gains a **two-users-same-key isolation** case (each sees their own content; one user's delete doesn't touch the other's identically-named key).
- e2e helpers and call sites updated to the owner-scoped signatures.
- Build, lint, and the full test-inclusive typecheck are clean.

## Verification caveat

The migration (PK swap + row duplication) and the integration/e2e suites need a **staging/CI run against real data + Docker** — testcontainers can't run in my environment. Please run the backend integration/e2e suite and the pre-flight NULL-owner `COUNT(*)` before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
