### PR TITLE
fix(backend): isolate publish-nodes on a dedicated queue + worker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Auto Drive is a decentralized content-addressed storage platform built on the Au
 
 Yarn 4.2.2 monorepo with workspaces in `apps/`, `packages/`, and `submodules/`.
 
-- **apps/backend** — Express.js API server (ESM, TypeScript). Runs as multiple processes: frontend API, download API, frontend worker, download worker.
+- **apps/backend** — Express.js API server (ESM, TypeScript). Runs as multiple processes: frontend API, download API, frontend worker, download worker, publish worker (dedicated on-chain publisher).
 - **apps/frontend** — Next.js 14 web app (React 18, Tailwind CSS, Zustand, Apollo Client). Routes are under `src/app/[chain]/`.
 - **apps/auth** — Express.js auth microservice (JWT, OAuth via Google/Discord/GitHub, SIWE for Web3). Deployable as AWS Lambda.
 - **apps/hasura** — Hasura GraphQL engine config (migrations and metadata).
@@ -74,7 +74,8 @@ yarn landing dev           # Landing page dev server
 
 Backend can also be started as split processes:
 - `yarn backend start:fe:api` — Frontend API only
-- `yarn backend start:fe:worker` — Upload processing worker only
+- `yarn backend start:fe:worker` — Upload processing worker only (fast frontend tasks)
+- `yarn backend start:publish:worker` — On-chain publishing worker only (dedicated `publish-manager` consumer; must run as a single process)
 - `yarn backend start:download:api` — Download API only
 - `yarn backend start:download:worker` — Download worker only
 
