### PR TITLE
feat(s3): faithfully round-trip object metadata (#786)

### DIFF
--- a/apps/backend/__tests__/integration/s3-sdk/index.spec.ts
+++ b/apps/backend/__tests__/integration/s3-sdk/index.spec.ts
@@ -1,4 +1,4 @@
-import { gzipSync } from 'zlib'
+import { gzipSync, gunzipSync } from 'zlib'
 import { dbMigration } from '../../utils/dbMigrate.js'
 import {
   AbortMultipartUploadCommand,
@@ -1163,24 +1163,59 @@ describe('AWS S3 - SDK', () => {
       expect(head.Metadata?.project).toBe('auto-drive')
     })
 
-    it('round-trips Content-Encoding for a non-internally-compressed object', async () => {
+    it('stores the body verbatim under a client Content-Encoding and returns both unchanged', async () => {
       const Key = 'metadata-test/encoding.txt'
-      // A client declaring Content-Encoding: gzip sends actually-gzipped bytes
-      // (the raw body-parser inflates per Content-Encoding, so an unencoded body
-      // with this header would be rejected as malformed — correct HTTP). The
-      // encoding is stored as metadata and returned verbatim; Auto Drive is not
-      // internally compressing this object, so it owns Content-Encoding.
+      // S3 stores object bytes byte-for-byte and treats Content-Encoding as
+      // opaque metadata — it never inflates the stored body. A client uploading
+      // gzipped bytes with Content-Encoding: gzip must therefore read those exact
+      // gzipped bytes back (NOT a server-inflated body), still labelled gzip.
+      // Auto Drive is not internally compressing this object, so it owns
+      // Content-Encoding on the response.
+      const gz = gzipSync(Buffer.from('encoded payload'))
       await s3Client.send(
         new PutObjectCommand({
           Bucket,
           Key,
-          Body: gzipSync(Buffer.from('encoded')),
+          Body: gz,
           ContentEncoding: 'gzip',
         }),
       )
 
       const head = await s3Client.send(new HeadObjectCommand({ Bucket, Key }))
       expect(head.ContentEncoding).toBe('gzip')
+
+      const get = await s3Client.send(new GetObjectCommand({ Bucket, Key }))
+      expect(get.ContentEncoding).toBe('gzip')
+      const body = Buffer.from(await get.Body!.transformToByteArray())
+      // The stored bytes are the gzipped bytes, verbatim — not server-inflated —
+      // so they still match the advertised Content-Encoding and gunzip cleanly.
+      expect(body.equals(gz)).toBe(true)
+      expect(gunzipSync(body).toString()).toBe('encoded payload')
+    })
+
+    it('round-trips an arbitrary (non-inflatable) Content-Encoding without rejecting it', async () => {
+      const Key = 'metadata-test/encoding-opaque.bin'
+      // Encodings the body parser cannot inflate (br, zstd, …) must not be
+      // rejected with 415: S3 treats Content-Encoding opaquely. These bytes are
+      // deliberately not valid brotli — the server stores and returns them
+      // verbatim regardless.
+      const bytes = Buffer.from([0x00, 0x01, 0x02, 0xfe, 0xff])
+      await s3Client.send(
+        new PutObjectCommand({
+          Bucket,
+          Key,
+          Body: bytes,
+          ContentEncoding: 'br',
+        }),
+      )
+
+      const head = await s3Client.send(new HeadObjectCommand({ Bucket, Key }))
+      expect(head.ContentEncoding).toBe('br')
+
+      const get = await s3Client.send(new GetObjectCommand({ Bucket, Key }))
+      expect(get.ContentEncoding).toBe('br')
+      const body = Buffer.from(await get.Body!.transformToByteArray())
+      expect(body.equals(bytes)).toBe(true)
     })
 
     it('carries metadata through a plain (COPY-directive) server-side copy', async () => {

--- a/apps/backend/__tests__/integration/s3-sdk/index.spec.ts
+++ b/apps/backend/__tests__/integration/s3-sdk/index.spec.ts
@@ -1338,6 +1338,62 @@ describe('AWS S3 - SDK', () => {
       expect(head.CacheControl).toBe('no-store')
       expect(head.Metadata?.part).toBe('meta')
     })
+
+    it('round-trips a Content-Encoding set on CreateMultipartUpload (empty-body op)', async () => {
+      // Content-Encoding is pure metadata on the bodyless CreateMultipartUpload
+      // POST. Until neutralizeContentEncoding covered this op, 'br' 415'd (and
+      // 'gzip' 400'd) at the body parser — which inspects the encoding before it
+      // notices the empty body — before the handler could capture it.
+      const Key = 'metadata-test/multipart-encoding.bin'
+      const create = await s3Client.send(
+        new CreateMultipartUploadCommand({ Bucket, Key, ContentEncoding: 'br' }),
+      )
+      const uploadId = create.UploadId
+      const part = await s3Client.send(
+        new UploadPartCommand({
+          Bucket,
+          Key,
+          UploadId: uploadId,
+          PartNumber: 1,
+          Body: Buffer.from('multipart body bytes'),
+        }),
+      )
+      await s3Client.send(
+        new CompleteMultipartUploadCommand({
+          Bucket,
+          Key,
+          UploadId: uploadId,
+          MultipartUpload: { Parts: [{ PartNumber: 1, ETag: part.ETag }] },
+        }),
+      )
+
+      const head = await s3Client.send(new HeadObjectCommand({ Bucket, Key }))
+      expect(head.ContentEncoding).toBe('br')
+    })
+
+    it('round-trips a Content-Encoding on a REPLACE-directive copy (empty-body op)', async () => {
+      // Same empty-body parser hazard: a REPLACE copy is a bodyless PUT carrying
+      // Content-Encoding as metadata.
+      const Src = 'metadata-test/copy-encoding-src.txt'
+      const Dst = 'metadata-test/copy-encoding-dst.txt'
+      await s3Client.send(
+        new PutObjectCommand({ Bucket, Key: Src, Body: Buffer.from('x') }),
+      )
+      await s3Client.send(
+        new CopyObjectCommand({
+          Bucket,
+          Key: Dst,
+          CopySource: Src,
+          MetadataDirective: 'REPLACE',
+          ContentEncoding: 'br',
+        }),
+      )
+
+      const head = await s3Client.send(
+        new HeadObjectCommand({ Bucket, Key: Dst }),
+      )
+      expect(head.ContentEncoding).toBe('br')
+    })
   })
 
   describe('Missing keys', () => {

--- a/apps/backend/__tests__/integration/s3-sdk/index.spec.ts
+++ b/apps/backend/__tests__/integration/s3-sdk/index.spec.ts
@@ -1,3 +1,4 @@
+import { gzipSync } from 'zlib'
 import { dbMigration } from '../../utils/dbMigrate.js'
 import {
   AbortMultipartUploadCommand,
@@ -1085,6 +1086,188 @@ describe('AWS S3 - SDK', () => {
         new HeadObjectCommand({ Bucket, Key: Dst }),
       )
       expect(head.Metadata?.mtime).toBeUndefined()
+    })
+  })
+
+  // S3 stores object metadata (system headers + arbitrary x-amz-meta-*) once at
+  // write and returns it verbatim on GET/HEAD; CopyObject carries or replaces it
+  // per the metadata directive. See issue #786.
+  describe('Object metadata', () => {
+    it('returns the stored Content-Type byte-for-byte, with no injected charset', async () => {
+      const Key = 'metadata-test/verbatim.csv'
+      await s3Client.send(
+        new PutObjectCommand({
+          Bucket,
+          Key,
+          Body: Buffer.from('a,b,c\n1,2,3'),
+          ContentType: 'text/csv',
+        }),
+      )
+
+      const head = await s3Client.send(new HeadObjectCommand({ Bucket, Key }))
+      // Previously came back as "text/csv; charset=utf-8" (Express appended the
+      // charset). It must now be exactly what was written.
+      expect(head.ContentType).toBe('text/csv')
+
+      const get = await s3Client.send(new GetObjectCommand({ Bucket, Key }))
+      expect(get.ContentType).toBe('text/csv')
+    })
+
+    it('preserves an explicit charset in the Content-Type', async () => {
+      const Key = 'metadata-test/charset.txt'
+      await s3Client.send(
+        new PutObjectCommand({
+          Bucket,
+          Key,
+          Body: Buffer.from('hola'),
+          ContentType: 'text/plain; charset=iso-8859-1',
+        }),
+      )
+
+      const head = await s3Client.send(new HeadObjectCommand({ Bucket, Key }))
+      expect(head.ContentType).toBe('text/plain; charset=iso-8859-1')
+    })
+
+    it('round-trips system metadata (Cache-Control, Content-Language, Content-Disposition)', async () => {
+      const Key = 'metadata-test/system.txt'
+      await s3Client.send(
+        new PutObjectCommand({
+          Bucket,
+          Key,
+          Body: Buffer.from('sys'),
+          CacheControl: 'max-age=3600, public',
+          ContentLanguage: 'en-GB',
+          ContentDisposition: 'attachment; filename="report.txt"',
+        }),
+      )
+
+      const head = await s3Client.send(new HeadObjectCommand({ Bucket, Key }))
+      expect(head.CacheControl).toBe('max-age=3600, public')
+      expect(head.ContentLanguage).toBe('en-GB')
+      expect(head.ContentDisposition).toBe('attachment; filename="report.txt"')
+    })
+
+    it('round-trips arbitrary user metadata (x-amz-meta-*)', async () => {
+      const Key = 'metadata-test/user.txt'
+      await s3Client.send(
+        new PutObjectCommand({
+          Bucket,
+          Key,
+          Body: Buffer.from('user'),
+          Metadata: { author: 'alice', project: 'auto-drive' },
+        }),
+      )
+
+      const head = await s3Client.send(new HeadObjectCommand({ Bucket, Key }))
+      expect(head.Metadata?.author).toBe('alice')
+      expect(head.Metadata?.project).toBe('auto-drive')
+    })
+
+    it('round-trips Content-Encoding for a non-internally-compressed object', async () => {
+      const Key = 'metadata-test/encoding.txt'
+      // A client declaring Content-Encoding: gzip sends actually-gzipped bytes
+      // (the raw body-parser inflates per Content-Encoding, so an unencoded body
+      // with this header would be rejected as malformed — correct HTTP). The
+      // encoding is stored as metadata and returned verbatim; Auto Drive is not
+      // internally compressing this object, so it owns Content-Encoding.
+      await s3Client.send(
+        new PutObjectCommand({
+          Bucket,
+          Key,
+          Body: gzipSync(Buffer.from('encoded')),
+          ContentEncoding: 'gzip',
+        }),
+      )
+
+      const head = await s3Client.send(new HeadObjectCommand({ Bucket, Key }))
+      expect(head.ContentEncoding).toBe('gzip')
+    })
+
+    it('carries metadata through a plain (COPY-directive) server-side copy', async () => {
+      const Src = 'metadata-test/copy-src.csv'
+      const Dst = 'metadata-test/copy-dst.csv'
+      await s3Client.send(
+        new PutObjectCommand({
+          Bucket,
+          Key: Src,
+          Body: Buffer.from('x'),
+          ContentType: 'text/csv',
+          CacheControl: 'max-age=60',
+          Metadata: { origin: 'src' },
+        }),
+      )
+      await s3Client.send(
+        new CopyObjectCommand({ Bucket, Key: Dst, CopySource: Src }),
+      )
+
+      const head = await s3Client.send(new HeadObjectCommand({ Bucket, Key: Dst }))
+      expect(head.ContentType).toBe('text/csv')
+      expect(head.CacheControl).toBe('max-age=60')
+      expect(head.Metadata?.origin).toBe('src')
+    })
+
+    it('replaces metadata on a REPLACE-directive copy', async () => {
+      const Src = 'metadata-test/replace-src.csv'
+      const Dst = 'metadata-test/replace-dst.json'
+      await s3Client.send(
+        new PutObjectCommand({
+          Bucket,
+          Key: Src,
+          Body: Buffer.from('x'),
+          ContentType: 'text/csv',
+          Metadata: { origin: 'src' },
+        }),
+      )
+      await s3Client.send(
+        new CopyObjectCommand({
+          Bucket,
+          Key: Dst,
+          CopySource: Src,
+          MetadataDirective: 'REPLACE',
+          ContentType: 'application/json',
+          Metadata: { origin: 'dst' },
+        }),
+      )
+
+      const head = await s3Client.send(new HeadObjectCommand({ Bucket, Key: Dst }))
+      expect(head.ContentType).toBe('application/json')
+      expect(head.Metadata?.origin).toBe('dst')
+    })
+
+    it('persists metadata supplied on CreateMultipartUpload', async () => {
+      const Key = 'metadata-test/multipart.bin'
+      const create = await s3Client.send(
+        new CreateMultipartUploadCommand({
+          Bucket,
+          Key,
+          ContentType: 'application/x-custom',
+          CacheControl: 'no-store',
+          Metadata: { part: 'meta' },
+        }),
+      )
+      const uploadId = create.UploadId
+      const part = await s3Client.send(
+        new UploadPartCommand({
+          Bucket,
+          Key,
+          UploadId: uploadId,
+          PartNumber: 1,
+          Body: Buffer.from('multipart body bytes'),
+        }),
+      )
+      await s3Client.send(
+        new CompleteMultipartUploadCommand({
+          Bucket,
+          Key,
+          UploadId: uploadId,
+          MultipartUpload: { Parts: [{ PartNumber: 1, ETag: part.ETag }] },
+        }),
+      )
+
+      const head = await s3Client.send(new HeadObjectCommand({ Bucket, Key }))
+      expect(head.ContentType).toBe('application/x-custom')
+      expect(head.CacheControl).toBe('no-store')
+      expect(head.Metadata?.part).toBe('meta')
     })
   })
 

--- a/apps/backend/__tests__/integration/s3-sdk/index.spec.ts
+++ b/apps/backend/__tests__/integration/s3-sdk/index.spec.ts
@@ -1459,6 +1459,34 @@ describe('AWS S3 - SDK', () => {
       expect(got).toEqual(CliBody)
     }, 15_000)
 
+    it('ignores a forged internal content-encoding stash header', async () => {
+      // The server stashes a real Content-Encoding on a request-scoped side
+      // channel (not on req.headers), so no header is a trusted internal channel.
+      // A client sending this made-up header directly must be ignored — it is
+      // just an unknown header, never persisted or re-emitted as the object's
+      // Content-Encoding (which would advertise an encoding untied to the bytes).
+      const key = '/cli-test/forged-encoding.txt'
+      const put = await fetch(`${S3_BASE}${key}`, {
+        method: 'PUT',
+        headers: {
+          Authorization: AUTH,
+          'x-autonomys-stashed-content-encoding': 'gzip',
+        },
+        body: Buffer.from('plain bytes') as unknown as BodyInit,
+      })
+      expect(put.status).toBe(200)
+
+      const get = await fetch(`${S3_BASE}${key}`, {
+        method: 'GET',
+        headers: { Authorization: AUTH },
+      })
+      expect(get.status).toBe(200)
+      expect(get.headers.get('content-encoding')).toBeNull()
+      expect(Buffer.from(await get.arrayBuffer())).toEqual(
+        Buffer.from('plain bytes'),
+      )
+    }, 15_000)
+
     it('multipart upload via raw requests round-trips (the original 500)', async () => {
       const key = '/cli-test/mpu.bin'
       const part1 = Buffer.from('AAAAAAAAAAAAAAAA')

--- a/apps/backend/__tests__/integration/s3-sdk/index.spec.ts
+++ b/apps/backend/__tests__/integration/s3-sdk/index.spec.ts
@@ -1163,6 +1163,40 @@ describe('AWS S3 - SDK', () => {
       expect(head.Metadata?.project).toBe('auto-drive')
     })
 
+    it('rejects user metadata over the 2 KB limit with MetadataTooLarge', async () => {
+      const Key = 'metadata-test/too-large.txt'
+      // 'big'(3) + 2100-byte value = 2103 bytes of user metadata, over the 2 KB
+      // S3 limit but well under Node's header budget (so the server, not Node,
+      // rejects it) — matching real S3, which returns 400 MetadataTooLarge.
+      let status: number | undefined
+      let code: string | undefined
+      try {
+        await s3Client.send(
+          new PutObjectCommand({
+            Bucket,
+            Key,
+            Body: Buffer.from('data'),
+            Metadata: { big: 'x'.repeat(2100) },
+          }),
+        )
+        throw new Error('expected the oversized-metadata PUT to be rejected')
+      } catch (e) {
+        const err = e as {
+          $metadata?: { httpStatusCode?: number }
+          name?: string
+        }
+        status = err.$metadata?.httpStatusCode
+        code = err.name
+      }
+      expect(status).toBe(400)
+      expect(code).toBe('MetadataTooLarge')
+
+      // The object must not have been created (rejected before the upload).
+      await expect(
+        s3Client.send(new HeadObjectCommand({ Bucket, Key })),
+      ).rejects.toThrow()
+    })
+
     it('stores the body verbatim under a client Content-Encoding and returns both unchanged', async () => {
       const Key = 'metadata-test/encoding.txt'
       // S3 stores object bytes byte-for-byte and treats Content-Encoding as

--- a/apps/backend/__tests__/unit/controllers/s3-user-metadata.spec.ts
+++ b/apps/backend/__tests__/unit/controllers/s3-user-metadata.spec.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from '@jest/globals'
+import { userMetadataByteSize } from '../../../src/app/controllers/s3/s3.js'
+
+// S3 caps user-defined metadata (x-amz-meta-*) at 2 KB, measured as the sum of
+// the UTF-8 byte lengths of every key and value; system headers don't count.
+// userMetadataByteSize is that measurement (the 2048-byte reject lives in the
+// write handlers and is exercised end-to-end in the s3-sdk integration suite).
+describe('userMetadataByteSize (S3 2 KB user-metadata limit)', () => {
+  it('is 0 when there is no user metadata', () => {
+    expect(userMetadataByteSize(null)).toBe(0)
+    expect(userMetadataByteSize(undefined)).toBe(0)
+    // System headers are not user metadata and must not be counted.
+    expect(
+      userMetadataByteSize({
+        contentType: 'text/csv',
+        cacheControl: 'max-age=999',
+      }),
+    ).toBe(0)
+  })
+
+  it('sums the byte lengths of user-metadata keys and values only', () => {
+    // 'author'(6) + 'alice'(5) + 'x'(1) + 'yz'(2) = 14; contentType excluded.
+    expect(
+      userMetadataByteSize({
+        contentType: 'text/csv',
+        userMetadata: { author: 'alice', x: 'yz' },
+      }),
+    ).toBe(14)
+  })
+
+  it('counts multi-byte UTF-8 by byte, not by character', () => {
+    // 'k'(1) + '€'(3 bytes in UTF-8) = 4.
+    expect(userMetadataByteSize({ userMetadata: { k: '€' } })).toBe(4)
+  })
+})

--- a/apps/backend/__tests__/unit/core/s3.spec.ts
+++ b/apps/backend/__tests__/unit/core/s3.spec.ts
@@ -42,6 +42,7 @@ describe('S3UseCases', () => {
       cid: 'cid123',
       md5: null,
       mtime: null,
+      metadata: null,
       ownerOauthProvider: 'google',
       ownerOauthUserId: 'user1',
       createdAt: new Date(0),
@@ -110,6 +111,28 @@ describe('S3UseCases', () => {
       )
     })
 
+    it('surfaces the stored object metadata for the response layer', async () => {
+      const objectMetadata = {
+        contentType: 'text/csv',
+        cacheControl: 'max-age=99',
+        userMetadata: { foo: 'bar' },
+      }
+      jest
+        .spyOn(s3ObjectMappingsRepository, 'findByKey')
+        .mockResolvedValue(mapping({ metadata: objectMetadata }))
+      jest
+        .spyOn(DownloadUseCase, 'downloadObjectByAnonymous')
+        .mockResolvedValue(ok({ read: jest.fn() }) as any)
+
+      const result = await S3UseCases.getObject(mockUser, {
+        Bucket: 'my-bucket',
+        Key: 'file.txt',
+      } as any)
+
+      expect(result.isOk()).toBe(true)
+      expect(result._unsafeUnwrap().objectMetadata).toEqual(objectMetadata)
+    })
+
     it('returns a null etag for legacy objects without md5', async () => {
       jest
         .spyOn(s3ObjectMappingsRepository, 'findByKey')
@@ -149,14 +172,11 @@ describe('S3UseCases', () => {
   })
 
   describe('createMultipartUpload', () => {
-    it('creates the upload; stashes no mtime when none is supplied', async () => {
+    it('creates the upload; stashes nothing when neither mtime nor metadata is supplied', async () => {
       jest
         .spyOn(UploadsUseCases, 'createFileUpload')
         .mockResolvedValue({ id: 'upload123' } as any)
-      const mtimeSpy = jest.spyOn(
-        s3ObjectMappingsRepository,
-        'setMultipartMtime',
-      )
+      const metaSpy = jest.spyOn(s3ObjectMappingsRepository, 'setMultipartMeta')
 
       const result = await S3UseCases.createMultipartUpload(mockUser, {
         Bucket: 'bucket',
@@ -165,15 +185,15 @@ describe('S3UseCases', () => {
       } as any)
 
       expect(result.isOk()).toBe(true)
-      expect(mtimeSpy).not.toHaveBeenCalled()
+      expect(metaSpy).not.toHaveBeenCalled()
     })
 
     it('stashes the client mtime by upload id when provided', async () => {
       jest
         .spyOn(UploadsUseCases, 'createFileUpload')
         .mockResolvedValue({ id: 'upload123' } as any)
-      const mtimeSpy = jest
-        .spyOn(s3ObjectMappingsRepository, 'setMultipartMtime')
+      const metaSpy = jest
+        .spyOn(s3ObjectMappingsRepository, 'setMultipartMeta')
         .mockResolvedValue(undefined)
 
       await S3UseCases.createMultipartUpload(mockUser, {
@@ -182,7 +202,25 @@ describe('S3UseCases', () => {
         Mtime: '1620000000.5',
       } as any)
 
-      expect(mtimeSpy).toHaveBeenCalledWith('upload123', '1620000000.5')
+      expect(metaSpy).toHaveBeenCalledWith('upload123', '1620000000.5', null)
+    })
+
+    it('stashes the object metadata by upload id when provided', async () => {
+      jest
+        .spyOn(UploadsUseCases, 'createFileUpload')
+        .mockResolvedValue({ id: 'upload123' } as any)
+      const metaSpy = jest
+        .spyOn(s3ObjectMappingsRepository, 'setMultipartMeta')
+        .mockResolvedValue(undefined)
+
+      const metadata = { contentType: 'text/csv', userMetadata: { a: '1' } }
+      await S3UseCases.createMultipartUpload(mockUser, {
+        Bucket: 'bucket',
+        Key: 'file.txt',
+        Metadata: metadata,
+      } as any)
+
+      expect(metaSpy).toHaveBeenCalledWith('upload123', null, metadata)
     })
   })
 
@@ -206,18 +244,19 @@ describe('S3UseCases', () => {
   })
 
   describe('completeMultipartUpload', () => {
-    it('completes the upload, persists the composite ETag + stashed mtime under the caller', async () => {
+    it('completes the upload, persists the composite ETag + stashed mtime/metadata under the caller', async () => {
       const completeSpy = jest
         .spyOn(UploadsUseCases, 'completeUpload')
         .mockResolvedValue('cid123')
       const mappingSpy = jest
         .spyOn(s3ObjectMappingsRepository, 'createMapping')
         .mockResolvedValue(mapping())
+      const stashedMetadata = { contentType: 'text/csv' }
       jest
-        .spyOn(s3ObjectMappingsRepository, 'getMultipartMtime')
-        .mockResolvedValue('1620000000.5')
-      const clearMtimeSpy = jest
-        .spyOn(s3ObjectMappingsRepository, 'deleteMultipartMtime')
+        .spyOn(s3ObjectMappingsRepository, 'getMultipartMeta')
+        .mockResolvedValue({ mtime: '1620000000.5', metadata: stashedMetadata })
+      const clearMetaSpy = jest
+        .spyOn(s3ObjectMappingsRepository, 'deleteMultipartMeta')
         .mockResolvedValue(undefined)
 
       const result = await S3UseCases.completeMultipartUpload(mockUser, {
@@ -234,7 +273,7 @@ describe('S3UseCases', () => {
       expect(completeSpy).toHaveBeenCalledWith(mockUser, 'upload123')
       expect(result._unsafeUnwrap().ETag).toMatch(MULTIPART_ETAG_RE)
       expect(result._unsafeUnwrap().Cid).toBe('cid123')
-      // createMapping is owner-scoped: (owner, owner, bucket, key, cid, md5, mtime).
+      // createMapping is owner-scoped: (owner, owner, bucket, key, cid, md5, mtime, metadata).
       expect(mappingSpy).toHaveBeenCalledWith(
         'google',
         'user1',
@@ -243,8 +282,9 @@ describe('S3UseCases', () => {
         'cid123',
         expect.stringMatching(MULTIPART_MD5_RE),
         '1620000000.5',
+        stashedMetadata,
       )
-      expect(clearMtimeSpy).toHaveBeenCalledWith('upload123')
+      expect(clearMetaSpy).toHaveBeenCalledWith('upload123')
     })
   })
 
@@ -338,7 +378,7 @@ describe('S3UseCases', () => {
         Body: Buffer.from('Hello, world!'),
       } as any)
 
-      // MD5 of "Hello, world!"; owner-scoped (owner, owner, bucket, key, cid, md5, mtime).
+      // MD5 of "Hello, world!"; owner-scoped (owner, owner, bucket, key, cid, md5, mtime, metadata).
       expect(mappingSpy).toHaveBeenCalledWith(
         'google',
         'user1',
@@ -347,6 +387,38 @@ describe('S3UseCases', () => {
         'cid123',
         '6cd3556deb0da54bca060b4c39479839',
         null,
+        null,
+      )
+    })
+
+    it('persists the captured object metadata onto the mapping', async () => {
+      setupPut()
+      const mappingSpy = jest
+        .spyOn(s3ObjectMappingsRepository, 'createMapping')
+        .mockResolvedValue(mapping())
+      const metadata = {
+        contentType: 'text/csv',
+        cacheControl: 'no-cache',
+        userMetadata: { author: 'alice' },
+      }
+
+      await S3UseCases.putObject(mockUser, {
+        Bucket: 'my-bucket',
+        Key: 'file.txt',
+        Body: Buffer.from('data'),
+        Metadata: metadata,
+      } as any)
+
+      // metadata is the 8th positional argument.
+      expect(mappingSpy).toHaveBeenCalledWith(
+        'google',
+        'user1',
+        'my-bucket',
+        'file.txt',
+        'cid123',
+        expect.any(String),
+        null,
+        metadata,
       )
     })
   })
@@ -607,6 +679,7 @@ describe('S3UseCases', () => {
       expect(result._unsafeUnwrap().ETag).toMatch(MD5_ETAG_RE)
       // Source lookup + destination creation are both scoped to the caller.
       expect(findSpy).toHaveBeenCalledWith('google', 'user1', 'src', 'a.txt')
+      // Default COPY directive: the destination inherits the source metadata.
       expect(createSpy).toHaveBeenCalledWith(
         'google',
         'user1',
@@ -615,6 +688,7 @@ describe('S3UseCases', () => {
         'srccid',
         source.md5,
         null,
+        source.metadata,
       )
     })
 
@@ -673,6 +747,7 @@ describe('S3UseCases', () => {
         'srccid',
         source.md5,
         '111.5',
+        source.metadata,
       )
     })
 
@@ -700,6 +775,7 @@ describe('S3UseCases', () => {
         'srccid',
         source.md5,
         '222.9',
+        source.metadata,
       )
     })
 
@@ -727,6 +803,69 @@ describe('S3UseCases', () => {
         'srccid',
         source.md5,
         null,
+        source.metadata,
+      )
+    })
+
+    it('inherits the source metadata under the default COPY directive', async () => {
+      const srcMeta = { contentType: 'text/csv', userMetadata: { a: '1' } }
+      jest
+        .spyOn(s3ObjectMappingsRepository, 'findByKey')
+        .mockResolvedValue(mapping({ ...source, metadata: srcMeta }))
+      const createSpy = jest
+        .spyOn(s3ObjectMappingsRepository, 'createMapping')
+        .mockResolvedValue({ ...source, updatedAt: new Date(1000) })
+
+      await S3UseCases.copyObject(mockUser, {
+        SourceBucket: 'src',
+        SourceKey: 'a.txt',
+        Bucket: 'dst',
+        Key: 'b.txt',
+      })
+
+      expect(createSpy).toHaveBeenCalledWith(
+        'google',
+        'user1',
+        'dst',
+        'b.txt',
+        'srccid',
+        source.md5,
+        null,
+        srcMeta,
+      )
+    })
+
+    it('replaces the destination metadata when the REPLACE directive provides it', async () => {
+      const srcMeta = { contentType: 'text/csv' }
+      const replacement = {
+        contentType: 'application/json',
+        userMetadata: { b: '2' },
+      }
+      jest
+        .spyOn(s3ObjectMappingsRepository, 'findByKey')
+        .mockResolvedValue(mapping({ ...source, metadata: srcMeta }))
+      const createSpy = jest
+        .spyOn(s3ObjectMappingsRepository, 'createMapping')
+        .mockResolvedValue({ ...source, updatedAt: new Date(1000) })
+
+      await S3UseCases.copyObject(mockUser, {
+        SourceBucket: 'src',
+        SourceKey: 'a.txt',
+        Bucket: 'dst',
+        Key: 'b.txt',
+        Metadata: replacement,
+      })
+
+      // The replacement wins over the source metadata; mtime is untouched here.
+      expect(createSpy).toHaveBeenCalledWith(
+        'google',
+        'user1',
+        'dst',
+        'b.txt',
+        'srccid',
+        source.md5,
+        null,
+        replacement,
       )
     })
 
@@ -750,35 +889,35 @@ describe('S3UseCases', () => {
   })
 
   describe('abortMultipartUpload', () => {
-    it('delegates to UploadsUseCases.abortUpload and clears the stashed mtime', async () => {
+    it('delegates to UploadsUseCases.abortUpload and clears the stashed metadata', async () => {
       const abortSpy = jest
         .spyOn(UploadsUseCases, 'abortUpload')
         .mockResolvedValue(ok(undefined))
-      const clearMtimeSpy = jest
-        .spyOn(s3ObjectMappingsRepository, 'deleteMultipartMtime')
+      const clearMetaSpy = jest
+        .spyOn(s3ObjectMappingsRepository, 'deleteMultipartMeta')
         .mockResolvedValue(undefined)
 
       const result = await S3UseCases.abortMultipartUpload(mockUser, 'upload123')
 
       expect(result.isOk()).toBe(true)
       expect(abortSpy).toHaveBeenCalledWith(mockUser, 'upload123')
-      expect(clearMtimeSpy).toHaveBeenCalledWith('upload123')
+      expect(clearMetaSpy).toHaveBeenCalledWith('upload123')
     })
 
-    it('propagates a not-found error for an unknown upload id (no mtime clear)', async () => {
+    it('propagates a not-found error for an unknown upload id (no metadata clear)', async () => {
       jest
         .spyOn(UploadsUseCases, 'abortUpload')
         .mockResolvedValue(err(new ObjectNotFoundError('Upload not found')))
-      const clearMtimeSpy = jest.spyOn(
+      const clearMetaSpy = jest.spyOn(
         s3ObjectMappingsRepository,
-        'deleteMultipartMtime',
+        'deleteMultipartMeta',
       )
 
       const result = await S3UseCases.abortMultipartUpload(mockUser, 'nope')
 
       expect(result.isErr()).toBe(true)
       expect(result._unsafeUnwrapErr()).toBeInstanceOf(ObjectNotFoundError)
-      expect(clearMtimeSpy).not.toHaveBeenCalled()
+      expect(clearMetaSpy).not.toHaveBeenCalled()
     })
 
     it('propagates a forbidden error when the caller does not own the upload', async () => {

--- a/apps/backend/migrations/20260715000000-s3-object-metadata.js
+++ b/apps/backend/migrations/20260715000000-s3-object-metadata.js
@@ -1,0 +1,51 @@
+'use strict'
+
+var dbm
+var type
+var seed
+var fs = require('fs')
+var path = require('path')
+var Promise
+
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  var filePath = path.join(
+    __dirname,
+    'sqls',
+    '20260715000000-s3-object-metadata-up.sql',
+  )
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      resolve(data)
+    })
+  }).then(function (data) {
+    return db.runSql(data)
+  })
+}
+
+exports.down = function (db) {
+  var filePath = path.join(
+    __dirname,
+    'sqls',
+    '20260715000000-s3-object-metadata-down.sql',
+  )
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      resolve(data)
+    })
+  }).then(function (data) {
+    return db.runSql(data)
+  })
+}
+
+exports._meta = {
+  version: 1,
+}

--- a/apps/backend/migrations/sqls/20260715000000-s3-object-metadata-down.sql
+++ b/apps/backend/migrations/sqls/20260715000000-s3-object-metadata-down.sql
@@ -1,0 +1,11 @@
+-- Reverse of the metadata migration. Restores the exact prior schema so an
+-- up/down/up cycle (as the test suite runs) never errors.
+--
+-- Restoring mtime's NOT NULL requires first clearing any staging rows that hold
+-- only metadata (mtime IS NULL) — they exist solely because the forward
+-- migration allowed them. Staging rows are transient, so dropping them is safe.
+ALTER TABLE "S3".object_mappings DROP COLUMN IF EXISTS metadata;
+ALTER TABLE "S3".multipart_upload_meta DROP COLUMN IF EXISTS metadata;
+
+DELETE FROM "S3".multipart_upload_meta WHERE mtime IS NULL;
+ALTER TABLE "S3".multipart_upload_meta ALTER COLUMN mtime SET NOT NULL;

--- a/apps/backend/migrations/sqls/20260715000000-s3-object-metadata-up.sql
+++ b/apps/backend/migrations/sqls/20260715000000-s3-object-metadata-up.sql
@@ -1,0 +1,24 @@
+-- Persist standard S3 object metadata alongside the CID.
+--
+-- The S3 layer previously stored only Content-Type (as the IPLD node's mimeType)
+-- and mtime, dropping Cache-Control, Content-Language, Content-Disposition,
+-- Content-Encoding and arbitrary x-amz-meta-* headers. S3 clients expect object
+-- metadata to round-trip verbatim on GET/HEAD and to be carried by CopyObject.
+--
+-- metadata: a JSONB bag of the per-key S3 metadata (contentType, cacheControl,
+-- contentLanguage, contentDisposition, contentEncoding, and a userMetadata map
+-- of x-amz-meta-* entries). It lives on the mapping — beside the content, not in
+-- the content hash — because metadata is a property of the S3 key, not of the
+-- bytes: two keys can point at the same CID with different declared metadata,
+-- and content-addressed dedup stays intact. NULL for objects written before this
+-- feature (they fall back to the IPLD-derived Content-Type as before).
+ALTER TABLE "S3".object_mappings ADD COLUMN metadata jsonb;
+
+-- Stage the metadata of an in-progress multipart upload the same way mtime is
+-- staged: S3 sends system/user metadata on CreateMultipartUpload but not on
+-- CompleteMultipartUpload, and the mapping row is only created at completion.
+ALTER TABLE "S3".multipart_upload_meta ADD COLUMN metadata jsonb;
+
+-- mtime is no longer the only thing a staging row can carry: an upload may stage
+-- metadata with no client mtime. Relax the NOT NULL so such a row can exist.
+ALTER TABLE "S3".multipart_upload_meta ALTER COLUMN mtime DROP NOT NULL;

--- a/apps/backend/src/app/controllers/s3/http.ts
+++ b/apps/backend/src/app/controllers/s3/http.ts
@@ -119,20 +119,33 @@ export const getS3Method = (req: Request): string => {
   }
 }
 
-// Operations whose request body IS the stored object. S3 stores that payload
-// byte-for-byte and treats Content-Encoding as opaque metadata — it must never
-// inflate the body. Express's parser otherwise gunzips gzip/deflate bodies (so
-// the stored bytes would no longer match the declared encoding) and rejects
-// unknown encodings (br, zstd) with 415 before they can be stored.
-const BODY_STORED_VERBATIM = new Set(['PutObject', 'UploadPart'])
+// The S3 write ops that may carry a client Content-Encoding the body parser must
+// not see. Two reasons, handled identically:
+//  - PutObject / UploadPart: the request body IS the stored object, so it must be
+//    kept byte-for-byte — S3 never inflates a stored body; Content-Encoding is
+//    opaque metadata. Left alone, Express gunzips gzip/deflate bodies (stored
+//    bytes then wouldn't match the declared encoding) or 415s unknown encodings
+//    (br, zstd) before they can be stored.
+//  - CreateMultipartUpload / CopyObject: no stored body, but Content-Encoding
+//    rides along as pure metadata on an empty body the parser still inspects.
+//    body-parser checks the encoding before it notices the body is empty
+//    (Content-Length: 0 counts as "has body"), so 'br' → 415 and 'gzip' → 400
+//    (gunzip on empty input) before the handler could read it as metadata.
+// For all of them, neutralizeContentEncoding moves the header onto a
+// request-scoped stash that getObjectMetadata reads back.
+const CONTENT_ENCODING_WRITE_OPS = new Set([
+  'PutObject',
+  'UploadPart',
+  'CreateMultipartUpload',
+  'CopyObject',
+])
 
 // Move a client-declared Content-Encoding out of the way of the body parser for
-// those operations, preserving it under an internal header for metadata
-// capture, so the exact wire bytes are stored and later returned verbatim under
-// the same encoding (GetObject/HeadObject re-emit it). aws-chunked is AWS
-// transfer framing, not object content: leave it in place so the parser's
-// existing handling stands rather than storing the framing bytes as data.
-const neutralizeObjectBodyEncoding = (
+// those ops (see above), preserving it under a request-scoped stash for metadata
+// capture; GetObject/HeadObject re-emit it. aws-chunked is AWS transfer framing,
+// not object content: leave it in place so the parser's existing handling stands
+// rather than storing the framing bytes as data.
+const neutralizeContentEncoding = (
   req: Request,
   _res: Response,
   next: NextFunction,
@@ -142,11 +155,12 @@ const neutralizeObjectBodyEncoding = (
     typeof encoding === 'string' &&
     encoding.toLowerCase() !== 'identity' &&
     !encoding.toLowerCase().includes('aws-chunked') &&
-    BODY_STORED_VERBATIM.has(getS3Method(req))
+    CONTENT_ENCODING_WRITE_OPS.has(getS3Method(req))
   ) {
     // Stash on a request-scoped side channel (not a header) so it round-trips as
     // metadata without being forgeable over the wire, then hide the real header
-    // from the parser so the body is stored verbatim.
+    // from the parser (which would otherwise inflate a stored body, or 415/400 on
+    // an empty one).
     stashContentEncoding(req, encoding)
     delete req.headers['content-encoding']
   }
@@ -166,9 +180,10 @@ s3Controller.get(
 
 s3Controller.use(
   '/:key(*)',
-  // Runs before the parser: hides a client Content-Encoding on body-storing
-  // ops so the object bytes are stored verbatim (see above).
-  neutralizeObjectBodyEncoding,
+  // Runs before the parser: moves a client Content-Encoding aside for the write
+  // ops that carry it, so the parser neither inflates a stored body nor 415/400s
+  // on an empty one (see above).
+  neutralizeContentEncoding,
   // S3 object bodies are opaque binary payloads. Always read the request body
   // as raw bytes regardless of (or the absence of) a Content-Type header.
   // `type: '*/*'` is insufficient: type-is returns false when no Content-Type

--- a/apps/backend/src/app/controllers/s3/http.ts
+++ b/apps/backend/src/app/controllers/s3/http.ts
@@ -1,4 +1,4 @@
-import { raw, Router, Request, Response } from 'express'
+import { raw, Router, Request, Response, NextFunction } from 'express'
 import { asyncSafeHandler } from '../../../shared/utils/express.js'
 import { createLogger } from '../../../infrastructure/drivers/logger.js'
 import {
@@ -17,6 +17,7 @@ import {
   notImplementedHandler,
   putObjectHandler,
   uploadPartHandler,
+  STASHED_CONTENT_ENCODING_HEADER,
 } from './s3.js'
 
 const s3Controller = Router()
@@ -118,6 +119,37 @@ export const getS3Method = (req: Request): string => {
   }
 }
 
+// Operations whose request body IS the stored object. S3 stores that payload
+// byte-for-byte and treats Content-Encoding as opaque metadata — it must never
+// inflate the body. Express's parser otherwise gunzips gzip/deflate bodies (so
+// the stored bytes would no longer match the declared encoding) and rejects
+// unknown encodings (br, zstd) with 415 before they can be stored.
+const BODY_STORED_VERBATIM = new Set(['PutObject', 'UploadPart'])
+
+// Move a client-declared Content-Encoding out of the way of the body parser for
+// those operations, preserving it under an internal header for metadata
+// capture, so the exact wire bytes are stored and later returned verbatim under
+// the same encoding (GetObject/HeadObject re-emit it). aws-chunked is AWS
+// transfer framing, not object content: leave it in place so the parser's
+// existing handling stands rather than storing the framing bytes as data.
+const neutralizeObjectBodyEncoding = (
+  req: Request,
+  _res: Response,
+  next: NextFunction,
+) => {
+  const encoding = req.headers['content-encoding']
+  if (
+    typeof encoding === 'string' &&
+    encoding.toLowerCase() !== 'identity' &&
+    !encoding.toLowerCase().includes('aws-chunked') &&
+    BODY_STORED_VERBATIM.has(getS3Method(req))
+  ) {
+    req.headers[STASHED_CONTENT_ENCODING_HEADER] = encoding
+    delete req.headers['content-encoding']
+  }
+  next()
+}
+
 s3Controller.get(
   '/',
   asyncSafeHandler(async (req: Request, res: Response) => {
@@ -131,6 +163,9 @@ s3Controller.get(
 
 s3Controller.use(
   '/:key(*)',
+  // Runs before the parser: hides a client Content-Encoding on body-storing
+  // ops so the object bytes are stored verbatim (see above).
+  neutralizeObjectBodyEncoding,
   // S3 object bodies are opaque binary payloads. Always read the request body
   // as raw bytes regardless of (or the absence of) a Content-Type header.
   // `type: '*/*'` is insufficient: type-is returns false when no Content-Type

--- a/apps/backend/src/app/controllers/s3/http.ts
+++ b/apps/backend/src/app/controllers/s3/http.ts
@@ -17,7 +17,7 @@ import {
   notImplementedHandler,
   putObjectHandler,
   uploadPartHandler,
-  STASHED_CONTENT_ENCODING_HEADER,
+  stashContentEncoding,
 } from './s3.js'
 
 const s3Controller = Router()
@@ -144,7 +144,10 @@ const neutralizeObjectBodyEncoding = (
     !encoding.toLowerCase().includes('aws-chunked') &&
     BODY_STORED_VERBATIM.has(getS3Method(req))
   ) {
-    req.headers[STASHED_CONTENT_ENCODING_HEADER] = encoding
+    // Stash on a request-scoped side channel (not a header) so it round-trips as
+    // metadata without being forgeable over the wire, then hide the real header
+    // from the parser so the body is stored verbatim.
+    stashContentEncoding(req, encoding)
     delete req.headers['content-encoding']
   }
   next()

--- a/apps/backend/src/app/controllers/s3/s3.ts
+++ b/apps/backend/src/app/controllers/s3/s3.ts
@@ -89,14 +89,24 @@ const headerString = (
   value: string | string[] | undefined,
 ): string | undefined => (typeof value === 'string' ? value : undefined)
 
-// Internal request header into which the S3 router moves a client-declared
-// Content-Encoding for the body-storing operations (PutObject/UploadPart)
-// BEFORE body parsing, hiding it from Express's parser so the object bytes are
-// stored verbatim — S3 never inflates a stored body; Content-Encoding is opaque
-// metadata. getObjectMetadata reads it back from here. See
-// neutralizeObjectBodyEncoding in http.ts.
-export const STASHED_CONTENT_ENCODING_HEADER =
-  'x-autonomys-stashed-content-encoding'
+// A client-declared Content-Encoding for a body-storing op (PutObject/
+// UploadPart) is stashed here by the S3 router's pre-parser middleware (see
+// http.ts) once it has hidden the header from Express's parser, so the object
+// bytes are stored verbatim — S3 never inflates a stored body; Content-Encoding
+// is opaque metadata. It is deliberately kept OFF req.headers, in a
+// request-scoped WeakMap keyed by the Request, so a client cannot forge it over
+// the wire: HTTP callers set headers, not this server-side side channel.
+// Entries are garbage-collected with the request.
+const stashedContentEncoding = new WeakMap<Request, string>()
+
+/**
+ * Stash a body-storing op's client Content-Encoding for later metadata capture
+ * (getObjectMetadata). Called only by the S3 router's pre-parser middleware; the
+ * value is thus never read from a client-controllable channel.
+ */
+export const stashContentEncoding = (req: Request, encoding: string): void => {
+  stashedContentEncoding.set(req, encoding)
+}
 
 /**
  * Capture the standard S3 object metadata a write request carries: the system
@@ -116,13 +126,15 @@ const getObjectMetadata = (req: Request): S3ObjectMetadata | null => {
   if (contentLanguage) metadata.contentLanguage = contentLanguage
   const contentDisposition = headerString(req.headers['content-disposition'])
   if (contentDisposition) metadata.contentDisposition = contentDisposition
-  // For PutObject/UploadPart the real Content-Encoding was moved to an internal
-  // header before body parsing (so the body is stored verbatim); read it from
-  // there. Other write ops (CreateMultipartUpload) still carry the real header,
-  // and it is metadata-only for them (no body to inflate).
+  // For PutObject/UploadPart the real Content-Encoding was moved off the headers
+  // before body parsing (so the body is stored verbatim) onto a request-scoped
+  // side channel; read it back from there. It cannot be forged: a client-sent
+  // header only ever lands in req.headers, never in the WeakMap. Other write ops
+  // (CreateMultipartUpload) still carry the real header, metadata-only (no body
+  // to inflate).
   const contentEncoding =
     headerString(req.headers['content-encoding']) ??
-    headerString(req.headers[STASHED_CONTENT_ENCODING_HEADER])
+    stashedContentEncoding.get(req)
   if (contentEncoding) metadata.contentEncoding = contentEncoding
 
   const userMetadata: Record<string, string> = {}

--- a/apps/backend/src/app/controllers/s3/s3.ts
+++ b/apps/backend/src/app/controllers/s3/s3.ts
@@ -89,6 +89,15 @@ const headerString = (
   value: string | string[] | undefined,
 ): string | undefined => (typeof value === 'string' ? value : undefined)
 
+// Internal request header into which the S3 router moves a client-declared
+// Content-Encoding for the body-storing operations (PutObject/UploadPart)
+// BEFORE body parsing, hiding it from Express's parser so the object bytes are
+// stored verbatim — S3 never inflates a stored body; Content-Encoding is opaque
+// metadata. getObjectMetadata reads it back from here. See
+// neutralizeObjectBodyEncoding in http.ts.
+export const STASHED_CONTENT_ENCODING_HEADER =
+  'x-autonomys-stashed-content-encoding'
+
 /**
  * Capture the standard S3 object metadata a write request carries: the system
  * headers (Content-Type, Cache-Control, Content-Language, Content-Disposition,
@@ -107,7 +116,13 @@ const getObjectMetadata = (req: Request): S3ObjectMetadata | null => {
   if (contentLanguage) metadata.contentLanguage = contentLanguage
   const contentDisposition = headerString(req.headers['content-disposition'])
   if (contentDisposition) metadata.contentDisposition = contentDisposition
-  const contentEncoding = headerString(req.headers['content-encoding'])
+  // For PutObject/UploadPart the real Content-Encoding was moved to an internal
+  // header before body parsing (so the body is stored verbatim); read it from
+  // there. Other write ops (CreateMultipartUpload) still carry the real header,
+  // and it is metadata-only for them (no body to inflate).
+  const contentEncoding =
+    headerString(req.headers['content-encoding']) ??
+    headerString(req.headers[STASHED_CONTENT_ENCODING_HEADER])
   if (contentEncoding) metadata.contentEncoding = contentEncoding
 
   const userMetadata: Record<string, string> = {}

--- a/apps/backend/src/app/controllers/s3/s3.ts
+++ b/apps/backend/src/app/controllers/s3/s3.ts
@@ -17,6 +17,7 @@ import {
   CompressionAlgorithm,
   EncryptionAlgorithm,
 } from '@autonomys/auto-dag-data'
+import { S3ObjectMetadata } from '../../../infrastructure/repositories/s3/objectMappings.js'
 
 const logger = createLogger('s3:controllers')
 
@@ -75,6 +76,85 @@ const getUploadOptions = (req: Request) => {
 const getMtime = (req: Request): string | null => {
   const mtime = req.headers['x-amz-meta-mtime']
   return typeof mtime === 'string' ? mtime : null
+}
+
+// x-amz-meta-* keys that are NOT free-form user metadata: they are handled by
+// dedicated paths and must be excluded from the captured userMetadata so they
+// are not double-stored / double-emitted. mtime has its own column; compression
+// and encryption drive the upload options (and round-trip via the IPLD flags);
+// cid is a response-only header the server sets.
+const RESERVED_META_KEYS = new Set(['mtime', 'compression', 'encryption', 'cid'])
+
+const headerString = (
+  value: string | string[] | undefined,
+): string | undefined => (typeof value === 'string' ? value : undefined)
+
+/**
+ * Capture the standard S3 object metadata a write request carries: the system
+ * headers (Content-Type, Cache-Control, Content-Language, Content-Disposition,
+ * Content-Encoding) and arbitrary user metadata (x-amz-meta-*, minus the
+ * reserved keys above). Returns null when the request carried no metadata at all
+ * so the stored column stays NULL for such objects.
+ */
+const getObjectMetadata = (req: Request): S3ObjectMetadata | null => {
+  const metadata: S3ObjectMetadata = {}
+
+  const contentType = headerString(req.headers['content-type'])
+  if (contentType) metadata.contentType = contentType
+  const cacheControl = headerString(req.headers['cache-control'])
+  if (cacheControl) metadata.cacheControl = cacheControl
+  const contentLanguage = headerString(req.headers['content-language'])
+  if (contentLanguage) metadata.contentLanguage = contentLanguage
+  const contentDisposition = headerString(req.headers['content-disposition'])
+  if (contentDisposition) metadata.contentDisposition = contentDisposition
+  const contentEncoding = headerString(req.headers['content-encoding'])
+  if (contentEncoding) metadata.contentEncoding = contentEncoding
+
+  const userMetadata: Record<string, string> = {}
+  for (const [name, value] of Object.entries(req.headers)) {
+    // Node lowercases header names, so a direct prefix check is sufficient.
+    const key = name.startsWith('x-amz-meta-')
+      ? name.slice('x-amz-meta-'.length)
+      : null
+    if (!key || RESERVED_META_KEYS.has(key)) continue
+    const v = headerString(value)
+    if (v !== undefined) userMetadata[key] = v
+  }
+  if (Object.keys(userMetadata).length > 0) metadata.userMetadata = userMetadata
+
+  return Object.keys(metadata).length > 0 ? metadata : null
+}
+
+/**
+ * Emit stored S3 object metadata on a GET/HEAD response verbatim, overriding the
+ * generic values the shared download-header helper computed. Uses res.setHeader
+ * (Node) rather than res.set (Express) so Content-Type is sent byte-for-byte with
+ * no injected "; charset=..." — S3 never mutates a stored Content-Type.
+ */
+const applyStoredMetadataHeaders = (
+  res: Response,
+  metadata: S3ObjectMetadata | null,
+  { isCompressed }: { isCompressed: boolean },
+) => {
+  if (!metadata) return
+  if (metadata.contentType) res.setHeader('Content-Type', metadata.contentType)
+  if (metadata.cacheControl)
+    res.setHeader('Cache-Control', metadata.cacheControl)
+  if (metadata.contentLanguage)
+    res.setHeader('Content-Language', metadata.contentLanguage)
+  if (metadata.contentDisposition)
+    res.setHeader('Content-Disposition', metadata.contentDisposition)
+  // Only surface a stored Content-Encoding when Auto Drive isn't managing the
+  // wire encoding itself: for internally-compressed objects the download helper
+  // owns Content-Encoding (deflate on the wire, or server-side inflate), and
+  // emitting the client's stored value too would double-advertise the encoding.
+  if (metadata.contentEncoding && !isCompressed)
+    res.setHeader('Content-Encoding', metadata.contentEncoding)
+  if (metadata.userMetadata) {
+    for (const [key, value] of Object.entries(metadata.userMetadata)) {
+      res.setHeader(`x-amz-meta-${key}`, value)
+    }
+  }
 }
 
 /**
@@ -235,12 +315,19 @@ export const getObjectHandler = async (req: Request, res: Response) => {
     etag,
     lastModified,
     mtime,
+    objectMetadata,
   } = downloadResult.value
 
   handleDownloadResponseHeaders(req, res, metadata, {
     byteRange: resultingByteRange,
   })
   handleS3DownloadResponseHeaders(req, res, metadata)
+  // Override the generic headers with the stored S3 metadata (verbatim
+  // Content-Type, Cache-Control, x-amz-meta-*, …) — must run after the helpers
+  // above so it wins.
+  applyStoredMetadataHeaders(res, objectMetadata, {
+    isCompressed: metadata.isCompressed,
+  })
 
   // ETag: set to the MD5 for objects uploaded after this feature was introduced.
   // Legacy objects (md5 = null in the DB) do not get an ETag header — the CID
@@ -287,12 +374,19 @@ export const headObjectHandler = async (req: Request, res: Response) => {
     etag,
     lastModified,
     mtime,
+    objectMetadata,
   } = downloadResult.value
 
   handleDownloadResponseHeaders(req, res, metadata, {
     byteRange: resultingByteRange,
   })
   handleS3DownloadResponseHeaders(req, res, metadata)
+  // Override the generic headers with the stored S3 metadata (verbatim
+  // Content-Type, Cache-Control, x-amz-meta-*, …) — must run after the helpers
+  // above so it wins.
+  applyStoredMetadataHeaders(res, objectMetadata, {
+    isCompressed: metadata.isCompressed,
+  })
 
   // ETag: set to the MD5 for objects uploaded after this feature was introduced.
   // Legacy objects (md5 = null in the DB) do not get an ETag header — the CID
@@ -393,6 +487,7 @@ export const createMultipartUploadHandler = async (
     ContentType: req.headers['content-type'],
     UploadOptions: uploadOptions,
     Mtime: getMtime(req),
+    Metadata: getObjectMetadata(req),
   })
 
   if (result.isErr()) {
@@ -610,6 +705,7 @@ export const putObjectHandler = async (req: Request, res: Response) => {
     ContentType: req.headers['content-type'],
     UploadOptions: uploadOptions,
     Mtime: getMtime(req),
+    Metadata: getObjectMetadata(req),
   })
 
   if (result.isErr()) {
@@ -657,17 +753,18 @@ export const copyObjectHandler = async (req: Request, res: Response) => {
   }
 
   // Metadata handling follows x-amz-metadata-directive (default COPY):
-  //  - COPY:    the destination inherits the source metadata → pass undefined so
-  //             the use case keeps the source mtime.
+  //  - COPY:    the destination inherits the source's metadata → pass undefined
+  //             for both mtime and metadata so the use case keeps the source's.
   //  - REPLACE: the destination's metadata is exactly what this request carries,
-  //             so use the x-amz-meta-mtime header verbatim — a string to set it,
-  //             or null to CLEAR it (REPLACE with no mtime header means no mtime;
-  //             rclone's SetModTime always sends REPLACE + mtime, so it still
-  //             writes the intended value).
+  //             so capture the request's mtime and object metadata verbatim. A
+  //             missing value CLEARS it (REPLACE with no such header means the
+  //             destination has none); rclone's SetModTime always sends
+  //             REPLACE + mtime, so it still writes the intended value.
   const directive = req.headers['x-amz-metadata-directive']
   const isReplace =
     typeof directive === 'string' && directive.toUpperCase() === 'REPLACE'
   const mtime = isReplace ? getMtime(req) : undefined
+  const metadata = isReplace ? getObjectMetadata(req) : undefined
 
   const result = await S3UseCases.copyObject(user, {
     SourceBucket: source.bucket,
@@ -675,6 +772,7 @@ export const copyObjectHandler = async (req: Request, res: Response) => {
     Bucket: bucket,
     Key: key,
     Mtime: mtime,
+    Metadata: metadata,
   })
 
   if (result.isErr()) {

--- a/apps/backend/src/app/controllers/s3/s3.ts
+++ b/apps/backend/src/app/controllers/s3/s3.ts
@@ -126,12 +126,13 @@ const getObjectMetadata = (req: Request): S3ObjectMetadata | null => {
   if (contentLanguage) metadata.contentLanguage = contentLanguage
   const contentDisposition = headerString(req.headers['content-disposition'])
   if (contentDisposition) metadata.contentDisposition = contentDisposition
-  // For PutObject/UploadPart the real Content-Encoding was moved off the headers
-  // before body parsing (so the body is stored verbatim) onto a request-scoped
-  // side channel; read it back from there. It cannot be forged: a client-sent
-  // header only ever lands in req.headers, never in the WeakMap. Other write ops
-  // (CreateMultipartUpload) still carry the real header, metadata-only (no body
-  // to inflate).
+  // The pre-parser middleware (http.ts) moves a client Content-Encoding off the
+  // headers onto a request-scoped side channel for EVERY write op that carries
+  // it — PutObject/UploadPart (body stored verbatim) and CreateMultipartUpload/
+  // CopyObject (empty body the parser would 415/400 on before this ran) — so
+  // read it back from there. It cannot be forged: a client-sent header only ever
+  // lands in req.headers, never in the WeakMap. The req.headers fallback just
+  // catches an 'identity' encoding the middleware intentionally leaves in place.
   const contentEncoding =
     headerString(req.headers['content-encoding']) ??
     stashedContentEncoding.get(req)

--- a/apps/backend/src/app/controllers/s3/s3.ts
+++ b/apps/backend/src/app/controllers/s3/s3.ts
@@ -152,6 +152,47 @@ const getObjectMetadata = (req: Request): S3ObjectMetadata | null => {
   return Object.keys(metadata).length > 0 ? metadata : null
 }
 
+// Real S3 caps user-defined metadata (the x-amz-meta-* entries) at 2 KB — the
+// sum of the UTF-8 byte lengths of every key and value — and rejects a larger
+// write with 400 MetadataTooLarge. System headers (Content-Type, Cache-Control,
+// …) do NOT count toward it. We enforce the same bound: it matches client/SDK
+// expectations (SDKs already handle this error) and keeps the stored metadata —
+// persisted as jsonb and replayed on every GET/HEAD — bounded.
+const MAX_USER_METADATA_BYTES = 2048
+
+/** Sum of the UTF-8 byte lengths of the user-metadata keys and values (the S3
+ *  measure for the 2 KB limit). System headers are excluded — only x-amz-meta-*
+ *  captured into userMetadata is counted. */
+export const userMetadataByteSize = (
+  metadata: S3ObjectMetadata | null | undefined,
+): number => {
+  if (!metadata?.userMetadata) return 0
+  let total = 0
+  for (const [key, value] of Object.entries(metadata.userMetadata)) {
+    total += Buffer.byteLength(key, 'utf8') + Buffer.byteLength(value, 'utf8')
+  }
+  return total
+}
+
+/**
+ * Guard the S3 2 KB user-metadata limit on a write. When exceeded, sends a 400
+ * MetadataTooLarge (S3's error, which SDKs recognise) and returns true so the
+ * caller bails before doing any upload work; returns false (nothing sent) when
+ * within the limit. Shared by every write that captures request metadata
+ * (PutObject, CreateMultipartUpload, CopyObject REPLACE) so none can bypass it.
+ */
+const rejectIfUserMetadataTooLarge = (
+  res: Response,
+  metadata: S3ObjectMetadata | null | undefined,
+): boolean => {
+  if (userMetadataByteSize(metadata) <= MAX_USER_METADATA_BYTES) return false
+  sendXML(res.status(400), 'Error', {
+    Code: 'MetadataTooLarge',
+    Message: 'Your metadata headers exceed the maximum allowed metadata size.',
+  })
+  return true
+}
+
 /**
  * Emit stored S3 object metadata on a GET/HEAD response verbatim, overriding the
  * generic values the shared download-header helper computed. Uses res.setHeader
@@ -508,13 +549,16 @@ export const createMultipartUploadHandler = async (
   const uploadOptions = getUploadOptions(req)
   const { bucket, key } = parseBucketAndKey(req.params.key)
 
+  const metadata = getObjectMetadata(req)
+  if (rejectIfUserMetadataTooLarge(res, metadata)) return
+
   const result = await S3UseCases.createMultipartUpload(user, {
     Bucket: bucket,
     Key: key,
     ContentType: req.headers['content-type'],
     UploadOptions: uploadOptions,
     Mtime: getMtime(req),
-    Metadata: getObjectMetadata(req),
+    Metadata: metadata,
   })
 
   if (result.isErr()) {
@@ -725,6 +769,9 @@ export const putObjectHandler = async (req: Request, res: Response) => {
   const uploadOptions = getUploadOptions(req)
   const { bucket, key } = parseBucketAndKey(req.params.key)
 
+  const metadata = getObjectMetadata(req)
+  if (rejectIfUserMetadataTooLarge(res, metadata)) return
+
   const result = await S3UseCases.putObject(user, {
     Bucket: bucket,
     Key: key,
@@ -732,7 +779,7 @@ export const putObjectHandler = async (req: Request, res: Response) => {
     ContentType: req.headers['content-type'],
     UploadOptions: uploadOptions,
     Mtime: getMtime(req),
-    Metadata: getObjectMetadata(req),
+    Metadata: metadata,
   })
 
   if (result.isErr()) {
@@ -792,6 +839,10 @@ export const copyObjectHandler = async (req: Request, res: Response) => {
     typeof directive === 'string' && directive.toUpperCase() === 'REPLACE'
   const mtime = isReplace ? getMtime(req) : undefined
   const metadata = isReplace ? getObjectMetadata(req) : undefined
+  // REPLACE carries new metadata on the request; enforce the 2 KB user-metadata
+  // limit here too. (COPY inherits the source's already-bounded metadata, so
+  // `metadata` is undefined and this is a no-op.)
+  if (rejectIfUserMetadataTooLarge(res, metadata)) return
 
   const result = await S3UseCases.copyObject(user, {
     SourceBucket: source.bucket,

--- a/apps/backend/src/core/s3/index.ts
+++ b/apps/backend/src/core/s3/index.ts
@@ -51,16 +51,21 @@ type CompleteMultipartUploadParams = CompleteMultipartUploadCommandParams & {
   Parts?: Array<{ PartNumber: number; ETag: string }>
 }
 
-/** PutObject params extended with the client modification time (x-amz-meta-mtime).
- *  Kept local rather than in the shared DTO — mtime is an rclone/tooling
+/** PutObject params extended with the client modification time (x-amz-meta-mtime)
+ *  and the standard S3 object metadata captured from the request headers.
+ *  Mtime is kept local rather than in the shared DTO — it is an rclone/tooling
  *  convention, not part of the standard S3 PutObject contract. */
-type PutObjectParams = PutObjectCommandParams & { Mtime?: string | null }
+type PutObjectParams = PutObjectCommandParams & {
+  Mtime?: string | null
+  Metadata?: S3ObjectMetadata | null
+}
 
-/** CreateMultipartUpload params extended with the client mtime, stashed by
- *  upload id so completeMultipartUpload can persist it (rclone sends
- *  x-amz-meta-mtime on create but not on complete). */
+/** CreateMultipartUpload params extended with the client mtime and object
+ *  metadata, both stashed by upload id so completeMultipartUpload can persist
+ *  them (S3 sends them on create but not on complete). */
 type CreateMultipartUploadParams = CreateMultipartUploadCommandParams & {
   Mtime?: string | null
+  Metadata?: S3ObjectMetadata | null
 }
 
 /** CopyObject params. Source is resolved from the x-amz-copy-source header in
@@ -73,6 +78,12 @@ type CopyObjectParams = {
   Key: string
   /** When set, overrides the source mtime on the destination (metadata REPLACE). */
   Mtime?: string | null
+  /**
+   * Metadata directive for the destination. `undefined` means COPY: the
+   * destination inherits the source metadata. A value (or explicit null) means
+   * REPLACE: the destination's metadata is exactly this, discarding the source's.
+   */
+  Metadata?: S3ObjectMetadata | null
 }
 
 /** CopyObject result: the standard fields the <CopyObjectResult> body needs,
@@ -86,7 +97,10 @@ import { UploadsUseCases } from '../uploads/uploads.js'
 import { UserWithOrganization } from '@auto-drive/models'
 import { handleInternalError } from '../../shared/utils/neverthrow.js'
 import { createLogger } from '../../infrastructure/drivers/logger.js'
-import { S3BucketInfo } from '../../infrastructure/repositories/s3/objectMappings.js'
+import {
+  S3BucketInfo,
+  S3ObjectMetadata,
+} from '../../infrastructure/repositories/s3/objectMappings.js'
 
 const logger = createLogger('useCases:s3')
 
@@ -125,6 +139,12 @@ type GetObjectUseCaseResult = GetObjectCommandResult & {
    * so tools like rclone read the same value they wrote. null when unset.
    */
   mtime: string | null
+  /**
+   * Stored S3 object metadata (Content-Type, Cache-Control, x-amz-meta-*, …),
+   * emitted verbatim on the response by the HTTP layer. null for objects written
+   * before metadata persistence (they fall back to the IPLD-derived headers).
+   */
+  objectMetadata: S3ObjectMetadata | null
 }
 
 const getObject = async (
@@ -160,6 +180,7 @@ const getObject = async (
     etag: mapping.md5 ? formatETag(mapping.md5) : null,
     lastModified: mapping.updatedAt,
     mtime: mapping.mtime,
+    objectMetadata: mapping.metadata,
   }))
 }
 
@@ -177,10 +198,14 @@ const createMultipartUpload = async (
     null,
   )
 
-  // Stash the client mtime (if any) so completeMultipartUpload can persist it —
-  // rclone sends x-amz-meta-mtime here, not on completion.
-  if (params.Mtime) {
-    await s3ObjectMappingsRepository.setMultipartMtime(upload.id, params.Mtime)
+  // Stash the client mtime and object metadata (if any) so
+  // completeMultipartUpload can persist them onto the mapping — S3 sends them
+  // here, on create, not on completion. Skip the write when there is nothing to
+  // stash so uploads that carry neither don't touch the staging table.
+  const mtime = params.Mtime ?? null
+  const metadata = params.Metadata ?? null
+  if (mtime || metadata) {
+    await s3ObjectMappingsRepository.setMultipartMeta(upload.id, mtime, metadata)
   }
 
   return ok({
@@ -230,9 +255,9 @@ const completeMultipartUpload = async (
   // for an MD5 on subsequent GET/HEAD requests.
   const md5ForStorage = hasValidParts ? etag.replace(/"/g, '') : null
 
-  // Persist the mtime stashed at CreateMultipartUpload, then clear the staging
-  // row. null when the client sent no x-amz-meta-mtime.
-  const mtime = await s3ObjectMappingsRepository.getMultipartMtime(
+  // Persist the mtime and object metadata stashed at CreateMultipartUpload, then
+  // clear the staging row. Both are null when the client sent neither.
+  const { mtime, metadata } = await s3ObjectMappingsRepository.getMultipartMeta(
     params.UploadId,
   )
 
@@ -244,8 +269,9 @@ const completeMultipartUpload = async (
     cid,
     md5ForStorage,
     mtime,
+    metadata,
   )
-  await s3ObjectMappingsRepository.deleteMultipartMtime(params.UploadId)
+  await s3ObjectMappingsRepository.deleteMultipartMeta(params.UploadId)
   logger.debug(
     'Created mapping: bucket=(%s) key=(%s) -> cid=(%s) etag=(%s)',
     mapping.bucket,
@@ -298,6 +324,7 @@ const putObject = async (
     cid,
     md5,
     params.Mtime ?? null,
+    params.Metadata ?? null,
   )
   logger.debug(
     'Created mapping: bucket=(%s) key=(%s) -> cid=(%s) etag=(%s)',
@@ -439,6 +466,12 @@ const copyObject = async (
 
   const mtime = params.Mtime !== undefined ? params.Mtime : source.mtime
 
+  // Metadata directive: undefined ⇒ COPY (inherit the source's metadata); a
+  // value or explicit null ⇒ REPLACE (the destination's metadata is exactly what
+  // the request carried, discarding the source's). Mirrors the mtime handling.
+  const metadata =
+    params.Metadata !== undefined ? params.Metadata : source.metadata
+
   // The destination key is created in the caller's namespace.
   const mapping = await s3ObjectMappingsRepository.createMapping(
     user.oauthProvider,
@@ -448,6 +481,7 @@ const copyObject = async (
     source.cid,
     source.md5,
     mtime,
+    metadata,
   )
 
   logger.debug(
@@ -472,10 +506,10 @@ const abortMultipartUpload = async (
   uploadId: string,
 ): Promise<Result<void, ObjectNotFoundError | ForbiddenError>> => {
   const result = await UploadsUseCases.abortUpload(user, uploadId)
-  // Clear any stashed mtime for this upload once it's genuinely aborted (only
+  // Clear any stashed metadata for this upload once it's genuinely aborted (only
   // on success, so a forbidden/unknown abort doesn't drop another upload's row).
   if (result.isOk()) {
-    await s3ObjectMappingsRepository.deleteMultipartMtime(uploadId)
+    await s3ObjectMappingsRepository.deleteMultipartMeta(uploadId)
   }
   return result
 }

--- a/apps/backend/src/infrastructure/repositories/s3/objectMappings.ts
+++ b/apps/backend/src/infrastructure/repositories/s3/objectMappings.ts
@@ -4,6 +4,32 @@ import { ownershipSQL } from '../objects/ownership.js'
 
 export type { S3ObjectListing }
 
+/**
+ * Standard S3 object metadata persisted per key, beside the content rather than
+ * inside the content hash: it is a property of the S3 key, not of the bytes, so
+ * two keys can point at the same CID with different declared metadata while
+ * content-addressed dedup stays intact. All fields are optional — a field is
+ * present only when the client set the corresponding header on write.
+ *
+ * Content-Type is stored here (verbatim) in addition to the IPLD node's mimeType
+ * so GET/HEAD can return exactly what the client sent — byte-for-byte, with no
+ * framework-injected charset — which the IPLD-derived value cannot guarantee.
+ */
+export interface S3ObjectMetadata {
+  /** Verbatim Content-Type as supplied on write (no charset injected on read). */
+  contentType?: string
+  cacheControl?: string
+  contentLanguage?: string
+  contentDisposition?: string
+  contentEncoding?: string
+  /**
+   * Arbitrary user metadata: the map of x-amz-meta-* entries keyed by the name
+   * after the `x-amz-meta-` prefix (lowercased, as S3 stores them). Excludes the
+   * reserved keys handled elsewhere (mtime, compression, encryption, cid).
+   */
+  userMetadata?: Record<string, string>
+}
+
 export interface S3KeyMapping {
   bucket: string
   key: string
@@ -16,6 +42,11 @@ export interface S3KeyMapping {
    * full precision; null means the object has no client mtime.
    */
   mtime: string | null
+  /**
+   * Standard S3 object metadata (Content-Type, Cache-Control, x-amz-meta-*, …).
+   * null for objects written before metadata persistence was introduced.
+   */
+  metadata: S3ObjectMetadata | null
   /**
    * The user who owns this key. Part of the mapping's identity: the S3 namespace
    * is scoped per user — (owner, bucket, key) is unique — so users never contend
@@ -38,6 +69,8 @@ interface S3KeyMappingDB {
   cid: S3KeyMapping['cid']
   md5: S3KeyMapping['md5']
   mtime: S3KeyMapping['mtime']
+  // pg parses a jsonb column into a JS object on read; null when unset.
+  metadata: S3ObjectMetadata | null
   owner_oauth_provider: S3KeyMapping['ownerOauthProvider']
   owner_oauth_user_id: S3KeyMapping['ownerOauthUserId']
   created_at: S3KeyMapping['createdAt']
@@ -55,6 +88,7 @@ const mapDBToDomain = (db: S3KeyMappingDB): S3KeyMapping => ({
   cid: db.cid,
   md5: db.md5 ?? null,
   mtime: db.mtime ?? null,
+  metadata: db.metadata ?? null,
   ownerOauthProvider: db.owner_oauth_provider,
   ownerOauthUserId: db.owner_oauth_user_id,
   createdAt: db.created_at,
@@ -69,6 +103,7 @@ const createMapping = async (
   cid: string,
   md5: string | null = null,
   mtime: string | null = null,
+  metadata: S3ObjectMetadata | null = null,
 ): Promise<S3KeyMapping> => {
   const db = await getDatabase()
 
@@ -76,18 +111,29 @@ const createMapping = async (
   // OWN row, so there is no cross-user contention to guard against. ON CONFLICT
   // resets deleted_at to NULL so a PutObject to a previously soft-deleted key
   // resurrects it — S3's "PUT after DELETE re-creates the object" (and
-  // TestObjectUpdate, which overwrites in place).
+  // TestObjectUpdate, which overwrites in place). Overwriting a key REPLACES its
+  // metadata wholesale (metadata = $8), matching S3: a PUT redefines the object's
+  // metadata rather than merging into what was there.
   const result = await db.query<S3KeyMappingDB>({
     text: `
       INSERT INTO "S3".object_mappings
-      (owner_oauth_provider, owner_oauth_user_id, bucket, "key", cid, md5, mtime)
-      VALUES ($1, $2, $3, $4, $5, $6, $7)
+      (owner_oauth_provider, owner_oauth_user_id, bucket, "key", cid, md5, mtime, metadata)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
       ON CONFLICT (owner_oauth_provider, owner_oauth_user_id, bucket, "key")
-        DO UPDATE SET cid = $5, md5 = $6, mtime = $7,
+        DO UPDATE SET cid = $5, md5 = $6, mtime = $7, metadata = $8,
           deleted_at = NULL, updated_at = NOW()
       RETURNING *
     `,
-    values: [ownerOauthProvider, ownerOauthUserId, bucket, s3Key, cid, md5, mtime],
+    values: [
+      ownerOauthProvider,
+      ownerOauthUserId,
+      bucket,
+      s3Key,
+      cid,
+      md5,
+      mtime,
+      metadata ? JSON.stringify(metadata) : null,
+    ],
   })
 
   return result.rows.map(mapDBToDomain)[0]
@@ -246,39 +292,48 @@ const listBuckets = async (
   }))
 }
 
-// ── Multipart upload mtime staging ────────────────────────────────────────
-// rclone sends x-amz-meta-mtime on CreateMultipartUpload but not on Complete,
-// and the mapping is only created at completion — so the mtime is stashed by
-// upload id here and read back in completeMultipartUpload. Keyed by the (unique)
-// upload id, so no owner scoping is needed.
+// ── Multipart upload metadata staging ─────────────────────────────────────
+// S3 sends the client mtime and system/user metadata on CreateMultipartUpload
+// but NOT on CompleteMultipartUpload, and the mapping is only created at
+// completion — so both are stashed by upload id here and read back in
+// completeMultipartUpload. Keyed by the (unique) upload id, so no owner scoping
+// is needed. Either value may be absent (an upload can carry metadata but no
+// mtime, or vice versa); a row is written whenever at least one is present.
 
-const setMultipartMtime = async (
+const setMultipartMeta = async (
   uploadId: string,
-  mtime: string,
+  mtime: string | null,
+  metadata: S3ObjectMetadata | null,
 ): Promise<void> => {
   const db = await getDatabase()
   await db.query({
     text: `
-      INSERT INTO "S3".multipart_upload_meta (upload_id, mtime)
-      VALUES ($1, $2)
-      ON CONFLICT (upload_id) DO UPDATE SET mtime = $2
+      INSERT INTO "S3".multipart_upload_meta (upload_id, mtime, metadata)
+      VALUES ($1, $2, $3)
+      ON CONFLICT (upload_id) DO UPDATE SET mtime = $2, metadata = $3
     `,
-    values: [uploadId, mtime],
+    values: [uploadId, mtime, metadata ? JSON.stringify(metadata) : null],
   })
 }
 
-const getMultipartMtime = async (
+const getMultipartMeta = async (
   uploadId: string,
-): Promise<string | null> => {
+): Promise<{ mtime: string | null; metadata: S3ObjectMetadata | null }> => {
   const db = await getDatabase()
-  const result = await db.query<{ mtime: string }>({
-    text: 'SELECT mtime FROM "S3".multipart_upload_meta WHERE upload_id = $1',
+  const result = await db.query<{
+    mtime: string | null
+    metadata: S3ObjectMetadata | null
+  }>({
+    text: 'SELECT mtime, metadata FROM "S3".multipart_upload_meta WHERE upload_id = $1',
     values: [uploadId],
   })
-  return result.rows[0]?.mtime ?? null
+  return {
+    mtime: result.rows[0]?.mtime ?? null,
+    metadata: result.rows[0]?.metadata ?? null,
+  }
 }
 
-const deleteMultipartMtime = async (uploadId: string): Promise<void> => {
+const deleteMultipartMeta = async (uploadId: string): Promise<void> => {
   const db = await getDatabase()
   await db.query({
     text: 'DELETE FROM "S3".multipart_upload_meta WHERE upload_id = $1',
@@ -377,9 +432,9 @@ export const s3ObjectMappingsRepository = {
   softDeleteMapping,
   restoreMappingsByCid,
   countActiveMappingsByCid,
-  setMultipartMtime,
-  getMultipartMtime,
-  deleteMultipartMtime,
+  setMultipartMeta,
+  getMultipartMeta,
+  deleteMultipartMeta,
   listBuckets,
   listObjects,
 }


### PR DESCRIPTION
Closes #786. Unblocks the metadata-fidelity item in the #787 tracker.

The S3 layer persisted only Content-Type (as the IPLD node's mimeType) and mtime, and mutated Content-Type on the way out. S3 clients expect object metadata to round-trip verbatim. This fixes both parts.

## Part 1 — verbatim Content-Type
`GetObject`/`HeadObject` now emit the stored Content-Type via Node's `res.setHeader` (after the shared download-header helper), so Express's `; charset=utf-8` injection is overridden. `text/csv` comes back as `text/csv`; an explicitly-stored charset is preserved.

## Part 2 — persist system + user metadata
A `metadata jsonb` column on `"S3".object_mappings` holds `contentType`, `cacheControl`, `contentLanguage`, `contentDisposition`, `contentEncoding`, and a `userMetadata` map of `x-amz-meta-*` (excluding the reserved `mtime`/`compression`/`encryption`/`cid`). It's:
- captured on PutObject and CreateMultipartUpload,
- threaded through `createMapping` and staged for multipart in `"S3".multipart_upload_meta` (mtime relaxed to nullable; the mtime-only staging trio generalised to `setMultipartMeta`/`getMultipartMeta`/`deleteMultipartMeta`),
- returned verbatim on GET/HEAD,
- carried by CopyObject per `x-amz-metadata-directive` (COPY inherits source, REPLACE uses the request).

A stored `Content-Encoding` is only surfaced when the object isn't internally compressed, so it never double-advertises against Auto Drive's own deflate handling.

Migration is additive and reversible (columns dropped, mtime NOT NULL restored on down).

## Tests
Unit (capture/store/return, copy metadata-directive) + integration (verbatim Content-Type incl. explicit charset, system + user metadata, Content-Encoding, COPY/REPLACE, multipart). `tsc` + `eslint` clean; full backend suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)