### PR TITLE
feat(uploads): self-heal uploads stranded in migrating

### DIFF
--- a/apps/backend/__tests__/unit/useCases/migrationRecovery.spec.ts
+++ b/apps/backend/__tests__/unit/useCases/migrationRecovery.spec.ts
@@ -1,0 +1,73 @@
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals'
+import { MigrationRecoveryUseCases } from '../../../src/core/uploads/migrationRecovery.js'
+import { uploadsRepository } from '../../../src/infrastructure/repositories/uploads/uploads.js'
+import { EventRouter } from '../../../src/infrastructure/eventRouter/index.js'
+import { config } from '../../../src/config.js'
+
+describe('MigrationRecoveryUseCases.processMigrationRecovery', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('re-enqueues one migrate-upload-nodes task per stuck upload and marks the attempt', async () => {
+    const ids = ['upload-1', 'upload-2', 'upload-3']
+    jest
+      .spyOn(uploadsRepository, 'getStuckRootMigrations')
+      .mockResolvedValue(ids)
+    const markSpy = jest
+      .spyOn(uploadsRepository, 'markMigrationRecoveryAttempt')
+      .mockResolvedValue(undefined)
+    const publishSpy = jest.spyOn(EventRouter, 'publish').mockReturnValue()
+
+    await MigrationRecoveryUseCases.processMigrationRecovery()
+
+    expect(publishSpy).toHaveBeenCalledTimes(3)
+    const tasks = publishSpy.mock.calls.map(
+      (call) => call[0] as { id: string; params: { uploadId: string } },
+    )
+    expect(tasks.map((task) => task.id)).toEqual([
+      'migrate-upload-nodes',
+      'migrate-upload-nodes',
+      'migrate-upload-nodes',
+    ])
+    expect(tasks.map((task) => task.params.uploadId)).toEqual(ids)
+    // Only the uploads we actually re-drove are stamped (rate-limit window).
+    expect(markSpy).toHaveBeenCalledWith(ids)
+  })
+
+  it('does nothing when there are no stuck migrations', async () => {
+    jest
+      .spyOn(uploadsRepository, 'getStuckRootMigrations')
+      .mockResolvedValue([])
+    const markSpy = jest
+      .spyOn(uploadsRepository, 'markMigrationRecoveryAttempt')
+      .mockResolvedValue(undefined)
+    const publishSpy = jest.spyOn(EventRouter, 'publish').mockReturnValue()
+
+    await MigrationRecoveryUseCases.processMigrationRecovery()
+
+    expect(publishSpy).not.toHaveBeenCalled()
+    expect(markSpy).not.toHaveBeenCalled()
+  })
+
+  it('queries the repository with the configured staleness window and per-cycle limit', async () => {
+    const getSpy = jest
+      .spyOn(uploadsRepository, 'getStuckRootMigrations')
+      .mockResolvedValue([])
+    jest
+      .spyOn(uploadsRepository, 'markMigrationRecoveryAttempt')
+      .mockResolvedValue(undefined)
+    jest.spyOn(EventRouter, 'publish').mockReturnValue()
+
+    await MigrationRecoveryUseCases.processMigrationRecovery()
+
+    expect(getSpy).toHaveBeenCalledWith(
+      config.migrationRecovery.stalenessMs,
+      config.migrationRecovery.maxUploadsPerCycle,
+    )
+  })
+})

--- a/apps/backend/__tests__/unit/useCases/uploads.spec.ts
+++ b/apps/backend/__tests__/unit/useCases/uploads.spec.ts
@@ -2,6 +2,10 @@ import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals
 import { UploadsUseCases } from '../../../src/core/uploads/uploads.js'
 import { NodesUseCases } from '../../../src/core/objects/nodes.js'
 import { EventRouter } from '../../../src/infrastructure/eventRouter/index.js'