@@ -160,7 +161,7 @@ PostgreSQL with `db-migrate` for migrations. Migration SQL files live in `apps/b
 
 ### Message Queue
 
-RabbitMQ queues: `task-manager`, `download-manager`, `frontend-errors`, `download-errors`. Tasks have a retry mechanism with `retriesLeft` counter.
+RabbitMQ queues: `task-manager`, `download-manager`, `publish-manager`, `frontend-errors`, `download-errors`, `publish-errors`. On-chain publishing (`publish-nodes`, `ensure-object-published`) is isolated on `publish-manager`, consumed only by the single publish worker. Tasks have a retry mechanism with `retriesLeft` counter; a failed task retries on its own queue and lands on the matching `*-errors` queue when retries are exhausted.
 
 ## Code Conventions
 

--- a/apps/backend/.env.sample
+++ b/apps/backend/.env.sample
@@ -20,6 +20,14 @@ CHAIN_CONFIRMATION_DEPTH=25
 # margin. Default 300000ms (5 min).
 CHAIN_TRANSACTION_TIMEOUT_MS=300000
 
+# Backstop timeout for a single publish-manager task (publish-nodes /
+# ensure-object-published). Guards against a transaction that is perpetually
+# re-included never settling and pinning a publish-worker slot forever: on
+# timeout the task is aborted and retried instead of deadlocking. Keep it well
+# above the legitimate batch confirmation time (a 50-node batch drained through
+# CHAIN_TRANSACTION_TIMEOUT_MS-bounded confirmations). Default 3600000ms (60 min).
+PUBLISH_TASK_TIMEOUT_MS=3600000
+
 # ---------------------------------------------------------------------------
 # Pay-with-AI3 / purchased credits feature
 # ---------------------------------------------------------------------------

--- a/apps/backend/__tests__/e2e/uploads/files.spec.ts
+++ b/apps/backend/__tests__/e2e/uploads/files.spec.ts
@@ -234,7 +234,9 @@ files.map((file, index) => {
 
         // Tag the upload
         await UploadsUseCases.tagUpload(cidToString(cid))
-        expect(rabbitMock).toHaveBeenCalledWith('task-manager', {
+        // publish-nodes is isolated on its own queue/worker (publish-manager),
+        // so it is no longer enqueued on the task-manager fast lane.
+        expect(rabbitMock).toHaveBeenCalledWith('publish-manager', {
           id: 'publish-nodes',
           params: {
             nodes: expect.arrayContaining([cidToString(cid)]),

--- a/apps/backend/__tests__/unit/OnchainPublisher.spec.ts
+++ b/apps/backend/__tests__/unit/OnchainPublisher.spec.ts
@@ -46,7 +46,11 @@ describe('OnchainPublisher', () => {
       .spyOn(nodesRepository, 'getNodesBlockchainDataBatch')
       .mockResolvedValue([])
 
-    await OnchainPublisher.publishNodes(nodes.map((e) => e.cid))
+    const controller = new AbortController()
+    await OnchainPublisher.publishNodes(
+      nodes.map((e) => e.cid),
+      controller.signal,
+    )
 
     const transactions = nodes.map((node) => {
       const buffer = Buffer.from(node.encoded_node, 'base64')
@@ -58,7 +62,9 @@ describe('OnchainPublisher', () => {
       }
     })
 
-    expect(submitSpy).toHaveBeenCalledWith(transactions)
+    // The task abort signal must reach the transaction manager so a timed-out
+    // publish task can tear down its in-flight confirmation watches.
+    expect(submitSpy).toHaveBeenCalledWith(transactions, controller.signal)
   })
 
   it('should not publish nodes if they are already published', async () => {
@@ -99,6 +105,7 @@ describe('OnchainPublisher', () => {
         }
       })
 
-    expect(submitSpy).toHaveBeenCalledWith(transactions)
+    // Signal is optional: called without one here, so it forwards undefined.
+    expect(submitSpy).toHaveBeenCalledWith(transactions, undefined)
   })
 })

--- a/apps/backend/__tests__/unit/TaskManager.spec.ts
+++ b/apps/backend/__tests__/unit/TaskManager.spec.ts
@@ -110,6 +110,14 @@ describe('TaskManager', () => {
       )
     })
 
+    it('should subscribe to the publish manager queue', () => {
+      EventRouter.listenPublishEvents()
+      expect(Rabbit.subscribe).toHaveBeenCalledWith(
+        'publish-manager',
+        expect.any(Function),
+      )
+    })
+
     it('should log an error when receiving an invalid task', async () => {
       EventRouter.listenFrontendEvents()
       await subscribeCallback({})
@@ -132,16 +140,35 @@ describe('TaskManager', () => {
       expect(UploadsUseCases.processMigration).toHaveBeenCalledWith('123')
     })
 
+    it('should forward publish-nodes to the publish manager queue without publishing inline', async () => {
+      EventRouter.listenFrontendEvents()
+      const task = {
+        id: 'publish-nodes',
+        params: { nodes: ['node1', 'node2'] },
+        retriesLeft: 3,
+      }
+
+      await subscribeCallback(task)
+
+      // publish-nodes runs on its own worker now; the frontend worker forwards
+      // it to publish-manager rather than signing transactions inline.
+      expect(OnchainPublisher.publishNodes).not.toHaveBeenCalled()
+      expect(Rabbit.publish).toHaveBeenCalledWith(
+        'publish-manager',
+        expect.objectContaining({ id: 'publish-nodes' }),
+      )
+    })
+
     it('should log an error when a task fails and has no retries left', async () => {
       EventRouter.listenFrontendEvents()
       const validTask = {
-        id: 'publish-nodes',
-        params: { nodes: ['node1', 'node2'] },
+        id: 'migrate-upload-nodes',
+        params: { uploadId: '123' },
         retriesLeft: 0,
       }
 
       jest
-        .mocked(OnchainPublisher.publishNodes)
+        .mocked(UploadsUseCases.processMigration)
         .mockImplementationOnce(async () => {
           throw new Error('Test error')
         })
@@ -190,7 +217,7 @@ describe('TaskManager', () => {
 
       expect(Rabbit.publish).toHaveBeenCalledTimes(2)
       expect(Rabbit.publish).toHaveBeenCalledWith('task-manager', tasks[0])
-      expect(Rabbit.publish).toHaveBeenCalledWith('task-manager', tasks[1])
+      expect(Rabbit.publish).toHaveBeenCalledWith('publish-manager', tasks[1])
     })
   })
 })

--- a/apps/backend/__tests__/unit/TaskManager.spec.ts
+++ b/apps/backend/__tests__/unit/TaskManager.spec.ts
@@ -199,6 +199,18 @@ describe('TaskManager', () => {
       expect(Rabbit.publish).toHaveBeenCalledWith('task-manager', task)
     })
 
+    it('should route ensure-object-published to the publish manager queue', () => {
+      const task: Task = {
+        id: 'ensure-object-published',
+        params: { cid: 'cid-ensure' },
+        retriesLeft: 3,
+      }
+
+      EventRouter.publish(task)
+
+      expect(Rabbit.publish).toHaveBeenCalledWith('publish-manager', task)
+    })
+
     it('should publish multiple tasks', () => {
       const tasks: Task[] = [
         {

--- a/apps/backend/__tests__/unit/eventRouter/processors.spec.ts
+++ b/apps/backend/__tests__/unit/eventRouter/processors.spec.ts
@@ -112,10 +112,13 @@ describe('EventRouter Processors', () => {
       expect(tagUploadSpy).toHaveBeenCalledWith('cid123')
     })
 
-    it('should handle ensure-object-published task', async () => {
+    it('should forward ensure-object-published to the dedicated publish queue instead of running it', async () => {
       const ensureObjectPublishedSpy = jest
         .spyOn(NodesUseCases, 'ensureObjectPublished')
         .mockResolvedValue(undefined)
+      const eventRouterPublishSpy = jest
+        .spyOn(EventRouter, 'publish')
+        .mockImplementation(() => undefined)
 
       const task = {
         id: 'ensure-object-published',
@@ -125,7 +128,15 @@ describe('EventRouter Processors', () => {
 
       await processFrontendTask(task)
 
-      expect(ensureObjectPublishedSpy).toHaveBeenCalledWith('cid456')
+      // ensure-object-published signs on-chain (via publishNodes); the frontend
+      // worker must forward it, never run it, to keep publishing single-process.
+      expect(ensureObjectPublishedSpy).not.toHaveBeenCalled()
+      expect(eventRouterPublishSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'ensure-object-published',
+          params: { cid: 'cid456' },
+        }),
+      )
     })
 
     it('should handle watch-intent-tx task', async () => {
@@ -231,6 +242,22 @@ describe('EventRouter Processors', () => {
       await processPublishTask(task)
 
       expect(publishNodesSpy).toHaveBeenCalledWith(['node1', 'node2'])
+    })
+
+    it('should handle ensure-object-published task', async () => {
+      const ensureObjectPublishedSpy = jest
+        .spyOn(NodesUseCases, 'ensureObjectPublished')
+        .mockResolvedValue(undefined)
+
+      const task = {
+        id: 'ensure-object-published',
+        params: { cid: 'cid789' },
+        retriesLeft: 3,
+      }
+
+      await processPublishTask(task)
+
+      expect(ensureObjectPublishedSpy).toHaveBeenCalledWith('cid789')
     })
 
     it('should resolve without publishing for an unknown task', async () => {

--- a/apps/backend/__tests__/unit/eventRouter/processors.spec.ts
+++ b/apps/backend/__tests__/unit/eventRouter/processors.spec.ts
@@ -8,6 +8,8 @@ import {
 } from '@jest/globals'
 import { processFrontendTask } from '../../../src/infrastructure/eventRouter/processors/frontend.js'
 import { processDownloadTask } from '../../../src/infrastructure/eventRouter/processors/download.js'
+import { processPublishTask } from '../../../src/infrastructure/eventRouter/processors/publish.js'
+import { EventRouter } from '../../../src/infrastructure/eventRouter/index.js'
 import { UploadsUseCases } from '../../../src/core/uploads/uploads.js'
 import { NodesUseCases } from '../../../src/core/objects/nodes.js'
 import { OnchainPublisher } from '../../../src/infrastructure/services/upload/onchainPublisher/index.js'
@@ -67,10 +69,13 @@ describe('EventRouter Processors', () => {
       ])
     })
 
-    it('should handle publish-nodes task', async () => {
+    it('should forward publish-nodes to the dedicated publish queue instead of running it', async () => {
       const publishNodesSpy = jest
         .spyOn(OnchainPublisher, 'publishNodes')
         .mockResolvedValue(undefined)
+      const eventRouterPublishSpy = jest
+        .spyOn(EventRouter, 'publish')
+        .mockImplementation(() => undefined)
 
       const task = {
         id: 'publish-nodes',
@@ -80,7 +85,15 @@ describe('EventRouter Processors', () => {
 
       await processFrontendTask(task)
 
-      expect(publishNodesSpy).toHaveBeenCalledWith(['node1'])
+      // The frontend worker must never sign transactions for publish-nodes; it
+      // forwards them so a single process (the publish worker) owns publishing.
+      expect(publishNodesSpy).not.toHaveBeenCalled()
+      expect(eventRouterPublishSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'publish-nodes',
+          params: { nodes: ['node1'] },
+        }),
+      )
     })
 
     it('should handle tag-upload task', async () => {
@@ -200,6 +213,39 @@ describe('EventRouter Processors', () => {
       }
 
       await expect(processDownloadTask(task)).resolves.toBeUndefined()
+    })
+  })
+
+  describe('processPublishTask', () => {
+    it('should handle publish-nodes task', async () => {
+      const publishNodesSpy = jest
+        .spyOn(OnchainPublisher, 'publishNodes')
+        .mockResolvedValue(undefined)
+
+      const task = {
+        id: 'publish-nodes',
+        params: { nodes: ['node1', 'node2'] },
+        retriesLeft: 3,
+      }
+
+      await processPublishTask(task)
+
+      expect(publishNodesSpy).toHaveBeenCalledWith(['node1', 'node2'])
+    })
+
+    it('should resolve without publishing for an unknown task', async () => {
+      const publishNodesSpy = jest
+        .spyOn(OnchainPublisher, 'publishNodes')
+        .mockResolvedValue(undefined)
+
+      const task = {
+        id: 'unknown-task',
+        params: {},
+        retriesLeft: 3,
+      }
+
+      await expect(processPublishTask(task)).resolves.toBeUndefined()
+      expect(publishNodesSpy).not.toHaveBeenCalled()
     })
   })
 })

--- a/apps/backend/__tests__/unit/eventRouter/processors.spec.ts
+++ b/apps/backend/__tests__/unit/eventRouter/processors.spec.ts
@@ -9,7 +9,7 @@ import {
 import { processFrontendTask } from '../../../src/infrastructure/eventRouter/processors/frontend.js'
 import { processDownloadTask } from '../../../src/infrastructure/eventRouter/processors/download.js'
 import { processPublishTask } from '../../../src/infrastructure/eventRouter/processors/publish.js'
-import { EventRouter } from '../../../src/infrastructure/eventRouter/index.js'
+import { Rabbit } from '../../../src/infrastructure/drivers/rabbit.js'
 import { UploadsUseCases } from '../../../src/core/uploads/uploads.js'
 import { NodesUseCases } from '../../../src/core/objects/nodes.js'
 import { OnchainPublisher } from '../../../src/infrastructure/services/upload/onchainPublisher/index.js'
@@ -73,9 +73,9 @@ describe('EventRouter Processors', () => {
       const publishNodesSpy = jest
         .spyOn(OnchainPublisher, 'publishNodes')
         .mockResolvedValue(undefined)
-      const eventRouterPublishSpy = jest
-        .spyOn(EventRouter, 'publish')
-        .mockImplementation(() => undefined)
+      const rabbitPublishSpy = jest
+        .spyOn(Rabbit, 'publish')
+        .mockResolvedValue(undefined)
 
       const task = {
         id: 'publish-nodes',
@@ -86,9 +86,11 @@ describe('EventRouter Processors', () => {
       await processFrontendTask(task)
 
       // The frontend worker must never sign transactions for publish-nodes; it
-      // forwards them so a single process (the publish worker) owns publishing.
+      // forwards them to the publish-manager queue so a single process (the
+      // publish worker) owns publishing.
       expect(publishNodesSpy).not.toHaveBeenCalled()
-      expect(eventRouterPublishSpy).toHaveBeenCalledWith(
+      expect(rabbitPublishSpy).toHaveBeenCalledWith(
+        'publish-manager',
         expect.objectContaining({
           id: 'publish-nodes',
           params: { nodes: ['node1'] },
@@ -116,9 +118,9 @@ describe('EventRouter Processors', () => {
       const ensureObjectPublishedSpy = jest
         .spyOn(NodesUseCases, 'ensureObjectPublished')
         .mockResolvedValue(undefined)
-      const eventRouterPublishSpy = jest
-        .spyOn(EventRouter, 'publish')
-        .mockImplementation(() => undefined)
+      const rabbitPublishSpy = jest
+        .spyOn(Rabbit, 'publish')
+        .mockResolvedValue(undefined)
 
       const task = {
         id: 'ensure-object-published',
@@ -131,7 +133,8 @@ describe('EventRouter Processors', () => {
       // ensure-object-published signs on-chain (via publishNodes); the frontend
       // worker must forward it, never run it, to keep publishing single-process.
       expect(ensureObjectPublishedSpy).not.toHaveBeenCalled()
-      expect(eventRouterPublishSpy).toHaveBeenCalledWith(
+      expect(rabbitPublishSpy).toHaveBeenCalledWith(
+        'publish-manager',
         expect.objectContaining({
           id: 'ensure-object-published',
           params: { cid: 'cid456' },

--- a/apps/backend/__tests__/unit/eventRouter/processors.spec.ts
+++ b/apps/backend/__tests__/unit/eventRouter/processors.spec.ts
@@ -277,5 +277,60 @@ describe('EventRouter Processors', () => {
       await expect(processPublishTask(task)).resolves.toBeUndefined()
       expect(publishNodesSpy).not.toHaveBeenCalled()
     })
+
+    it('retries a failed publish task back onto publish-manager, never the fast lane', async () => {
+      jest
+        .spyOn(OnchainPublisher, 'publishNodes')
+        .mockRejectedValue(new Error('publish boom'))
+      const rabbitPublishSpy = jest
+        .spyOn(Rabbit, 'publish')
+        .mockResolvedValue(undefined)
+
+      const task = {
+        id: 'publish-nodes',
+        params: { nodes: ['node1'] },
+        retriesLeft: 2,
+      }
+
+      await processPublishTask(task)
+
+      // The retry must stay on the isolated publish lane, decremented, and must
+      // never leak back to task-manager — keeping publishing failures out of the
+      // fast frontend lane is the whole point of the dedicated queue.
+      expect(rabbitPublishSpy).toHaveBeenCalledWith(
+        'publish-manager',
+        expect.objectContaining({ id: 'publish-nodes', retriesLeft: 1 }),
+      )
+      expect(rabbitPublishSpy).not.toHaveBeenCalledWith(
+        'task-manager',
+        expect.anything(),
+      )
+    })
+
+    it('routes an exhausted publish task to publish-errors, not the fast lane', async () => {
+      jest
+        .spyOn(OnchainPublisher, 'publishNodes')
+        .mockRejectedValue(new Error('publish boom'))
+      const rabbitPublishSpy = jest
+        .spyOn(Rabbit, 'publish')
+        .mockResolvedValue(undefined)
+
+      const task = {
+        id: 'publish-nodes',
+        params: { nodes: ['node1'] },
+        retriesLeft: 0,
+      }
+
+      await processPublishTask(task)
+
+      expect(rabbitPublishSpy).toHaveBeenCalledWith(
+        'publish-errors',
+        expect.objectContaining({ id: 'publish-nodes' }),
+      )
+      expect(rabbitPublishSpy).not.toHaveBeenCalledWith(
+        'task-manager',
+        expect.anything(),
+      )
+    })
   })
 })

--- a/apps/backend/__tests__/unit/eventRouter/processors.spec.ts
+++ b/apps/backend/__tests__/unit/eventRouter/processors.spec.ts
@@ -244,7 +244,10 @@ describe('EventRouter Processors', () => {
 
       await processPublishTask(task)
 
-      expect(publishNodesSpy).toHaveBeenCalledWith(['node1', 'node2'])
+      expect(publishNodesSpy).toHaveBeenCalledWith(
+        ['node1', 'node2'],
+        expect.any(AbortSignal),
+      )
     })
 
     it('should handle ensure-object-published task', async () => {
@@ -260,7 +263,10 @@ describe('EventRouter Processors', () => {
 
       await processPublishTask(task)
 
-      expect(ensureObjectPublishedSpy).toHaveBeenCalledWith('cid789')
+      expect(ensureObjectPublishedSpy).toHaveBeenCalledWith(
+        'cid789',
+        expect.any(AbortSignal),
+      )
     })
 
     it('should resolve without publishing for an unknown task', async () => {

--- a/apps/backend/__tests__/unit/utils/queue.spec.ts
+++ b/apps/backend/__tests__/unit/utils/queue.spec.ts
@@ -1,0 +1,59 @@
+import {
+  jest,
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+} from '@jest/globals'
+import { isTaskQueueBusy } from '../../../src/shared/utils/queue.js'
+import { Rabbit } from '../../../src/infrastructure/drivers/rabbit.js'
+
+describe('isTaskQueueBusy', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('defers on any pending message in task-manager by default (threshold 0)', async () => {
+    jest.spyOn(Rabbit, 'getMessageCount').mockResolvedValue(1)
+    await expect(isTaskQueueBusy('caller')).resolves.toBe(true)
+  })
+
+  it('does not defer when the default queue is empty', async () => {
+    jest.spyOn(Rabbit, 'getMessageCount').mockResolvedValue(0)
+    await expect(isTaskQueueBusy('caller')).resolves.toBe(false)
+  })
+
+  it('inspects the requested queue', async () => {
+    const spy = jest.spyOn(Rabbit, 'getMessageCount').mockResolvedValue(0)
+    await isTaskQueueBusy('caller', 'publish-manager', 100)
+    expect(spy).toHaveBeenCalledWith('publish-manager')
+  })
+
+  it('does not defer while depth is at or below the threshold', async () => {
+    jest.spyOn(Rabbit, 'getMessageCount').mockResolvedValue(100)
+    await expect(
+      isTaskQueueBusy('caller', 'publish-manager', 100),
+    ).resolves.toBe(false)
+  })
+
+  it('defers once depth exceeds the threshold', async () => {
+    jest.spyOn(Rabbit, 'getMessageCount').mockResolvedValue(101)
+    await expect(
+      isTaskQueueBusy('caller', 'publish-manager', 100),
+    ).resolves.toBe(true)
+  })
+
+  it('proceeds (returns false) when the depth check throws', async () => {
+    jest
+      .spyOn(Rabbit, 'getMessageCount')
+      .mockRejectedValue(new Error('broker unavailable'))
+    await expect(
+      isTaskQueueBusy('caller', 'publish-manager', 100),
+    ).resolves.toBe(false)
+  })
+})

--- a/apps/backend/__tests__/unit/utils/queue.spec.ts
+++ b/apps/backend/__tests__/unit/utils/queue.spec.ts
@@ -28,9 +28,11 @@ describe('isTaskQueueBusy', () => {
     await expect(isTaskQueueBusy('caller')).resolves.toBe(false)
   })
 
-  it('inspects the requested queue', async () => {
+  it('inspects the requested queue and returns false when below threshold', async () => {
     const spy = jest.spyOn(Rabbit, 'getMessageCount').mockResolvedValue(0)
-    await isTaskQueueBusy('caller', 'publish-manager', 100)
+    await expect(
+      isTaskQueueBusy('caller', 'publish-manager', 100),
+    ).resolves.toBe(false)
     expect(spy).toHaveBeenCalledWith('publish-manager')
   })
 

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -16,6 +16,7 @@
     "start:download": "node dist/app/servers/download.js",
     "start:download:api": "node dist/app/apis/download.js",
     "start:download:worker": "node dist/app/servers/downloadWorker.js",
+    "start:publish:worker": "node dist/app/servers/publishWorker.js",
     "lint": "eslint . "
   },
   "dependencies": {

--- a/apps/backend/src/app/servers/frontend.ts
+++ b/apps/backend/src/app/servers/frontend.ts
@@ -12,6 +12,12 @@
     '../../infrastructure/services/paymentManager/index.js'
   )
   EventRouter.listenFrontendEvents()
+  // This all-in-one server also consumes publish-manager so a single-process
+  // deployment (e.g. local `start:fe`) still publishes nodes. In the split
+  // production topology this queue is served by the dedicated publish worker
+  // (start:publish:worker) instead. Publishing runs in a single process either
+  // way, keeping signing-account nonces collision-free.
+  EventRouter.listenPublishEvents()
   if (
     config.featureFlags.flags.buyCredits.active ||
     config.featureFlags.flags.buyCredits.staffOnly

--- a/apps/backend/src/app/servers/publishWorker.ts
+++ b/apps/backend/src/app/servers/publishWorker.ts
@@ -22,6 +22,12 @@
   // second concurrent publisher would hand out colliding nonces. Run this
   // worker as a single replica and do not enable publish-nodes handling
   // elsewhere.
+  //
+  // Deploy note: the pre-isolation frontend worker signed publish-nodes inline,
+  // so during a rolling upgrade an old start:fe:worker can still be signing when
+  // this worker starts. The compose `depends_on: backend-worker` sequences the
+  // standard single-host deploy so the old worker is stopped first; other deploy
+  // models must ensure the old frontend worker is gone before this worker signs.
   EventRouter.listenPublishEvents()
   logger.info('Publish worker started, consuming publish-manager queue')
 

--- a/apps/backend/src/app/servers/publishWorker.ts
+++ b/apps/backend/src/app/servers/publishWorker.ts
@@ -1,0 +1,37 @@
+;(async () => {
+  if (process.env.NODE_ENV === 'production') {
+    await import('./awsSetup.js').then(({ setupFinished }) => setupFinished)
+  }
+
+  await import('../../app/apis/worker.js')
+  const { EventRouter } = await import(
+    '../../infrastructure/eventRouter/index.js'
+  )
+  const { Rabbit } = await import('../../infrastructure/drivers/rabbit.js')
+  const { createLogger } = await import(
+    '../../infrastructure/drivers/logger.js'
+  )
+  const logger = createLogger('servers:publishWorker')
+
+  // Dedicated consumer for the publish-manager queue. On-chain publishing
+  // blocks for the confirmation-depth window per batch; isolating it in its own
+  // process keeps those waits off the frontend worker's task-manager slots.
+  //
+  // IMPORTANT: on-chain publishing must run in exactly one process. Signing
+  // accounts' nonces are tracked in-memory per process (see accounts.ts), so a
+  // second concurrent publisher would hand out colliding nonces. Run this
+  // worker as a single replica and do not enable publish-nodes handling
+  // elsewhere.
+  EventRouter.listenPublishEvents()
+  logger.info('Publish worker started, consuming publish-manager queue')
+
+  const shutdown = async () => {
+    logger.info('Shutting down publish worker...')
+    await Rabbit.close()
+    logger.info('Publish worker shut down successfully')
+    process.exit(0)
+  }
+
+  process.on('SIGTERM', shutdown)
+  process.on('SIGINT', shutdown)
+})()

--- a/apps/backend/src/app/servers/publishWorker.ts
+++ b/apps/backend/src/app/servers/publishWorker.ts
@@ -30,23 +30,30 @@
   // standard single-host deploy so the old worker is stopped first; other deploy
   // models must ensure the old frontend worker is gone before this worker signs.
 
-  // Gate on the same flag as the frontend worker's task-manager consumer.
-  // backend-publish-worker shares backend-worker's (frontend/frontend-worker)
-  // profiles, so without this gate every host in those profiles would begin
-  // signing — including hosts where TASK_MANAGER_ACTIVE/ALL_SERVICES_ACTIVE is
-  // unset or TASK_MANAGER_DISABLED=true, which publish nothing today. That is
-  // exactly the dual-signer nonce collision this worker exists to prevent, only
-  // in steady state rather than during a deploy. Tying publishing to
-  // taskManager.active keeps it on precisely the single host that runs the
-  // frontend worker's task-manager consumer (one signer), and mirrors the
-  // frontend worker's own no-services exit.
-  if (!config.featureFlags.flags.taskManager.active) {
-    logger.info('Task manager inactive, publish worker has nothing to do, exiting')
-    process.exit(1)
+  // Gate publishing on the same flag as the frontend worker's task-manager
+  // consumer. backend-publish-worker shares backend-worker's
+  // (frontend/frontend-worker) profiles, so a host in those profiles that is not
+  // the task-manager host must not start signing here — that is exactly the
+  // dual-signer nonce collision this worker exists to prevent, in steady state
+  // rather than during a deploy. Tying it to taskManager.active keeps signing on
+  // precisely the single host that runs the frontend worker's task-manager
+  // consumer (one signer).
+  //
+  // When the flag is off we stay up but IDLE rather than exiting: apis/worker.js
+  // already serves /health (keeping the process alive), and exiting under the
+  // service's `restart: unless-stopped` policy would crash-loop the container —
+  // Docker restarts it on ANY exit code, so a lower exit code would not help.
+  // Idling consumes nothing (no signing, so the safety goal holds) while keeping
+  // the health probe green, instead of a pointless restart loop.
+  if (config.featureFlags.flags.taskManager.active) {
+    EventRouter.listenPublishEvents()
+    logger.info('Publish worker started, consuming publish-manager queue')
+  } else {
+    logger.warn(
+      'Task manager inactive on this host; publish worker idling without ' +
+        'consuming publish-manager (no signing).',
+    )
   }
-
-  EventRouter.listenPublishEvents()
-  logger.info('Publish worker started, consuming publish-manager queue')
 
   const shutdown = async () => {
     logger.info('Shutting down publish worker...')

--- a/apps/backend/src/app/servers/publishWorker.ts
+++ b/apps/backend/src/app/servers/publishWorker.ts
@@ -8,6 +8,7 @@
     '../../infrastructure/eventRouter/index.js'
   )
   const { Rabbit } = await import('../../infrastructure/drivers/rabbit.js')
+  const { config } = await import('../../config.js')
   const { createLogger } = await import(
     '../../infrastructure/drivers/logger.js'
   )
@@ -28,6 +29,22 @@
   // this worker starts. The compose `depends_on: backend-worker` sequences the
   // standard single-host deploy so the old worker is stopped first; other deploy
   // models must ensure the old frontend worker is gone before this worker signs.
+
+  // Gate on the same flag as the frontend worker's task-manager consumer.
+  // backend-publish-worker shares backend-worker's (frontend/frontend-worker)
+  // profiles, so without this gate every host in those profiles would begin
+  // signing — including hosts where TASK_MANAGER_ACTIVE/ALL_SERVICES_ACTIVE is
+  // unset or TASK_MANAGER_DISABLED=true, which publish nothing today. That is
+  // exactly the dual-signer nonce collision this worker exists to prevent, only
+  // in steady state rather than during a deploy. Tying publishing to
+  // taskManager.active keeps it on precisely the single host that runs the
+  // frontend worker's task-manager consumer (one signer), and mirrors the
+  // frontend worker's own no-services exit.
+  if (!config.featureFlags.flags.taskManager.active) {
+    logger.info('Task manager inactive, publish worker has nothing to do, exiting')
+    process.exit(1)
+  }
+
   EventRouter.listenPublishEvents()
   logger.info('Publish worker started, consuming publish-manager queue')
 

--- a/apps/backend/src/config.ts
+++ b/apps/backend/src/config.ts
@@ -66,6 +66,14 @@ export const config = {
     // ≈ 1.7 hours — generous enough to not interfere with slow-but-active
     // publishing, while catching genuinely stalled objects.
     stalenessThresholdBlocks: Number(env('PUBLISHING_RECOVERY_STALENESS_BLOCKS', '1000')),
+    // Skip a recovery cycle when publish-manager already holds more than this
+    // many ready (not-yet-started) tasks. Recovery's output (publish-nodes)
+    // lands on publish-manager, so an unchecked recovery would keep piling
+    // duplicate publish tasks onto a saturated queue while confirmations are
+    // stalled, growing the backlog without bound. A threshold (not > 0) is
+    // deliberate: publish-manager legitimately holds a shallow backlog while
+    // batches await confirmation, and that must not suppress recovery.
+    publishManagerBacklogLimit: Number(env('PUBLISHING_RECOVERY_PUBLISH_BACKLOG_LIMIT', '100')),
   },
   filesGateway: {
     url: env('FILES_GATEWAY_URL'),

--- a/apps/backend/src/config.ts
+++ b/apps/backend/src/config.ts
@@ -58,6 +58,27 @@ export const config = {
   reconciliation: {
     intervalMs: Number(env('RECONCILIATION_INTERVAL_MS', '300000')), // 5 minutes
   },
+  publishing: {
+    // Backstop timeout for a single on-chain publishing task (publish-nodes /
+    // ensure-object-published) on the publish-manager worker. The per-transaction
+    // timeout in transactionManager is re-armed on every `isInBlock`, so a
+    // transaction that is perpetually re-included (the failure mode this worker
+    // isolates) never settles and its handler never returns — holding a prefetch
+    // slot indefinitely. This handler-level timeout aborts such a task so it
+    // retries with a fresh nonce, turning a permanent stall into a bounded retry
+    // (and eventually publish-errors) instead of a silent deadlock of the whole
+    // publish worker.
+    //
+    // It must sit comfortably ABOVE the legitimate worst case so it never fires
+    // for merely-slow batches: a batch is up to PUBLISH_BATCH_SIZE (50) remarks,
+    // drained through the shared pLimit(maxConcurrentUploads) across all in-flight
+    // tasks, each transaction taking ~confirmationDepth blocks (plus inclusion
+    // latency) to confirm. The 60-minute default clears a heavy multi-batch
+    // backlog with headroom; raise it if you raise confirmationDepth /
+    // transactionTimeoutMs or run under sustained congestion. The real cure is
+    // the confirmation-watch fix (separate PR); this is containment.
+    taskTimeoutMs: positiveIntEnv('PUBLISH_TASK_TIMEOUT_MS', 3600000),
+  },
   publishingRecovery: {
     intervalMs: Number(env('PUBLISHING_RECOVERY_INTERVAL_MS', '300000')), // 5 minutes
     maxObjectsPerCycle: Number(env('PUBLISHING_RECOVERY_MAX_PER_CYCLE', '5')),

--- a/apps/backend/src/core/objects/nodes.ts
+++ b/apps/backend/src/core/objects/nodes.ts
@@ -252,13 +252,19 @@ const setPublishedOn = async (
   return
 }
 
-const ensureObjectPublished = async (cid: string): Promise<void> => {
+const ensureObjectPublished = async (
+  cid: string,
+  signal?: AbortSignal,
+): Promise<void> => {
   const nodes = await nodesRepository.getNodesByRootCid(cid)
   if (nodes.length === 0) {
     throw new Error(`Nodes not found for ${cid}`)
   }
 
-  await OnchainPublisher.publishNodes(nodes.map((node) => node.cid))
+  await OnchainPublisher.publishNodes(
+    nodes.map((node) => node.cid),
+    signal,
+  )
 }
 
 const handleRepeatedNodes = async (nodes: Node[]): Promise<void> => {

--- a/apps/backend/src/infrastructure/drivers/rabbit.ts
+++ b/apps/backend/src/infrastructure/drivers/rabbit.ts
@@ -11,7 +11,7 @@ type Queue = (typeof queues)[number]
 
 const logger = createLogger('drivers:rabbit')
 
-const queues = ['task-manager', 'download-manager'] as const
+const queues = ['task-manager', 'download-manager', 'publish-manager'] as const
 const subscriptions: Partial<Record<Queue, SubscriptionCallback[]>> = {}
 
 let channelPromise: Promise<Channel> | null = null

--- a/apps/backend/src/infrastructure/drivers/rabbit.ts
+++ b/apps/backend/src/infrastructure/drivers/rabbit.ts
@@ -7,7 +7,7 @@ type SubscriptionCallback = (
   message: Record<string, unknown>,
 ) => Promise<unknown>
 
-type Queue = (typeof queues)[number]
+export type Queue = (typeof queues)[number]
 
 const logger = createLogger('drivers:rabbit')
 
@@ -125,7 +125,11 @@ const subscribe = async (
   }
 }
 
-const getMessageCount = async (queue: string): Promise<number> => {
+// Typed to the known `Queue` union rather than `string`: checkQueue against a
+// non-existent queue returns a 404 that tears down the shared channel (breaking
+// every concurrent publish/consume until keepAlive rebuilds it), so a typo'd
+// queue name must fail at compile time, not at runtime.
+const getMessageCount = async (queue: Queue): Promise<number> => {
   const channel = await getChannel()
   const result = await channel.checkQueue(queue)
   return result.messageCount

--- a/apps/backend/src/infrastructure/eventRouter/index.ts
+++ b/apps/backend/src/infrastructure/eventRouter/index.ts
@@ -45,8 +45,11 @@ const getTargetQueueByTask = (task: Task) => {
       return 'download-manager'
     // On-chain publishing blocks for the confirmation-depth window per batch;
     // route it to a dedicated queue/worker so those waits never hold up the
-    // fast frontend tasks on task-manager.
+    // fast frontend tasks on task-manager. publish-nodes and
+    // ensure-object-published both sign via the publisher, so they must share
+    // the single publish worker (signing-account nonces are per-process).
     case 'publish-nodes':
+    case 'ensure-object-published':
       return 'publish-manager'
     default:
       return 'task-manager'

--- a/apps/backend/src/infrastructure/eventRouter/index.ts
+++ b/apps/backend/src/infrastructure/eventRouter/index.ts
@@ -7,6 +7,10 @@ import {
   frontendErrorPublishedQueue,
   processFrontendTask,
 } from './processors/frontend.js'
+import {
+  processPublishTask,
+  publishErrorPublishedQueue,
+} from './processors/publish.js'
 import { Task } from './tasks.js'
 
 export const EventRouter = {
@@ -15,6 +19,9 @@ export const EventRouter = {
   },
   listenDownloadEvents: () => {
     Rabbit.subscribe('download-manager', processDownloadTask)
+  },
+  listenPublishEvents: () => {
+    Rabbit.subscribe('publish-manager', processPublishTask)
   },
   publish: (tasks: Task[] | Task) => {
     if (Array.isArray(tasks)) {
@@ -36,6 +43,11 @@ const getTargetQueueByTask = (task: Task) => {
     case 'object-archived':
     case 'populate-cache':
       return 'download-manager'
+    // On-chain publishing blocks for the confirmation-depth window per batch;
+    // route it to a dedicated queue/worker so those waits never hold up the
+    // fast frontend tasks on task-manager.
+    case 'publish-nodes':
+      return 'publish-manager'
     default:
       return 'task-manager'
   }
@@ -47,6 +59,8 @@ const getFailedTaskQueue = (task: Task) => {
       return frontendErrorPublishedQueue
     case 'download-manager':
       return downloadErrorPublishedQueue
+    case 'publish-manager':
+      return publishErrorPublishedQueue
     default:
       throw new Error(`Unknown task: ${task.id}`)
   }

--- a/apps/backend/src/infrastructure/eventRouter/processors/frontend.ts
+++ b/apps/backend/src/infrastructure/eventRouter/processors/frontend.ts
@@ -3,33 +3,32 @@ import { ReconciliationUseCases } from '../../../core/objects/reconciliation.js'
 import { PublishingRecoveryUseCases } from '../../../core/objects/publishingRecovery.js'
 import { UploadsUseCases } from '../../../core/uploads/uploads.js'
 import { EventRouter } from '../index.js'
-import { Task, createTask } from '../tasks.js'
+import { Task } from '../tasks.js'
 import { createHandlerWithRetries } from '../utils.js'
 import { paymentManager } from '../../services/paymentManager/index.js'
 
 export const frontendErrorPublishedQueue = 'frontend-errors'
 
 export const processFrontendTask = createHandlerWithRetries(
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  ({ id, params }: Task, _signal: AbortSignal) => {
+  (task: Task) => {
+    const { id, params } = task
     if (id === 'migrate-upload-nodes') {
       return UploadsUseCases.processMigration(params.uploadId)
     } else if (id === 'archive-objects') {
       return NodesUseCases.processNodeArchived(params.objects)
-    } else if (id === 'publish-nodes') {
-      // publish-nodes now runs on its own queue/worker (publish-manager) so its
-      // multi-minute on-chain confirmation waits never block the fast tasks on
-      // task-manager. A publish-nodes arriving here was enqueued on task-manager
-      // before this routing change (or is in flight during a rolling deploy):
-      // forward it to the dedicated queue rather than running it, so on-chain
-      // publishing stays in a single process and signing-account nonces never
-      // collide across workers.
-      EventRouter.publish(createTask({ id, params: { nodes: params.nodes } }))
+    } else if (id === 'publish-nodes' || id === 'ensure-object-published') {
+      // Both of these sign transactions via the on-chain publisher, which now
+      // runs on the dedicated publish worker (publish-manager). Two reasons they
+      // must not run here: (1) on-chain confirmation takes minutes per batch and
+      // would hold this fast lane's prefetch slots; (2) publishing must happen
+      // in a single process because signing-account nonces are tracked in-memory
+      // per process, so a second signer would collide. Forward any that still
+      // arrive here (enqueued on task-manager before this routing change, or in
+      // flight during a rolling deploy) rather than executing them.
+      EventRouter.publish(task)
       return Promise.resolve()
     } else if (id === 'tag-upload') {
       return UploadsUseCases.tagUpload(params.cid)
-    } else if (id === 'ensure-object-published') {
-      return NodesUseCases.ensureObjectPublished(params.cid)
     } else if (id === 'watch-intent-tx') {
       return paymentManager.watchTransaction(params.txHash)
     } else if (id === 'reconcile-archival') {

--- a/apps/backend/src/infrastructure/eventRouter/processors/frontend.ts
+++ b/apps/backend/src/infrastructure/eventRouter/processors/frontend.ts
@@ -2,7 +2,7 @@ import { NodesUseCases } from '../../../core/objects/nodes.js'
 import { ReconciliationUseCases } from '../../../core/objects/reconciliation.js'
 import { PublishingRecoveryUseCases } from '../../../core/objects/publishingRecovery.js'
 import { UploadsUseCases } from '../../../core/uploads/uploads.js'
-import { EventRouter } from '../index.js'
+import { Rabbit } from '../../drivers/rabbit.js'
 import { Task } from '../tasks.js'
 import { createHandlerWithRetries } from '../utils.js'
 import { paymentManager } from '../../services/paymentManager/index.js'
@@ -25,8 +25,13 @@ export const processFrontendTask = createHandlerWithRetries(
       // per process, so a second signer would collide. Forward any that still
       // arrive here (enqueued on task-manager before this routing change, or in
       // flight during a rolling deploy) rather than executing them.
-      EventRouter.publish(task)
-      return Promise.resolve()
+      //
+      // Return the enqueue promise so createHandlerWithRetries acks the
+      // task-manager message only after the task is durably on publish-manager.
+      // Resolving before the hand-off completes would ack first and drop the
+      // task with no redelivery if this process crashed in between. Both ids
+      // route to the single publish-manager queue (see getTargetQueueByTask).
+      return Rabbit.publish('publish-manager', task)
     } else if (id === 'tag-upload') {
       return UploadsUseCases.tagUpload(params.cid)
     } else if (id === 'watch-intent-tx') {

--- a/apps/backend/src/infrastructure/eventRouter/processors/frontend.ts
+++ b/apps/backend/src/infrastructure/eventRouter/processors/frontend.ts
@@ -1,9 +1,9 @@
-import { OnchainPublisher } from '../../services/upload/onchainPublisher/index.js'
 import { NodesUseCases } from '../../../core/objects/nodes.js'
 import { ReconciliationUseCases } from '../../../core/objects/reconciliation.js'
 import { PublishingRecoveryUseCases } from '../../../core/objects/publishingRecovery.js'
 import { UploadsUseCases } from '../../../core/uploads/uploads.js'
-import { Task } from '../tasks.js'
+import { EventRouter } from '../index.js'
+import { Task, createTask } from '../tasks.js'
 import { createHandlerWithRetries } from '../utils.js'
 import { paymentManager } from '../../services/paymentManager/index.js'
 
@@ -17,7 +17,15 @@ export const processFrontendTask = createHandlerWithRetries(
     } else if (id === 'archive-objects') {
       return NodesUseCases.processNodeArchived(params.objects)
     } else if (id === 'publish-nodes') {
-      return OnchainPublisher.publishNodes(params.nodes)
+      // publish-nodes now runs on its own queue/worker (publish-manager) so its
+      // multi-minute on-chain confirmation waits never block the fast tasks on
+      // task-manager. A publish-nodes arriving here was enqueued on task-manager
+      // before this routing change (or is in flight during a rolling deploy):
+      // forward it to the dedicated queue rather than running it, so on-chain
+      // publishing stays in a single process and signing-account nonces never
+      // collide across workers.
+      EventRouter.publish(createTask({ id, params: { nodes: params.nodes } }))
+      return Promise.resolve()
     } else if (id === 'tag-upload') {
       return UploadsUseCases.tagUpload(params.cid)
     } else if (id === 'ensure-object-published') {

--- a/apps/backend/src/infrastructure/eventRouter/processors/publish.ts
+++ b/apps/backend/src/infrastructure/eventRouter/processors/publish.ts
@@ -1,0 +1,31 @@
+import { OnchainPublisher } from '../../services/upload/onchainPublisher/index.js'
+import { Task } from '../tasks.js'
+import { createHandlerWithRetries } from '../utils.js'
+import { createLogger } from '../../drivers/logger.js'
+
+const logger = createLogger('eventRouter:processor:publish')
+
+export const publishErrorPublishedQueue = 'publish-errors'
+
+// Dedicated processor for on-chain publishing. `publish-nodes` submits each
+// node as a transaction and only resolves after `confirmationDepth` blocks are
+// built on top (~2.5-5 min per batch, see transactionManager.ts). Running it on
+// its own queue/worker keeps those long confirmation waits from holding
+// task-manager prefetch slots and starving the fast frontend tasks that share
+// them (migrate-upload-nodes, archive-objects, tag-upload, ...).
+export const processPublishTask = createHandlerWithRetries(
+  ({ id, params }: Task) => {
+    if (id === 'publish-nodes') {
+      return OnchainPublisher.publishNodes(params.nodes)
+    } else {
+      logger.error(
+        'Received task %s but no handler found (processors/publish.ts)',
+        id,
+      )
+      throw new Error(`Received task ${id} but no handler found.`)
+    }
+  },
+  {
+    errorPublishQueue: publishErrorPublishedQueue,
+  },
+)

--- a/apps/backend/src/infrastructure/eventRouter/processors/publish.ts
+++ b/apps/backend/src/infrastructure/eventRouter/processors/publish.ts
@@ -1,4 +1,5 @@
 import { OnchainPublisher } from '../../services/upload/onchainPublisher/index.js'
+import { NodesUseCases } from '../../../core/objects/nodes.js'
 import { Task } from '../tasks.js'
 import { createHandlerWithRetries } from '../utils.js'
 import { createLogger } from '../../drivers/logger.js'
@@ -7,16 +8,20 @@ const logger = createLogger('eventRouter:processor:publish')
 
 export const publishErrorPublishedQueue = 'publish-errors'
 
-// Dedicated processor for on-chain publishing. `publish-nodes` submits each
-// node as a transaction and only resolves after `confirmationDepth` blocks are
-// built on top (~2.5-5 min per batch, see transactionManager.ts). Running it on
-// its own queue/worker keeps those long confirmation waits from holding
-// task-manager prefetch slots and starving the fast frontend tasks that share
-// them (migrate-upload-nodes, archive-objects, tag-upload, ...).
+// Dedicated processor for on-chain publishing. Both `publish-nodes` and
+// `ensure-object-published` sign transactions via the on-chain publisher and
+// only resolve after `confirmationDepth` blocks build on top (~2.5-5 min per
+// batch, see transactionManager.ts). Running them on their own queue/worker
+// keeps those long confirmation waits from holding task-manager prefetch slots
+// and starving the fast frontend tasks (migrate-upload-nodes, archive-objects,
+// tag-upload, ...). They share this single worker so signing-account nonces
+// (tracked in-memory per process) never collide across processes.
 export const processPublishTask = createHandlerWithRetries(
   ({ id, params }: Task) => {
     if (id === 'publish-nodes') {
       return OnchainPublisher.publishNodes(params.nodes)
+    } else if (id === 'ensure-object-published') {
+      return NodesUseCases.ensureObjectPublished(params.cid)
     } else {
       logger.error(
         'Received task %s but no handler found (processors/publish.ts)',

--- a/apps/backend/src/infrastructure/eventRouter/processors/publish.ts
+++ b/apps/backend/src/infrastructure/eventRouter/processors/publish.ts
@@ -24,15 +24,17 @@ export const publishErrorPublishedQueue = 'publish-errors'
 //
 // taskTimeoutMs is the backstop for the perpetual-re-inclusion deadlock: without
 // it a handler that never returns would pin a prefetch slot forever (see
-// config.publishing.taskTimeoutMs). On timeout the handler is aborted and the
-// task retries on publish-manager, so a permanent stall degrades to a bounded
-// retry instead of freezing this worker.
+// config.publishing.taskTimeoutMs). On timeout createHandlerWithRetries aborts
+// the signal we forward into the publisher, which tears down the in-flight
+// signAndSend / confirmation-watch subscriptions before the task retries on
+// publish-manager — so a permanent stall degrades to a bounded retry without
+// leaking orphaned watches that would otherwise multiply across retries.
 export const processPublishTask = createHandlerWithRetries(
-  ({ id, params }: Task) => {
+  ({ id, params }: Task, signal: AbortSignal) => {
     if (id === 'publish-nodes') {
-      return OnchainPublisher.publishNodes(params.nodes)
+      return OnchainPublisher.publishNodes(params.nodes, signal)
     } else if (id === 'ensure-object-published') {
-      return NodesUseCases.ensureObjectPublished(params.cid)
+      return NodesUseCases.ensureObjectPublished(params.cid, signal)
     } else {
       logger.error(
         'Received task %s but no handler found (processors/publish.ts)',

--- a/apps/backend/src/infrastructure/eventRouter/processors/publish.ts
+++ b/apps/backend/src/infrastructure/eventRouter/processors/publish.ts
@@ -3,6 +3,7 @@ import { NodesUseCases } from '../../../core/objects/nodes.js'
 import { Task } from '../tasks.js'
 import { createHandlerWithRetries } from '../utils.js'
 import { createLogger } from '../../drivers/logger.js'
+import { config } from '../../../config.js'
 
 const logger = createLogger('eventRouter:processor:publish')
 
@@ -16,6 +17,16 @@ export const publishErrorPublishedQueue = 'publish-errors'
 // and starving the fast frontend tasks (migrate-upload-nodes, archive-objects,
 // tag-upload, ...). They share this single worker so signing-account nonces
 // (tracked in-memory per process) never collide across processes.
+//
+// `ensure-object-published` has no active producer today (nothing enqueues it —
+// see tasks.ts / eventRouter routing); it is handled here defensively so that
+// if it is ever emitted it lands on the single signer rather than the fast lane.
+//
+// taskTimeoutMs is the backstop for the perpetual-re-inclusion deadlock: without
+// it a handler that never returns would pin a prefetch slot forever (see
+// config.publishing.taskTimeoutMs). On timeout the handler is aborted and the
+// task retries on publish-manager, so a permanent stall degrades to a bounded
+// retry instead of freezing this worker.
 export const processPublishTask = createHandlerWithRetries(
   ({ id, params }: Task) => {
     if (id === 'publish-nodes') {
@@ -32,5 +43,6 @@ export const processPublishTask = createHandlerWithRetries(
   },
   {
     errorPublishQueue: publishErrorPublishedQueue,
+    taskTimeoutMs: config.publishing.taskTimeoutMs,
   },
 )

--- a/apps/backend/src/infrastructure/services/publishingRecoveryJob.ts
+++ b/apps/backend/src/infrastructure/services/publishingRecoveryJob.ts
@@ -10,7 +10,15 @@ const logger = createLogger('PublishingRecoveryJob')
 let publishingRecoveryInterval: NodeJS.Timeout | null = null
 
 const enqueuePublishingRecovery = async () => {
-  if (await isTaskQueueBusy('publishing recovery')) return
+  // Defer while either lane has a backlog: recover-publishing itself runs on
+  // task-manager, and the publish-nodes it produces land on publish-manager.
+  // Piling on while either is deep just grows a backlog that isn't draining
+  // (e.g. while on-chain confirmations are stalled).
+  const busy = await isTaskQueueBusy('publishing recovery', [
+    'task-manager',
+    'publish-manager',
+  ])
+  if (busy) return
 
   logger.debug('Enqueuing recover-publishing task')
   EventRouter.publish(

--- a/apps/backend/src/infrastructure/services/publishingRecoveryJob.ts
+++ b/apps/backend/src/infrastructure/services/publishingRecoveryJob.ts
@@ -10,7 +10,23 @@ const logger = createLogger('PublishingRecoveryJob')
 let publishingRecoveryInterval: NodeJS.Timeout | null = null
 
 const enqueuePublishingRecovery = async () => {
+  // Defer while the fast lane is busy (recover-publishing runs on task-manager).
   if (await isTaskQueueBusy('publishing recovery')) return
+
+  // Also defer when the publish lane is genuinely backed up. Recovery's output
+  // (publish-nodes) lands on publish-manager; without this it would keep piling
+  // duplicate publish tasks onto a saturated queue while confirmations are
+  // stalled, growing the backlog without bound. The threshold (not > 0) lets
+  // recovery still run during the shallow backlogs of normal confirmation waits.
+  if (
+    await isTaskQueueBusy(
+      'publishing recovery',
+      'publish-manager',
+      config.publishingRecovery.publishManagerBacklogLimit,
+    )
+  ) {
+    return
+  }
 
   logger.debug('Enqueuing recover-publishing task')
   EventRouter.publish(

--- a/apps/backend/src/infrastructure/services/publishingRecoveryJob.ts
+++ b/apps/backend/src/infrastructure/services/publishingRecoveryJob.ts
@@ -10,15 +10,7 @@ const logger = createLogger('PublishingRecoveryJob')
 let publishingRecoveryInterval: NodeJS.Timeout | null = null
 
 const enqueuePublishingRecovery = async () => {
-  // Defer while either lane has a backlog: recover-publishing itself runs on
-  // task-manager, and the publish-nodes it produces land on publish-manager.
-  // Piling on while either is deep just grows a backlog that isn't draining
-  // (e.g. while on-chain confirmations are stalled).
-  const busy = await isTaskQueueBusy('publishing recovery', [
-    'task-manager',
-    'publish-manager',
-  ])
-  if (busy) return
+  if (await isTaskQueueBusy('publishing recovery')) return
 
   logger.debug('Enqueuing recover-publishing task')
   EventRouter.publish(

--- a/apps/backend/src/infrastructure/services/upload/onchainPublisher/index.ts
+++ b/apps/backend/src/infrastructure/services/upload/onchainPublisher/index.ts
@@ -8,7 +8,7 @@ const logger = createLogger('upload:onchainPublisher')
 
 export const transactionManager = createTransactionManager()
 
-const publishNodes = async (cids: string[]) => {
+const publishNodes = async (cids: string[], signal?: AbortSignal) => {
   logger.info('Uploading %d nodes', cids.length)
 
   const nodes = await nodesRepository.getNodesByCids(cids)
@@ -55,7 +55,7 @@ const publishNodes = async (cids: string[]) => {
     }
   })
 
-  const results = await transactionManager.submit(transactions)
+  const results = await transactionManager.submit(transactions, signal)
   const someNodeFailed = results.some((result) => !result.success)
   if (someNodeFailed) {
     throw new Error('Failed to publish nodes')

--- a/apps/backend/src/infrastructure/services/upload/onchainPublisher/transactionManager.ts
+++ b/apps/backend/src/infrastructure/services/upload/onchainPublisher/transactionManager.ts
@@ -38,6 +38,7 @@ const submitTransaction = (
   keyPair: KeyringPair,
   transaction: SubmittableExtrinsic<'promise'>,
   nonce: number,
+  signal?: AbortSignal,
 ): Promise<TransactionResult> => {
   return new Promise((resolve, reject) => {
     const txHash = transaction.hash.toString()
@@ -70,6 +71,9 @@ const submitTransaction = (
       clearTimeout(timeoutHandle)
       // Remove the API error listener to prevent accumulation
       api.off('error', onApiError)
+      // Stop listening for the task-timeout abort so a settled transaction's
+      // listener doesn't linger on the (long-lived) task signal.
+      signal?.removeEventListener('abort', onAbort)
       if (extrinsicUnsub) {
         extrinsicUnsub()
       }
@@ -90,6 +94,26 @@ const submitTransaction = (
       isResolved = true
       cleanup()
       reject(error)
+    }
+
+    // The publish task's overall timeout (config.publishing.taskTimeoutMs) aborts
+    // this signal when it fires. Settle as a non-fault failure so the account is
+    // resynced (not evicted, see isAccountFault) and — the reason for honoring
+    // the signal — cleanup() tears down the signAndSend / new-heads
+    // subscriptions. Without this the confirmation watch keeps running after the
+    // task has already been retried, and the orphaned watches multiply across
+    // retries.
+    const onAbort = () => {
+      logger.warn(
+        'Transaction aborted before confirmation (task timeout). Tx hash: %s',
+        txHash,
+      )
+      resolveOnce({
+        success: false,
+        txHash,
+        status: 'Aborted',
+        error: 'Publishing task aborted before confirmation',
+      })
     }
 
     // (Re)start the timeout clock. The inclusion phase and the confirmation
@@ -120,6 +144,15 @@ const submitTransaction = (
     }
 
     api.once('error', onApiError)
+
+    // If the task was aborted before this transaction's turn in the pLimit queue
+    // came up, settle immediately without opening any subscription. Otherwise
+    // listen for an abort while in flight (cleanup removes the listener).
+    if (signal?.aborted) {
+      onAbort()
+      return
+    }
+    signal?.addEventListener('abort', onAbort, { once: true })
 
     /**
      * Opens a single new-heads subscription (idempotent across re-inclusions)
@@ -362,6 +395,7 @@ export const createTransactionManager = () => {
 
   const submit = async (
     transactions: Transaction[],
+    signal?: AbortSignal,
   ): Promise<TransactionResult[]> => {
     await ensureInitialized()
 
@@ -379,7 +413,7 @@ export const createTransactionManager = () => {
         )
 
         return pLimitted(() =>
-          submitTransaction(api, account, trx, nonce)
+          submitTransaction(api, account, trx, nonce, signal)
             .catch((error) => {
               logger.error(error as Error, 'Transaction submission failed')
               return {

--- a/apps/backend/src/shared/utils/queue.ts
+++ b/apps/backend/src/shared/utils/queue.ts
@@ -6,24 +6,31 @@ const logger = createLogger('utils:queue')
 const TASK_MANAGER_QUEUE = 'task-manager'
 
 /**
- * Returns true when the task-manager queue has pending messages,
- * signalling that callers should defer non-urgent work.
+ * Returns true when any of the given queues has pending messages, signalling
+ * that callers should defer non-urgent work. Defaults to the task-manager
+ * (fast) lane; callers whose work lands on another queue — e.g. publishing
+ * recovery, whose publish-nodes tasks run on publish-manager — should pass
+ * that queue too so they don't keep deepening a backlog that isn't draining.
  *
  * On check failure the function returns false (proceed), because a
  * transient RabbitMQ hiccup should not permanently block recovery jobs.
  */
 export const isTaskQueueBusy = async (
   callerLabel: string,
+  queues: readonly string[] = [TASK_MANAGER_QUEUE],
 ): Promise<boolean> => {
   try {
-    const pending = await Rabbit.getMessageCount(TASK_MANAGER_QUEUE)
-    if (pending > 0) {
-      logger.debug(
-        'Deferring %s, %d tasks pending in queue',
-        callerLabel,
-        pending,
-      )
-      return true
+    for (const queue of queues) {
+      const pending = await Rabbit.getMessageCount(queue)
+      if (pending > 0) {
+        logger.debug(
+          'Deferring %s, %d tasks pending in %s',
+          callerLabel,
+          pending,
+          queue,
+        )
+        return true
+      }
     }
   } catch (error) {
     logger.warn(

--- a/apps/backend/src/shared/utils/queue.ts
+++ b/apps/backend/src/shared/utils/queue.ts
@@ -6,31 +6,24 @@ const logger = createLogger('utils:queue')
 const TASK_MANAGER_QUEUE = 'task-manager'
 
 /**
- * Returns true when any of the given queues has pending messages, signalling
- * that callers should defer non-urgent work. Defaults to the task-manager
- * (fast) lane; callers whose work lands on another queue — e.g. publishing
- * recovery, whose publish-nodes tasks run on publish-manager — should pass
- * that queue too so they don't keep deepening a backlog that isn't draining.
+ * Returns true when the task-manager queue has pending messages,
+ * signalling that callers should defer non-urgent work.
  *
  * On check failure the function returns false (proceed), because a
  * transient RabbitMQ hiccup should not permanently block recovery jobs.
  */
 export const isTaskQueueBusy = async (
   callerLabel: string,
-  queues: readonly string[] = [TASK_MANAGER_QUEUE],
 ): Promise<boolean> => {
   try {
-    for (const queue of queues) {
-      const pending = await Rabbit.getMessageCount(queue)
-      if (pending > 0) {
-        logger.debug(
-          'Deferring %s, %d tasks pending in %s',
-          callerLabel,
-          pending,
-          queue,
-        )
-        return true
-      }
+    const pending = await Rabbit.getMessageCount(TASK_MANAGER_QUEUE)
+    if (pending > 0) {
+      logger.debug(
+        'Deferring %s, %d tasks pending in queue',
+        callerLabel,
+        pending,
+      )
+      return true
     }
   } catch (error) {
     logger.warn(

--- a/apps/backend/src/shared/utils/queue.ts
+++ b/apps/backend/src/shared/utils/queue.ts
@@ -6,22 +6,31 @@ const logger = createLogger('utils:queue')
 const TASK_MANAGER_QUEUE = 'task-manager'
 
 /**
- * Returns true when the task-manager queue has pending messages,
- * signalling that callers should defer non-urgent work.
+ * Returns true when `queue` holds more than `threshold` pending messages,
+ * signalling that callers should defer non-urgent work. Defaults to the
+ * task-manager (fast) lane with a zero threshold (defer on any backlog).
+ * Callers whose work targets another queue can check it with a higher
+ * threshold — e.g. publishing recovery checks publish-manager, which normally
+ * holds a shallow backlog while batches await on-chain confirmation, so only a
+ * genuine pile-up (not mere non-emptiness) should defer it.
  *
  * On check failure the function returns false (proceed), because a
  * transient RabbitMQ hiccup should not permanently block recovery jobs.
  */
 export const isTaskQueueBusy = async (
   callerLabel: string,
+  queue: string = TASK_MANAGER_QUEUE,
+  threshold: number = 0,
 ): Promise<boolean> => {
   try {
-    const pending = await Rabbit.getMessageCount(TASK_MANAGER_QUEUE)
-    if (pending > 0) {
+    const pending = await Rabbit.getMessageCount(queue)
+    if (pending > threshold) {
       logger.debug(
-        'Deferring %s, %d tasks pending in queue',
+        'Deferring %s, %d tasks pending in %s (threshold %d)',
         callerLabel,
         pending,
+        queue,
+        threshold,
       )
       return true
     }

--- a/apps/backend/src/shared/utils/queue.ts
+++ b/apps/backend/src/shared/utils/queue.ts
@@ -1,4 +1,4 @@
-import { Rabbit } from '../../infrastructure/drivers/rabbit.js'
+import { Rabbit, type Queue } from '../../infrastructure/drivers/rabbit.js'
 import { createLogger } from '../../infrastructure/drivers/logger.js'
 
 const logger = createLogger('utils:queue')
@@ -19,7 +19,7 @@ const TASK_MANAGER_QUEUE = 'task-manager'
  */
 export const isTaskQueueBusy = async (
   callerLabel: string,
-  queue: string = TASK_MANAGER_QUEUE,
+  queue: Queue = TASK_MANAGER_QUEUE,
   threshold: number = 0,
 ): Promise<boolean> => {
   try {

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -89,6 +89,38 @@ services:
       - workspace
       - backend
       - start:fe:worker
+  # Dedicated worker for on-chain node publishing. publish-nodes tasks block for
+  # the confirmation-depth window (~2.5-5 min per batch), so they run here on
+  # their own queue (publish-manager) instead of holding task-manager slots and
+  # starving the frontend worker's fast tasks. Shares backend-worker's profiles
+  # so it deploys on the same single host that runs start:fe:worker today.
+  #
+  # IMPORTANT: on-chain publishing must run in exactly ONE process — signing
+  # accounts' nonces are tracked in-memory per process, so a second concurrent
+  # publisher would hand out colliding nonces. Keep this to a single replica; if
+  # you ever run the frontend profile on more than one host, move publishing to
+  # its own single-host profile instead of sharing these.
+  backend-publish-worker:
+    image: ${BACKEND_IMAGE}
+    volumes:
+      - files_cache:/usr/src/app/apps/backend/.cache
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      - PORT=3000
+    profiles:
+      - frontend
+      - frontend-worker
+    logging:
+      driver: loki
+      options:
+        loki-url: 'https://logging.subspace.network/loki/api/v1/push'
+    command:
+      - yarn
+      - workspace
+      - backend
+      - start:publish:worker
   backend-api:
     image: ${BACKEND_IMAGE}
     volumes:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -100,8 +100,20 @@ services:
   # publisher would hand out colliding nonces. Keep this to a single replica; if
   # you ever run the frontend profile on more than one host, move publishing to
   # its own single-host profile instead of sharing these.
+  #
+  # Rolling-deploy safety: before this change the frontend worker signed
+  # publish-nodes inline, so during the upgrade the OLD start:fe:worker keeps
+  # signing until it stops while this new worker also signs — two signers whose
+  # in-memory nonces can collide. depends_on: backend-worker makes the standard
+  # single-host `docker compose up -d` safe: compose recreates backend-worker
+  # (stop old, start new) before starting this worker, so the old inline signer
+  # is gone before this one begins. For a non-recreate/rolling or multi-host
+  # deploy, stop the old frontend worker before this worker starts signing (or
+  # roll out the new frontend workers first, then start this worker).
   backend-publish-worker:
     image: ${BACKEND_IMAGE}
+    depends_on:
+      - backend-worker
     volumes:
       - files_cache:/usr/src/app/apps/backend/.cache
     restart: unless-stopped

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -110,10 +110,25 @@ services:
   # is gone before this one begins. For a non-recreate/rolling or multi-host
   # deploy, stop the old frontend worker before this worker starts signing (or
   # roll out the new frontend workers first, then start this worker).
+  #
+  # This depends_on recreation only fires when BACKEND_IMAGE actually changes:
+  # the ansible deploy sets BACKEND_IMAGE from the new image_tag, which changes
+  # backend-worker's config hash and triggers stop-old/start-new. Ship this
+  # compose change WITH a new image tag — a compose-only redeploy on an unchanged
+  # BACKEND_IMAGE neither recreates backend-worker (so the sequencing is lost)
+  # nor finds dist/app/servers/publishWorker.js in the old image (so this worker
+  # crash-loops under restart: unless-stopped).
   backend-publish-worker:
     image: ${BACKEND_IMAGE}
     depends_on:
       - backend-worker
+    # Publish the worker's health endpoint (apis/worker.ts GET /health) like
+    # every other backend service. This is the SOLE on-chain publisher, and the
+    # deploy checklist asks operators to confirm exactly one is running, so it is
+    # the last process that should lose its probe. BACKEND_PUBLISH_WORKER_PORT
+    # must be set in the deploy env (Infisical) alongside BACKEND_WORKER_PORT.
+    ports:
+      - '${BACKEND_PUBLISH_WORKER_PORT}:3000'
     volumes:
       - files_cache:/usr/src/app/apps/backend/.cache
     restart: unless-stopped
@@ -121,6 +136,11 @@ services:
       - .env
     environment:
       - PORT=3000
+    healthcheck:
+      test: ['CMD', 'curl', '-f', 'http://localhost:3000/health']
+      interval: 15s
+      timeout: 10s
+      retries: 3
     profiles:
       - frontend
       - frontend-worker

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -232,34 +232,49 @@ flowchart LR
     subgraph Queues["RabbitMQ Queues"]
         TM["task-manager"]
         DM["download-manager"]
+        PM["publish-manager"]
         FE["frontend-errors"]
         DE["download-errors"]
+        PE["publish-errors"]
     end
 
     subgraph Consumers
         FW["Frontend Worker"]
         DW["Download Worker"]
+        PW["Publish Worker"]
     end
 
     Backend --> TM
     Backend --> DM
+    Backend --> PM
     TM --> FW
     DM --> DW
+    PM --> PW
     FW -->|"retries exhausted"| FE
     DW -->|"retries exhausted"| DE
+    PW -->|"retries exhausted"| PE
     FW -->|"retry"| TM
     DW -->|"retry"| DM
+    PW -->|"retry"| PM
 ```
