### PR TITLE
fix(s3): DeleteObject of a bare name is soft-delete (204), not 403

### DIFF
--- a/apps/backend/__tests__/integration/s3-sdk/index.spec.ts
+++ b/apps/backend/__tests__/integration/s3-sdk/index.spec.ts
@@ -574,9 +574,20 @@ describe('AWS S3 - SDK', () => {
       expect(head.headers.get('etag')).toMatch(MD5_ETAG_RE)
     }, 15_000)
 
-    it('DELETE of a bare, slash-less name is DeleteObject (403 immutable), not DeleteBucket', async () => {
-      const res = await raw('DELETE', '/looks-like-a-bucket')
-      expect(res.status).toBe(403)
+    it('DELETE of a bare, slash-less name is DeleteObject (soft-delete, 204), not DeleteBucket', async () => {
+      // Seed a bare object, then DELETE the same bare path. DeleteObject
+      // soft-deletes it and answers 204 (idempotent), after which a GET 404s —
+      // proof the object, not a bucket, was the target. A DeleteBucket would
+      // instead 404 (NoSuchBucket) on this never-created bucket and leave the
+      // object reachable, so a future "no-slash = bucket op" rule would break
+      // these assertions.
+      const body = Buffer.from('bare-delete-target')
+      expect((await raw('PUT', '/bare-delete-target', body)).status).toBe(200)
+
+      const del = await raw('DELETE', '/bare-delete-target')
+      expect(del.status).toBe(204)
+
+      expect((await raw('GET', '/bare-delete-target')).status).toBe(404)
     }, 15_000)
   })
 

--- a/apps/backend/src/app/controllers/s3/http.ts
+++ b/apps/backend/src/app/controllers/s3/http.ts
@@ -43,7 +43,7 @@ type S3HandlerConfig = {
 // on the first object write. A bare
 // PUT/DELETE/HEAD is therefore dispatched below as an ordinary object op:
 //   PUT  → PutObject       HEAD → HeadObject
-//   DELETE → DeleteObject (403, storage is immutable)
+//   DELETE → DeleteObject (204; soft-delete — the S3 namespace is mutable)
 // There is deliberately no CreateBucket / DeleteBucket / HeadBucket entry.
 const S3HandlerConfig: S3HandlerConfig = {
   GetObject: getObjectHandler,


### PR DESCRIPTION
## Why main's CI is red

The [Services CI on `main`](https://github.com/autonomys/auto-drive/actions/runs/29274134776/job/86901573171) fails on a single test:

```
FAIL __tests__/integration/s3-sdk/index.spec.ts
  ● Bucket-level ops fold into default-bucket object ops
    › DELETE of a bare, slash-less name is DeleteObject (403 immutable), not DeleteBucket
    Expected: 403
    Received: 204
```

This is a **semantic merge conflict** between two S3 PRs that were green independently and only clash once both are on `main`:

- **#779 (`docs/s3-no-bucket-endpoints`)** added a decision-lock test asserting a bare, slash-less `DELETE /{name}` returns **403** — encoding the then-true fact that the store was immutable, and that such a path is routed as `DeleteObject`, **not** `DeleteBucket`.
- **#778 (`feat/s3-soft-delete-rclone`)**, merged last, made `DeleteObject` a mutable **soft-delete** that returns **204** (idempotent) — see `deleteObjectHandler` in `apps/backend/src/app/controllers/s3/s3.ts` and the "the S3 namespace is mutable" note at s3.ts:314.

So the assertion (`403 immutable`) went stale the moment soft-delete landed. `204` is the correct, intended behavior — it's already the pattern the passing `DeleteObject` tests use (DELETE → 204, then GET → 404, at index.spec.ts:773-805).

## The fix

- **Test** — rewrite the assertion to prove the *same* decision under the new semantics, mirroring the sibling `HEAD` test's self-contained style: seed a bare object, `DELETE` it (expect **204**), then confirm a follow-up `GET` **404**s. That proves the object — not a bucket — was the target (a `DeleteBucket` would `404 NoSuchBucket` on the never-created bucket and leave the object reachable).
- **Comment** — fix a stale inline comment in `apps/backend/src/app/controllers/s3/http.ts` that still described `DELETE → DeleteObject (403, storage is immutable)`, which already contradicted the "supports soft-delete/rename" note a few lines below it.

No production code paths change — this only realigns a stale test and comment with the shipped soft-delete behavior.


🤖 Generated with [Claude Code](https://claude.com/claude-code)