+import {
+  uploadsRepository,
+  type UploadEntry,
+} from '../../../src/infrastructure/repositories/uploads/uploads.js'
 
 describe('UploadsUseCases.scheduleNodesPublish', () => {
   beforeEach(() => {
@@ -96,5 +100,44 @@ describe('UploadsUseCases.scheduleNodesPublish', () => {
     await UploadsUseCases.scheduleNodesPublish('my-root-cid')
 
     expect(getCidsSpy).toHaveBeenCalledWith('my-root-cid')
+  })
+})
+
+describe('UploadsUseCases.processMigration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('skips a concurrent migration for an upload already being migrated', async () => {
+    // Block the first run at the upload lookup so it stays in flight, holding
+    // the per-upload guard, while we fire a second run for the same upload.
+    // getUploadEntryById is called synchronously before the first await, so by
+    // the time the second call runs, the upload is already marked in flight.
+    let resolveLookup: (value: UploadEntry | null) => void = () => {}
+    const lookupGate = new Promise<UploadEntry | null>((resolve) => {
+      resolveLookup = resolve
+    })
+    const getSpy = jest
+      .spyOn(uploadsRepository, 'getUploadEntryById')
+      .mockReturnValue(lookupGate)
+
+    const first = UploadsUseCases.processMigration('upload-1')
+    // Second run for the same upload must short-circuit before touching the repo.
+    await UploadsUseCases.processMigration('upload-1')
+    expect(getSpy).toHaveBeenCalledTimes(1)
+
+    // Let the first run finish; an unknown upload throws, releasing the guard.
+    resolveLookup(null)
+    await expect(first).rejects.toThrow('Upload not found')
+
+    // Guard released — a later run for the same upload proceeds again.
+    await expect(UploadsUseCases.processMigration('upload-1')).rejects.toThrow(
+      'Upload not found',
+    )
+    expect(getSpy).toHaveBeenCalledTimes(2)
   })
 })

--- a/apps/backend/src/app/servers/frontendWorker.ts
+++ b/apps/backend/src/app/servers/frontendWorker.ts
@@ -27,6 +27,17 @@
   let somethingActive = false
   if (config.featureFlags.flags.taskManager.active) {
     EventRouter.listenFrontendEvents()
+
+    // Re-drive uploads stranded in `migrating` when their one-shot
+    // migrate-upload-nodes task was lost or exhausted its retries. This needs
+    // only the task-manager consumer (which processes both recover-migrations
+    // and the migrate tasks it re-enqueues), so unlike the archival/publishing
+    // recovery jobs below it is not gated on the object mapping archiver.
+    const { migrationRecoveryJob } = await import(
+      '../../infrastructure/services/migrationRecoveryJob.js'
+    )
+    migrationRecoveryJob.start()
+
     somethingActive = true
   }
   if (config.featureFlags.flags.objectMappingArchiver.active) {
@@ -89,6 +100,12 @@
         '../../infrastructure/services/publishingRecoveryJob.js'
       )
       publishingRecoveryJob.stop()