+
+> On-chain publishing (`publish-nodes`, `ensure-object-published`) runs on its
+> own `publish-manager` queue and a dedicated **Publish Worker** so its long
+> confirmation waits (~2.5–5 min per batch) never hold `task-manager` slots and
+> starve the fast frontend tasks. Publishing must run in exactly one process —
+> signing-account nonces are tracked in-memory per process — so this worker is a
+> single replica and the frontend worker forwards any publish task it receives to
+> `publish-manager` rather than signing it.
 
 #### Task Types
 
 | Task ID                   | Queue            | Description                     |
 | ------------------------- | ---------------- | ------------------------------- |
 | `migrate-upload-nodes`    | task-manager     | Move upload data to nodes table |
-| `publish-nodes`           | task-manager     | Publish IPLD nodes on-chain     |
+| `publish-nodes`           | publish-manager  | Publish IPLD nodes on-chain     |
 | `tag-upload`              | task-manager     | Add security tags to uploads    |
 | `archive-objects`         | task-manager     | Mark objects as archived        |
-| `ensure-object-published` | task-manager     | Verify on-chain publication     |
+| `ensure-object-published` | publish-manager  | Verify on-chain publication     |
 | `watch-intent-tx`         | task-manager     | Monitor payment transactions    |
 | `async-download-created`  | download-manager | Prepare async download          |
 | `object-archived`         | download-manager | Handle post-archival tasks      |