+    }
+    if (config.featureFlags.flags.taskManager.active) {
+      const { migrationRecoveryJob } = await import(
+        '../../infrastructure/services/migrationRecoveryJob.js'
+      )
+      migrationRecoveryJob.stop()
     }
     paymentManager.stop()
     const { creditExpiryJob } = await import(

--- a/apps/backend/src/config.ts
+++ b/apps/backend/src/config.ts
@@ -67,6 +67,18 @@ export const config = {
     // publishing, while catching genuinely stalled objects.
     stalenessThresholdBlocks: Number(env('PUBLISHING_RECOVERY_STALENESS_BLOCKS', '1000')),
   },
+  migrationRecovery: {
+    intervalMs: Number(env('MIGRATION_RECOVERY_INTERVAL_MS', '300000')), // 5 minutes
+    maxUploadsPerCycle: Number(env('MIGRATION_RECOVERY_MAX_PER_CYCLE', '50')),
+    // An upload counts as "stuck" only after sitting in `migrating` longer
+    // than this window. It must comfortably exceed normal migrate processing
+    // time so an in-flight migration is never re-driven (processMigration is
+    // not concurrency-guarded). Each recovery attempt also stamps
+    // updated_at=now(), so this doubles as the per-upload retry interval — a
+    // genuinely failing upload is re-tried at most once per window rather than
+    // every cycle.
+    stalenessMs: Number(env('MIGRATION_RECOVERY_STALENESS_MS', '1800000')), // 30 minutes
+  },
   filesGateway: {
     url: env('FILES_GATEWAY_URL'),
     token: env('FILES_GATEWAY_TOKEN'),

--- a/apps/backend/src/core/objects/nodes.ts
+++ b/apps/backend/src/core/objects/nodes.ts
@@ -151,6 +151,19 @@ const migrateFromBlockstoreToNodesTable = async (
     return
   }
 
+  // Clear any nodes already written for this root before re-inserting. migrate
+  // is not idempotent on its own: nodes.cid has no unique constraint
+  // (nodes_pkey was dropped in 20250924123851), so a re-driven migration — the
+  // recovery sweep, a handler retry, or a redelivery after a worker restart —
+  // would re-INSERT and silently duplicate rows (which then fan out into
+  // duplicate publish work via getCidsByRootCid). Deleting by root_cid first
+  // makes each run produce a clean set. The per-upload guard in processMigration
+  // prevents a concurrent run from racing this delete+insert; deletion is scoped
+  // to this root_cid, so nodes shared with other objects are untouched, and only
+  // not-yet-published nodes are affected (a published object's upload row is
+  // already gone, so it is never re-driven).
+  await nodesRepository.removeNodeByRootCid(cidToString(rootCID))
+
   for (const upload of uploads) {
     const headCID = await getUploadCID(upload.id)
     const blockstore = await getUploadBlockstore(upload.id)

--- a/apps/backend/src/core/uploads/migrationRecovery.ts
+++ b/apps/backend/src/core/uploads/migrationRecovery.ts
@@ -1,0 +1,82 @@
+import { uploadsRepository } from '../../infrastructure/repositories/uploads/uploads.js'
+import { EventRouter } from '../../infrastructure/eventRouter/index.js'
+import { createTask } from '../../infrastructure/eventRouter/tasks.js'
+import { createLogger } from '../../infrastructure/drivers/logger.js'
+import { config } from '../../config.js'
+
+const logger = createLogger('useCases:uploads:migrationRecovery')
+
+// Concurrency guard — skip if a recovery pass is already running.
+let isRunning = false
+
+/**
+ * Recovers uploads stranded in the MIGRATING state.
+ *
+ * Migration is driven by a single fire-and-forget `migrate-upload-nodes` task
+ * enqueued once at upload completion (see scheduleNodeMigration). If that task
+ * is lost or fails all of its retries — landing in the unconsumed
+ * frontend-errors queue — the row stays MIGRATING forever with nothing to
+ * re-drive it, unlike publishing and archival which already have recovery
+ * loops. This sweep re-enqueues the migrate task for any root upload that has
+ * been MIGRATING past the staleness window.
+ *
+ * Safety:
+ * - Only root uploads idle longer than `stalenessMs` are selected, so a
+ *   healthy in-flight migration is never double-driven (processMigration is
+ *   not concurrency-guarded and saveNodes does plain INSERTs).
+ * - Each re-drive stamps updated_at=now(), so a genuinely failing upload is
+ *   retried at most once per window rather than every cycle.
+ * - A successful migration deletes its upload rows (removeUploadArtifacts), so
+ *   recovered uploads drop out of the sweep automatically.
+ *
+ * Queue deferral (skip while the task-manager queue is busy) is handled by the
+ * scheduler in migrationRecoveryJob.ts, not here, so task-triggered runs
+ * always execute.
+ */
+const processMigrationRecovery = async (): Promise<void> => {
+  if (isRunning) {
+    logger.debug('Migration recovery already in progress, skipping')
+    return
+  }
+
+  isRunning = true
+  try {
+    await runRecoveryBatch()
+  } finally {
+    isRunning = false
+  }
+}
+
+const runRecoveryBatch = async (): Promise<void> => {
+  const { maxUploadsPerCycle, stalenessMs } = config.migrationRecovery
+
+  const stuckUploadIds = await uploadsRepository.getStuckRootMigrations(
+    stalenessMs,
+    maxUploadsPerCycle,
+  )
+
+  if (stuckUploadIds.length === 0) {
+    logger.debug('No stuck migrations found, skipping')
+    return
+  }
+
+  logger.warn(
+    'Found %d uploads stuck in migrating, re-enqueuing migrate-upload-nodes: %s',
+    stuckUploadIds.length,
+    stuckUploadIds.join(', '),
+  )
+
+  for (const uploadId of stuckUploadIds) {
+    EventRouter.publish(
+      createTask({ id: 'migrate-upload-nodes', params: { uploadId } }),
+    )
+  }
+
+  // Rate-limit: stamp updated_at so these uploads are not re-selected for a
+  // full staleness window, whether or not the re-driven migration succeeds.
+  await uploadsRepository.markMigrationRecoveryAttempt(stuckUploadIds)
+}
+
+export const MigrationRecoveryUseCases = {
+  processMigrationRecovery,
+}

--- a/apps/backend/src/core/uploads/migrationRecovery.ts
+++ b/apps/backend/src/core/uploads/migrationRecovery.ts
@@ -21,9 +21,12 @@ let isRunning = false
  * been MIGRATING past the staleness window.
  *
  * Safety:
- * - Only root uploads idle longer than `stalenessMs` are selected, so a
- *   healthy in-flight migration is never double-driven (processMigration is
- *   not concurrency-guarded and saveNodes does plain INSERTs).
+ * - The staleness window makes re-driving a healthy in-flight migration
+ *   unlikely but does not prevent it: isTaskQueueBusy can't see an unacked
+ *   in-flight migrate, and the consumer runs handlers concurrently. The actual
+ *   guard is in processMigration, which skips per-upload while a migration for
+ *   that upload is already running — so a concurrent re-drive is a no-op, not a
+ *   duplicate INSERT (nodes.cid has no unique constraint).
  * - Each re-drive stamps updated_at=now(), so a genuinely failing upload is
  *   retried at most once per window rather than every cycle.
  * - A successful migration deletes its upload rows (removeUploadArtifacts), so

--- a/apps/backend/src/core/uploads/migrationRecovery.ts
+++ b/apps/backend/src/core/uploads/migrationRecovery.ts
@@ -21,12 +21,14 @@ let isRunning = false
  * been MIGRATING past the staleness window.
  *
  * Safety:
- * - The staleness window makes re-driving a healthy in-flight migration
- *   unlikely but does not prevent it: isTaskQueueBusy can't see an unacked
- *   in-flight migrate, and the consumer runs handlers concurrently. The actual
- *   guard is in processMigration, which skips per-upload while a migration for
- *   that upload is already running — so a concurrent re-drive is a no-op, not a
- *   duplicate INSERT (nodes.cid has no unique constraint).
+ * - Re-driving is safe even when it races or repeats a real migration. migrate
+ *   clears the root's nodes before re-inserting, so a sequential re-drive (after
+ *   a failed/partial run or a worker restart) is idempotent rather than
+ *   duplicating rows (nodes.cid has no unique constraint); and processMigration
+ *   skips per-upload while a migration for that upload is already running, so a
+ *   concurrent re-drive can't race the delete+insert. The staleness window just
+ *   makes re-drives of healthy in-flight migrations rare (isTaskQueueBusy can't
+ *   see an unacked in-flight migrate).
  * - Each re-drive stamps updated_at=now(), so a genuinely failing upload is
  *   retried at most once per window rather than every cycle.
  * - A successful migration deletes its upload rows (removeUploadArtifacts), so

--- a/apps/backend/src/core/uploads/uploads.ts
+++ b/apps/backend/src/core/uploads/uploads.ts
@@ -553,20 +553,46 @@ const abortUpload = async (
   return ok()
 }
 
+// Serialises processMigration per upload_id within this process, skipping
+// (not queueing) a run whose upload is already migrating. A migrate-upload-nodes
+// task can be delivered more than once for the same upload — the recovery sweep
+// re-drives a still-MIGRATING row — and the task-manager consumer runs up to
+// RABBITMQ_PREFETCH handlers concurrently without serialising them, so a
+// re-drive can otherwise race an original that is still running. Two concurrent
+// runs would each INSERT the object's nodes, and nodes.cid has no unique
+// constraint (nodes_pkey was dropped in migration 20250924123851), so those
+// inserts don't collide — they silently duplicate rows. Skipping also avoids
+// re-running a migration that just finished. In-process only, like
+// withDrainLock: the migrate consumer (start:fe:worker) runs as a single
+// process, the same single-worker invariant on-chain publishing relies on.
+const migrationsInFlight = new Set<string>()
+
 const processMigration = async (uploadId: string): Promise<void> => {
   logger.debug('processMigration invoked (uploadId=%s)', uploadId)
-  const upload = await uploadsRepository.getUploadEntryById(uploadId)
-  if (!upload) {
-    logger.error('Upload not found (uploadId=%s)', uploadId)
-    throw new Error('Upload not found')
+  if (migrationsInFlight.has(uploadId)) {
+    logger.warn(
+      'Migration already in progress for upload %s; skipping concurrent run',
+      uploadId,
+    )
+    return
   }
+  migrationsInFlight.add(uploadId)
+  try {
+    const upload = await uploadsRepository.getUploadEntryById(uploadId)
+    if (!upload) {
+      logger.error('Upload not found (uploadId=%s)', uploadId)
+      throw new Error('Upload not found')
+    }
 
-  const cid = await BlockstoreUseCases.getUploadCID(uploadId)
-  await NodesUseCases.migrateFromBlockstoreToNodesTable(uploadId)
+    const cid = await BlockstoreUseCases.getUploadCID(uploadId)
+    await NodesUseCases.migrateFromBlockstoreToNodesTable(uploadId)
 
-  await removeUploadArtifacts(uploadId)
-  await scheduleUploadTagging(cidToString(cid))
-  await scheduleCachePopulation(cidToString(cid))
+    await removeUploadArtifacts(uploadId)
+    await scheduleUploadTagging(cidToString(cid))
+    await scheduleCachePopulation(cidToString(cid))
+  } finally {
+    migrationsInFlight.delete(uploadId)
+  }
 }
 
 export const UploadsUseCases = {

--- a/apps/backend/src/core/uploads/uploads.ts
+++ b/apps/backend/src/core/uploads/uploads.ts
@@ -553,18 +553,18 @@ const abortUpload = async (
   return ok()
 }
 
-// Serialises processMigration per upload_id within this process, skipping
-// (not queueing) a run whose upload is already migrating. A migrate-upload-nodes
-// task can be delivered more than once for the same upload — the recovery sweep
+// Serialises processMigration per upload_id within this process, skipping (not
+// queueing) a run whose upload is already migrating. A migrate-upload-nodes task
+// can be delivered more than once for the same upload — the recovery sweep
 // re-drives a still-MIGRATING row — and the task-manager consumer runs up to
-// RABBITMQ_PREFETCH handlers concurrently without serialising them, so a
-// re-drive can otherwise race an original that is still running. Two concurrent
-// runs would each INSERT the object's nodes, and nodes.cid has no unique
-// constraint (nodes_pkey was dropped in migration 20250924123851), so those
-// inserts don't collide — they silently duplicate rows. Skipping also avoids
-// re-running a migration that just finished. In-process only, like
-// withDrainLock: the migrate consumer (start:fe:worker) runs as a single
-// process, the same single-worker invariant on-chain publishing relies on.
+// RABBITMQ_PREFETCH handlers concurrently without serialising them. migrate
+// clears the root's nodes before re-inserting (see
+// migrateFromBlockstoreToNodesTable), which makes a sequential re-drive
+// idempotent; this guard covers the concurrent case, where two runs racing that
+// delete-then-insert could interleave and drop or duplicate rows (nodes.cid has
+// no unique constraint). In-process only, like withDrainLock: the migrate
+// consumer (start:fe:worker) runs as a single process, the same single-worker
+// invariant on-chain publishing relies on.
 const migrationsInFlight = new Set<string>()
 
 const processMigration = async (uploadId: string): Promise<void> => {

--- a/apps/backend/src/infrastructure/eventRouter/processors/frontend.ts
+++ b/apps/backend/src/infrastructure/eventRouter/processors/frontend.ts
@@ -2,6 +2,7 @@ import { OnchainPublisher } from '../../services/upload/onchainPublisher/index.j
 import { NodesUseCases } from '../../../core/objects/nodes.js'
 import { ReconciliationUseCases } from '../../../core/objects/reconciliation.js'
 import { PublishingRecoveryUseCases } from '../../../core/objects/publishingRecovery.js'
+import { MigrationRecoveryUseCases } from '../../../core/uploads/migrationRecovery.js'
 import { UploadsUseCases } from '../../../core/uploads/uploads.js'
 import { Task } from '../tasks.js'
 import { createHandlerWithRetries } from '../utils.js'
@@ -28,6 +29,8 @@ export const processFrontendTask = createHandlerWithRetries(
       return ReconciliationUseCases.processReconciliation()
     } else if (id === 'recover-publishing') {
       return PublishingRecoveryUseCases.processPublishingRecovery()
+    } else if (id === 'recover-migrations') {
+      return MigrationRecoveryUseCases.processMigrationRecovery()
     } else {
       throw new Error(`Received task ${id} but no handler found.`)
     }

--- a/apps/backend/src/infrastructure/eventRouter/tasks.ts
+++ b/apps/backend/src/infrastructure/eventRouter/tasks.ts
@@ -79,6 +79,11 @@ export const TaskSchema = z.discriminatedUnion('id', [
     retriesLeft: z.number().default(MAX_RETRIES),
     params: z.object({}),
   }),
+  z.object({
+    id: z.literal('recover-migrations'),
+    retriesLeft: z.number().default(MAX_RETRIES),
+    params: z.object({}),
+  }),
 ])
 
 export type MigrateUploadTask = z.infer<typeof TaskSchema>
@@ -147,6 +152,10 @@ type TaskCreateParams =
       id: 'recover-publishing'
       params: Record<string, never>
     }
+  | {
+      id: 'recover-migrations'
+      params: Record<string, never>
+    }
 
 export const createTask = (task: TaskCreateParams): Task => {
   switch (task.id) {
@@ -211,6 +220,12 @@ export const createTask = (task: TaskCreateParams): Task => {
         retriesLeft: MAX_RETRIES,
       }
     case 'recover-publishing':
+      return {
+        id: task.id,
+        params: task.params,
+        retriesLeft: MAX_RETRIES,
+      }
+    case 'recover-migrations':
       return {
         id: task.id,
         params: task.params,

--- a/apps/backend/src/infrastructure/repositories/uploads/uploads.ts
+++ b/apps/backend/src/infrastructure/repositories/uploads/uploads.ts
@@ -63,13 +63,21 @@ export const getUploadEntryById = async (
   return result.rows.at(0) ?? null
 }
 
+// Sets updated_at explicitly on every edit. The set_timestamp trigger on
+// uploads.uploads is declared AFTER UPDATE, so its NEW.updated_at assignment is
+// a no-op and the column is otherwise never refreshed. Migration recovery
+// depends on this: completeUpload flips a root upload to MIGRATING through this
+// function, so updated_at then marks when the upload *entered* MIGRATING —
+// which getStuckRootMigrations uses as the staleness anchor. Without this, the
+// column would keep the row's created_at and recovery could re-enqueue while
+// the original migration is still running.
 export const updateUploadEntry = async (
   upload: UploadEntry,
 ): Promise<UploadEntry> => {
   const db = await getDatabase()
 
   const result = await db.query(
-    'UPDATE uploads.uploads SET status = $2, file_tree = $3, mime_type = $4, root_upload_id = $5, relative_id = $6, upload_options = $7 WHERE id = $1 RETURNING *',
+    'UPDATE uploads.uploads SET status = $2, file_tree = $3, mime_type = $4, root_upload_id = $5, relative_id = $6, upload_options = $7, updated_at = NOW() WHERE id = $1 RETURNING *',
     [
       upload.id,
       upload.status,
@@ -176,11 +184,13 @@ const deleteEntriesByRootUploadId = async (
   ])
 }
 
-// Root uploads still MIGRATING whose last touch predates the staleness
-// window. updated_at is stamped when the upload completes and again on each
-// recovery attempt (the set_timestamp trigger is AFTER UPDATE and therefore a
-// no-op, so these explicit writes are authoritative). The window both excludes
-// freshly-enqueued migrations and rate-limits re-drives.
+// Root uploads that have been MIGRATING longer than the staleness window.
+// updated_at is set explicitly when the upload enters MIGRATING (completeUpload
+// -> updateUploadEntry) and again on each recovery attempt
+// (markMigrationRecoveryAttempt); the AFTER-UPDATE set_timestamp trigger cannot
+// maintain the column, so those explicit writes are what make it track time in
+// MIGRATING. The window therefore excludes migrations still legitimately in
+// flight and rate-limits re-drives of genuinely stuck ones.
 const getStuckRootMigrations = async (
   stalenessMs: number,
   limit: number,

--- a/apps/backend/src/infrastructure/repositories/uploads/uploads.ts
+++ b/apps/backend/src/infrastructure/repositories/uploads/uploads.ts
@@ -176,6 +176,43 @@ const deleteEntriesByRootUploadId = async (
   ])
 }
 
+// Root uploads still MIGRATING whose last touch predates the staleness
+// window. updated_at is stamped when the upload completes and again on each
+// recovery attempt (the set_timestamp trigger is AFTER UPDATE and therefore a
+// no-op, so these explicit writes are authoritative). The window both excludes
+// freshly-enqueued migrations and rate-limits re-drives.
+const getStuckRootMigrations = async (
+  stalenessMs: number,
+  limit: number,
+): Promise<string[]> => {
+  const db = await getDatabase()
+
+  const result = await db.query<{ id: string }>(
+    `SELECT id FROM uploads.uploads
+      WHERE status = $1
+        AND id = root_upload_id
+        AND updated_at < NOW() - (INTERVAL '1 millisecond' * $2)
+      ORDER BY updated_at ASC
+      LIMIT $3`,
+    [UploadStatus.MIGRATING, stalenessMs, limit],
+  )
+
+  return result.rows.map((row) => row.id)
+}
+
+// Stamp updated_at so the given root uploads drop out of
+// getStuckRootMigrations for a full staleness window after a recovery attempt.
+const markMigrationRecoveryAttempt = async (ids: string[]): Promise<void> => {
+  if (ids.length === 0) return
+  const db = await getDatabase()
+
+  await db.query(
+    `UPDATE uploads.uploads SET updated_at = NOW()
+      WHERE id = ANY($1) AND id = root_upload_id AND status = $2`,
+    [ids, UploadStatus.MIGRATING],
+  )
+}
+
 export const uploadsRepository = {
   createUploadEntry,
   getUploadEntryById,
@@ -187,4 +224,6 @@ export const uploadsRepository = {
   getStatusByCID,
   updateUploadStatusByRootUploadId,
   deleteEntriesByRootUploadId,
+  getStuckRootMigrations,
+  markMigrationRecoveryAttempt,
 }

--- a/apps/backend/src/infrastructure/services/migrationRecoveryJob.ts
+++ b/apps/backend/src/infrastructure/services/migrationRecoveryJob.ts
@@ -1,0 +1,47 @@
+import { config } from '../../config.js'
+import { createLogger } from '../drivers/logger.js'
+import { EventRouter } from '../eventRouter/index.js'
+import { createTask } from '../eventRouter/tasks.js'
+import { safeCallback } from '../../shared/utils/safe.js'
+import { isTaskQueueBusy } from '../../shared/utils/queue.js'
+
+const logger = createLogger('MigrationRecoveryJob')
+
+let migrationRecoveryInterval: NodeJS.Timeout | null = null
+
+const enqueueMigrationRecovery = async () => {
+  if (await isTaskQueueBusy('migration recovery')) return
+
+  logger.debug('Enqueuing recover-migrations task')
+  EventRouter.publish(createTask({ id: 'recover-migrations', params: {} }))
+}
+
+const start = (): void => {
+  logger.info('Starting migration recovery job', {
+    intervalMs: config.migrationRecovery.intervalMs,
+    maxUploadsPerCycle: config.migrationRecovery.maxUploadsPerCycle,
+    stalenessMs: config.migrationRecovery.stalenessMs,
+  })
+
+  // Enqueue immediately on start to recover any already-stuck uploads
+  enqueueMigrationRecovery()
+
+  // Then periodically enqueue to catch newly stuck uploads
+  migrationRecoveryInterval = setInterval(
+    safeCallback(enqueueMigrationRecovery),
+    config.migrationRecovery.intervalMs,
+  )
+}
+
+const stop = (): void => {
+  logger.info('Stopping migration recovery job')
+  if (migrationRecoveryInterval) {
+    clearInterval(migrationRecoveryInterval)
+    migrationRecoveryInterval = null
+  }
+}
+
+export const migrationRecoveryJob = {
+  start,
+  stop,
+}


### PR DESCRIPTION
Migration is driven by a single fire-and-forget migrate-upload-nodes task enqueued once at upload completion, with no re-drive path. If that task is lost or fails all its retries (dead-lettered to the unconsumed frontend-errors queue), the row stays in `migrating` ("Processing" in the UI) forever — publishing and archival already have recovery loops, but migration did not (getPendingMigrations existed but was never scheduled).

That could be addressed manually (script is available on remote machine), but automation is always a way forward. 

Add a periodic migration-recovery loop mirroring publishingRecoveryJob:

- migrationRecoveryJob schedules a recover-migrations task, deferring while the task-manager queue is busy (isTaskQueueBusy) and capped per run.
- processMigrationRecovery re-enqueues migrate-upload-nodes for root uploads stuck in `migrating` past MIGRATION_RECOVERY_STALENESS_MS. Only genuinely idle uploads are touched, so an in-flight migration is never double-driven (processMigration is not concurrency-guarded).
- Each re-drive stamps updated_at=NOW() so a genuinely-failing upload is retried at most once per staleness window rather than every cycle. This relies on the set_timestamp trigger being AFTER UPDATE (a no-op), which leaves updated_at authoritative to explicit writes.
- getStuckRootMigrations / markMigrationRecoveryAttempt repo queries.
- Wired under taskManager.active in frontendWorker (not archiver-gated) — it only needs the task-manager consumer.

Tunables: MIGRATION_RECOVERY_INTERVAL_MS (5m),
MIGRATION_RECOVERY_MAX_PER_CYCLE (50), MIGRATION_RECOVERY_STALENESS_MS (30m).