@@ -270,8 +285,17 @@ flowchart LR
 Each task includes a `retriesLeft` counter (configured via `TASK_MANAGER_MAX_RETRIES`):
 
 1. **On success**: Message is acknowledged and removed from queue
-2. **On failure with retries remaining**: Task is re-published with decremented `retriesLeft`
-3. **On failure with no retries**: Task is moved to the error queue (`frontend-errors` or `download-errors`)
+2. **On failure with retries remaining**: Task is re-published with decremented `retriesLeft` (onto its own queue — a failed `publish-manager` task retries on `publish-manager`, never the fast lane)
+3. **On failure with no retries**: Task is moved to the matching error queue (`frontend-errors`, `download-errors`, or `publish-errors`)
+
+> **Error queues are terminal.** `frontend-errors`, `download-errors`, and
+> `publish-errors` have no consumer — they hold tasks that exhausted their
+> retries for manual inspection. `publish-errors` is the terminal destination
+> for on-chain publishing failures (the publish worker is the sole signer), so
+> its depth should be monitored/alerted: a rising `publish-errors` means
+> publishing is failing even after retries. The publish handler also carries a
+> generous per-task timeout (`PUBLISH_TASK_TIMEOUT_MS`) so a transaction that
+> never confirms degrades to a bounded retry instead of pinning a worker slot.
 
 ```typescript
 // Task structure
@@ -301,8 +325,9 @@ apps/backend/src/infrastructure/
     ├── tasks.ts            # Task schemas (Zod validation)
     ├── utils.ts            # Retry wrapper with error handling
     └── processors/
-        ├── frontend.ts     # Upload/publish task handlers
-        └── download.ts     # Download/cache task handlers
+        ├── frontend.ts     # Fast upload task handlers (forwards publish tasks)
+        ├── download.ts     # Download/cache task handlers
+        └── publish.ts      # On-chain publishing (dedicated publish worker)
 ```
 
 ---


### PR DESCRIPTION
## TL;DR

Isolates on-chain publishing onto its own queue + worker so it can't take down the fast frontend task lane. **This is blast-radius containment, not the root-cause cure** — see below.

## Problem

On-chain publishing (`publish-nodes`, and `ensure-object-published`) submits each node as a `system.remark` and, per the #706 hardening in `transactionManager`, resolves only after `confirmationDepth` (25) blocks build on top of its inclusion block. The `task-manager` consumer awaits the handler before acking, so each publishing task **holds a prefetch slot** for the whole confirmation window — starving the fast frontend tasks it shares the queue with (`migrate-upload-nodes`, `archive-objects`, `tag-upload`).

Production debugging then showed this is currently **unbounded**, not just slow: transactions get included but never confirm, hit the 5-min timeout, and are retried with the same nonce → same extrinsic hash → re-included forever. The publishing handlers never return → never ack → **all consumer slots saturate** and `task-manager` freezes. The queue backlog is the symptom; the publishing failure is the cause.

## What this PR does

Give on-chain publishing its own queue and worker, mirroring the existing `download-manager` split, so those waits (bounded or not) never block the frontend fast lane.

- New `publish-manager` queue; **both signing tasks** — `publish-nodes` and `ensure-object-published` — route there (`eventRouter`).
- New `processPublishTask` processor + `publishWorker` server (`start:publish:worker`).
- New `backend-publish-worker` compose service.

## Single-signer safety (important)

Signing-account nonces are tracked **in-memory per process** (`onchainPublisher/accounts.ts`), so on-chain publishing must run in **exactly one process** — a second concurrent publisher hands out colliding nonces. Both `publish-nodes` and `ensure-object-published` sign (via `OnchainPublisher.publishNodes`), so both are moved to the single publish worker. To hold the invariant across the transition:

- The **frontend processor forwards** either signing task if it still receives one (enqueued before this change / mid rolling-deploy) instead of executing it — the frontend worker never signs.
- The combined `start:fe` server also consumes `publish-manager`, so single-process/local runs still publish.
- The `backend-publish-worker` service **shares `backend-worker`'s profiles**, so it deploys on the same single host that runs `start:fe:worker` today — no `COMPOSE_PROFILES`/env change, and publishing can't silently halt by being left unconfigured.

## ⚠️ This is containment, not the cure

The actual outage is that **confirmations never land** — a `transactionManager` confirmation-watch issue (likely the new-heads subscription not delivering, so `head ≥ inclusionNumber + 25` never becomes true; note the chain and `isInBlock` are advancing fine). That's a separate fix and the durability priority. This PR ensures that while publishing is down (or merely slow), the fast lane keeps draining and the failure stays contained to `publish-manager`.

## ⚠️ Confirm before merge/deploy

Co-location is safe **iff `start:fe:worker` runs on exactly one host today** (it must, or there'd be nonce collisions already). If the frontend profile runs on more than one host, the publish worker should move to its own single-host profile instead.

## Deploy notes

- Quarantined publishing tasks (`publish-nodes`, and `ensure-object-published` if present) replay cleanly: `EventRouter.publish` routes them to `publish-manager`, consumed only by the new worker.
- After deploy: `task-manager` should drain to ~0 while `publish-manager` holds the (currently non-confirming) work; confirm exactly one `backend-publish-worker` container.

## Verification

- `tsc` build passes; ESLint clean on all changed files.
- **24/24** unit tests pass — `TaskManager.spec.ts` + `eventRouter/processors.spec.ts`, covering routing + forwarding for both signing tasks, `listenPublishEvents`, and `processPublishTask`.
- e2e/integration (TestContainers) will run in CI.

## Follow-up (not in this PR)

- **The confirmation-watch fix** (the real cure) — separate PR.
- `isTaskQueueBusy` (publishing-recovery deferral) still checks only `task-manager`; may want to also consider `publish-manager` depth now.
- `watch-intent-tx` (EVM/payments) can also block a `task-manager` slot on confirmation; lower priority, separate subsystem — isolate similarly if it becomes a problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
