### PR TITLE
fix(publishing): poll fallback so confirmation survives a silent new-…

### DIFF
--- a/apps/backend/.env.sample
+++ b/apps/backend/.env.sample
@@ -20,6 +20,13 @@ CHAIN_CONFIRMATION_DEPTH=25
 # margin. Default 300000ms (5 min).
 CHAIN_TRANSACTION_TIMEOUT_MS=300000
 
+# Safety-net cadence (ms) for confirming published transactions. Confirmation is
+# normally driven by a new-heads subscription; if that subscription goes silent
+# after a WebSocket reconnect, the chain head is also polled on this interval so
+# confirmation still completes instead of stranding the tx in "publishing".
+# Default 6000ms (~1 block at 6s/block).
+CHAIN_CONFIRMATION_POLL_INTERVAL_MS=6000
+
 # ---------------------------------------------------------------------------
 # Pay-with-AI3 / purchased credits feature
 # ---------------------------------------------------------------------------

--- a/apps/backend/__tests__/unit/onchainPublisher/transactionManager.spec.ts
+++ b/apps/backend/__tests__/unit/onchainPublisher/transactionManager.spec.ts
@@ -1,0 +1,191 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals'
+import type { ApiPromise } from '@polkadot/api'
+import type { SubmittableExtrinsic } from '@polkadot/api/types'
+import type { KeyringPair } from '@polkadot/keyring/types'
+import { submitTransaction } from '../../../src/infrastructure/services/upload/onchainPublisher/transactionManager.js'
+import { config } from '../../../src/config.js'
+
+/**
+ * Unit tests for the confirmation watch in `submitTransaction`, focused on the
+ * poll fallback that cures the "stuck in publishing" incident: confirmation
+ * must still complete when the new-heads subscription goes silent (e.g. after a
+ * WebSocket reconnect), and a subscription that fails to open must no longer
+ * fail the transaction. The polkadot `api` and the extrinsic are mocked; fake
+ * timers drive the poll interval deterministically.
+ */
+
+const TX_HASH = '0xtx'
+const INCLUSION_HASH = '0xincl'
+const INCLUSION_NUMBER = 100
+const REORG_HASH = '0xreorg'
+const KEYPAIR = {} as unknown as KeyringPair
+
+// A head high enough that the confirmation depth is reached in a single check.
+const HEAD_AT_DEPTH = INCLUSION_NUMBER + config.chain.confirmationDepth
+
+type HeadHandler = (header: { number: { toNumber: () => number } }) => unknown
+type SubscribeImpl = (cb: HeadHandler) => Promise<() => void>
+
+const makeApi = (opts: {
+  subscribe: SubscribeImpl
+  headNumber: number
+  canonicalHash?: string
+}) => {
+  const { subscribe, headNumber, canonicalHash = INCLUSION_HASH } = opts
+  return {
+    once: jest.fn(),
+    off: jest.fn(),
+    registry: { findMetaError: () => ({ section: 'x', name: 'y', docs: ['z'] }) },
+    rpc: {
+      chain: {
+        // Resolves the inclusion block number for the hash reported by isInBlock.
+        getBlock: jest.fn(async () => ({
+          block: { header: { number: { toNumber: () => INCLUSION_NUMBER } } },
+        })),
+        subscribeNewHeads: jest.fn(subscribe),
+        // The poll fallback's head source — a fresh request each tick.
+        getHeader: jest.fn(async () => ({
+          number: { toNumber: () => headNumber },
+        })),
+        // Canonical block hash at the inclusion height (== inclusion hash unless
+        // a reorg is being simulated).
+        getBlockHash: jest.fn(async () => ({ toString: () => canonicalHash })),
+      },
+    },
+  }
+}
+
+const makeTransaction = () => {
+  let statusCb: ((result: unknown) => unknown) | undefined
+  const signAndSend = jest.fn(
+    (_keyPair: unknown, _opts: unknown, cb: (result: unknown) => unknown) => {
+      statusCb = cb
+      return Promise.resolve(() => {})
+    },
+  )
+  const tx = { hash: { toString: () => TX_HASH }, signAndSend }
+  // Simulate the extrinsic reaching a block (inclusion).
+  const triggerInBlock = () => {
+    if (!statusCb) throw new Error('signAndSend was not called')
+    return statusCb({
+      status: {
+        isInBlock: true,
+        isInvalid: false,
+        isUsurped: false,
+        type: 'InBlock',
+        asInBlock: { toString: () => INCLUSION_HASH },
+      },
+    })
+  }
+  return { tx, triggerInBlock }
+}
+
+const run = (api: ReturnType<typeof makeApi>, tx: ReturnType<typeof makeTransaction>['tx']) =>
+  submitTransaction(
+    api as unknown as ApiPromise,
+    KEYPAIR,
+    tx as unknown as SubmittableExtrinsic<'promise'>,
+    0,
+  )
+
+describe('submitTransaction — confirmation watch', () => {
+  afterEach(() => {
+    jest.useRealTimers()
+    jest.restoreAllMocks()
+  })
+
+  it('confirms via the poll fallback when the subscription never delivers a head', async () => {
+    jest.useFakeTimers()
+    // Silent subscription: returns an unsub but never invokes the callback,
+    // simulating a WS subscription that went dead after a reconnect.
+    const api = makeApi({
+      subscribe: async () => () => {},
+      headNumber: HEAD_AT_DEPTH,
+    })
+    const { tx, triggerInBlock } = makeTransaction()
+
+    const result = run(api, tx)
+    await triggerInBlock()
+
+    // No head is ever pushed; only the poll can move this forward.
+    await jest.advanceTimersByTimeAsync(config.chain.confirmationPollIntervalMs * 2)
+
+    await expect(result).resolves.toMatchObject({
+      success: true,
+      status: 'InBlock',
+      blockNumber: INCLUSION_NUMBER,
+      blockHash: INCLUSION_HASH,
+    })
+    expect(api.rpc.chain.getHeader).toHaveBeenCalled()
+
+    // The poll interval is torn down on resolution: further time does not poll.
+    const polls = api.rpc.chain.getHeader.mock.calls.length
+    await jest.advanceTimersByTimeAsync(config.chain.confirmationPollIntervalMs * 3)
+    expect(api.rpc.chain.getHeader.mock.calls.length).toBe(polls)
+  })
+
+  it('does not fail the tx when the subscription cannot be opened — the poll still confirms', async () => {
+    jest.useFakeTimers()
+    // subscribeNewHeads rejects. Before the fix this resolved ConfirmationError
+    // immediately (→ nonce resync → same-nonce retry, a step in the incident
+    // loop); now the poll fallback carries the tx to confirmation.
+    const api = makeApi({
+      subscribe: async () => {
+        throw new Error('subscription failed to open')
+      },
+      headNumber: HEAD_AT_DEPTH,
+    })
+    const { tx, triggerInBlock } = makeTransaction()
+
+    const result = run(api, tx)
+    await triggerInBlock()
+    await jest.advanceTimersByTimeAsync(config.chain.confirmationPollIntervalMs * 2)
+
+    await expect(result).resolves.toMatchObject({ success: true, status: 'InBlock' })
+  })
+
+  it('still confirms via the new-heads subscription (primary path unchanged)', async () => {
+    jest.useFakeTimers()
+    let headCb: HeadHandler | undefined
+    const api = makeApi({
+      subscribe: async (cb) => {
+        headCb = cb
+        return () => {}
+      },
+      headNumber: 0, // getHeader is unused on the subscription path
+    })
+    const { tx, triggerInBlock } = makeTransaction()
+
+    const result = run(api, tx)
+    await triggerInBlock()
+
+    // Push a head at confirmation depth through the subscription — no poll tick.
+    await headCb!({ number: { toNumber: () => HEAD_AT_DEPTH } })
+
+    await expect(result).resolves.toMatchObject({
+      success: true,
+      status: 'InBlock',
+      blockNumber: INCLUSION_NUMBER,
+    })
+    expect(api.rpc.chain.getHeader).not.toHaveBeenCalled()
+  })
+
+  it('resolves Reorged when the inclusion block is no longer canonical at depth', async () => {
+    jest.useFakeTimers()
+    const api = makeApi({
+      subscribe: async () => () => {},
+      headNumber: HEAD_AT_DEPTH,
+      canonicalHash: REORG_HASH, // chain reports a different block at the height
+    })
+    const { tx, triggerInBlock } = makeTransaction()
+
+    const result = run(api, tx)
+    await triggerInBlock()
+    await jest.advanceTimersByTimeAsync(config.chain.confirmationPollIntervalMs * 2)
+
+    await expect(result).resolves.toMatchObject({
+      success: false,
+      status: 'Reorged',
+    })
+  })
+})

--- a/apps/backend/src/config.ts
+++ b/apps/backend/src/config.ts
@@ -45,6 +45,21 @@ export const config = {
     // 5-minute default leaves room for inclusion latency. Raise this if you
     // increase confirmationDepth or run under sustained heavy load.
     transactionTimeoutMs: positiveIntEnv('CHAIN_TRANSACTION_TIMEOUT_MS', 300000),
+    // Safety-net cadence for the confirmation watch. Confirmation is normally
+    // driven by a new-heads subscription, but a WebSocket reconnect can leave
+    // that subscription silently dead while the chain keeps advancing — so
+    // `head >= inclusion + confirmationDepth` is never observed and the tx
+    // hangs until transactionTimeoutMs, is retried with the same nonce,
+    // re-included, and stalls again. In addition to the subscription, the head
+    // is polled on this interval and the same confirmation check is run, so
+    // confirmation still completes when the subscription stops delivering.
+    // Roughly one block time keeps the degraded path about as timely as the
+    // healthy one; the cost is one `getHeader` per in-flight tx per interval.
+    // Falls back to 6000ms for missing/invalid values so the poll never stalls.
+    confirmationPollIntervalMs: positiveIntEnv(
+      'CHAIN_CONFIRMATION_POLL_INTERVAL_MS',
+      6000,
+    ),
   },
   memoryDownloadCache: {
     maxCacheSize: Number(

--- a/apps/backend/src/infrastructure/drivers/substrate.ts
+++ b/apps/backend/src/infrastructure/drivers/substrate.ts
@@ -1,8 +1,32 @@
 import { ApiPromise, WsProvider } from '@polkadot/api'
 import { config } from '../../config.js'
+import { createLogger } from './logger.js'
+
+const logger = createLogger('drivers:substrate')
 
 export const createConnection = (): Promise<ApiPromise> => {
   const provider = new WsProvider(config.chain.endpoint)
+
+  // Surface the WebSocket connection lifecycle. WsProvider auto-reconnects on a
+  // dropped socket, but an RPC subscription opened on the old socket can stop
+  // delivering after the reconnect while one-shot calls (getHeader/getBlockHash)
+  // keep working — which is exactly what strands a publish transaction in
+  // "publishing" (see the confirmation poll fallback in transactionManager).
+  // Logging connect/disconnect makes a reconnect visible in the trace so a
+  // stalled confirmation can be correlated with a socket blip rather than
+  // inferred from a frozen queue.
+  provider.on('connected', () =>
+    logger.info('Substrate RPC connected: %s', config.chain.endpoint),
+  )
+  provider.on('disconnected', () =>
+    logger.warn(
+      'Substrate RPC disconnected: %s (WsProvider will auto-reconnect)',
+      config.chain.endpoint,
+    ),
+  )
+  provider.on('error', (error) =>
+    logger.error(error as Error, 'Substrate RPC provider error'),
+  )
 
   return ApiPromise.create({
     provider,

--- a/apps/backend/src/infrastructure/services/upload/onchainPublisher/transactionManager.ts
+++ b/apps/backend/src/infrastructure/services/upload/onchainPublisher/transactionManager.ts
@@ -33,7 +33,9 @@ const logger = createLogger('upload:transactionManager')
  * was reorged out, we resolve `success: false` so the node re-enters the
  * publishing pipeline instead of being silently lost.
  */
-const submitTransaction = (
+// Exported for unit testing of the confirmation watch (subscription + poll
+// fallback) against a mocked polkadot api; not part of the module's public API.
+export const submitTransaction = (
   api: ApiPromise,
   keyPair: KeyringPair,
   transaction: SubmittableExtrinsic<'promise'>,
@@ -78,9 +80,16 @@ const submitTransaction = (
     let confirmationChecking = false
 
     let timeoutHandle: ReturnType<typeof setTimeout>
+    // Interval handle for the confirmation poll fallback (startConfirmationPoll);
+    // cleared in cleanup() alongside the subscriptions.
+    let pollHandle: ReturnType<typeof setInterval> | undefined
 
     const cleanup = () => {
       clearTimeout(timeoutHandle)
+      if (pollHandle) {
+        clearInterval(pollHandle)
+        pollHandle = undefined
+      }
       // Remove the API error listener to prevent accumulation
       api.off('error', onApiError)
       if (extrinsicUnsub) {
@@ -145,11 +154,173 @@ const submitTransaction = (
     api.once('error', onApiError)
 
     /**
-     * Opens a single new-heads subscription (idempotent across re-inclusions)
-     * that, once `confirmationDepth` blocks have built on the *current*
-     * inclusion block, verifies that block is still canonical before resolving.
-     * The inclusion target is read live, so a reorg that re-includes the
-     * extrinsic in a new block is followed rather than mistaken for a drop.
+     * Runs the confirmation/canonical decision for a single observed head
+     * height. Invoked from both the new-heads subscription (the low-latency
+     * primary path) and the poll fallback (the liveness backstop), so the
+     * decision lives in one place. `confirmationChecking` serialises the two, so
+     * a subscription head and a poll tick can never run the canonical lookup
+     * concurrently. `source` is logged so the trace shows which path is driving
+     * progress: if the `head-sub` lines stop while `poll` lines keep advancing,
+     * the subscription has gone silent and the fallback is carrying the tx.
+     */
+    const runConfirmationCheck = async (
+      headNumber: number,
+      source: 'head-sub' | 'poll',
+    ) => {
+      if (isResolved || confirmationChecking) return
+      // Snapshot the current inclusion target; it can change under us if a
+      // reorg re-includes the extrinsic in a new block mid-flight.
+      const targetHash = inclusionHash
+      const targetNumber = inclusionNumber
+      if (targetHash === undefined || targetNumber === undefined) return
+
+      // Block-by-block confirmation trace. For every observed head while this tx
+      // is awaiting confirmation we log: the current head height, the block the
+      // tx is currently considered included in, how many confirmations have
+      // accumulated vs. how many are required, and how many blocks are still
+      // outstanding. If `remaining` fails to trend toward 0 — e.g. it stays
+      // pinned near `confirmationDepth` while `head` keeps climbing — the
+      // inclusion target is moving in lockstep with the head (repeated
+      // re-inclusion; see the RE-INCLUDED log) and the tx will never confirm. If
+      // the `head-sub` source stops advancing while the `poll` source keeps
+      // going, the subscription stalled and the poll is covering for it. Either
+      // pattern explains a tx stuck in "publishing".
+      const requiredHeadNumber = targetNumber + config.chain.confirmationDepth
+      const confirmations = headNumber - targetNumber
+      logger.debug(
+        'Tx %s confirmation trace [%s]: head #%d | inclusion #%d (%s) | %d/%d confirmations | need head >= #%d | %d block(s) remaining',
+        txHash,
+        source,
+        headNumber,
+        targetNumber,
+        targetHash,
+        confirmations < 0 ? 0 : confirmations,
+        config.chain.confirmationDepth,
+        requiredHeadNumber,
+        Math.max(0, requiredHeadNumber - headNumber),
+      )
+
+      if (
+        !hasReachedConfirmationDepth(
+          headNumber,
+          targetNumber,
+          config.chain.confirmationDepth,
+        )
+      )
+        return
+
+      confirmationChecking = true
+      try {
+        // The block is now buried deep enough. Verify the inclusion block is
+        // still the canonical block at its height — if a reorg replaced it, our
+        // transaction is no longer on-chain.
+        const canonicalHash = (
+          await api.rpc.chain.getBlockHash(targetNumber)
+        ).toString()
+
+        // If the inclusion target changed during the async lookup (the extrinsic
+        // was re-included elsewhere), defer to the next head rather than judging
+        // against a stale target.
+        if (inclusionHash !== targetHash || inclusionNumber !== targetNumber) {
+          return
+        }
+
+        // Confirmation depth reached: this is the actual publish/drop decision.
+        // Log the comparison that drives it — the hash we recorded at inclusion
+        // vs. the hash the chain now reports as canonical at that same height. A
+        // mismatch here (rather than a never-reached depth) means the block was
+        // reorged out from under a confirmed tx.
+        logger.debug(
+          'Tx %s reached confirmation depth at head #%d [%s] — canonical check @ height #%d: expected(inclusion)=%s canonical(chain)=%s => %s',
+          txHash,
+          headNumber,
+          source,
+          targetNumber,
+          targetHash,
+          canonicalHash,
+          isStillCanonical(canonicalHash, targetHash)
+            ? 'MATCH → publishing'
+            : 'MISMATCH → reorged/dropping',
+        )
+
+        if (isStillCanonical(canonicalHash, targetHash)) {
+          resolveOnce({
+            success: true,
+            txHash,
+            blockHash: targetHash,
+            blockNumber: targetNumber,
+            status: 'InBlock',
+          })
+        } else {
+          logger.warn(
+            'Tx %s reorged out: inclusion block %d (%s) replaced by %s',
+            txHash,
+            targetNumber,
+            targetHash,
+            canonicalHash,
+          )
+          resolveOnce({
+            success: false,
+            txHash,
+            status: 'Reorged',
+            error: 'Inclusion block reorged out before confirmation',
+          })
+        }
+      } catch (error) {
+        // A transient RPC failure during the canonical-hash lookup must not
+        // surface as an unhandled rejection. Log and let the next observed head
+        // re-trigger the check; the overall timeout is the backstop.
+        logger.warn(
+          error as Error,
+          'Confirmation check failed for tx %s; retrying on next head',
+          txHash,
+        )
+      } finally {
+        confirmationChecking = false
+      }
+    }
+
+    /**
+     * Liveness backstop for the confirmation watch (idempotent). The new-heads
+     * subscription below is the primary signal, but a WebSocket reconnect can
+     * leave that subscription silently dead: the socket comes back — so one-shot
+     * RPC calls like getHeader/getBlockHash work again — while the subscription
+     * never re-delivers, so `head >= inclusion + depth` is never observed. The
+     * tx then hangs until the timeout, is retried with the same nonce,
+     * re-included, and stalls again (the "stuck in publishing" incident).
+     * Polling the head on an interval and running the same check makes
+     * confirmation progress even when the subscription has stopped delivering;
+     * getHeader() is a fresh request each tick, unaffected by a dead
+     * subscription.
+     */
+    const startConfirmationPoll = () => {
+      if (pollHandle) return
+      pollHandle = setInterval(() => {
+        if (isResolved) return
+        api.rpc.chain
+          .getHeader()
+          .then((header) =>
+            runConfirmationCheck(header.number.toNumber(), 'poll'),
+          )
+          .catch((error) => {
+            // Transient RPC failure (e.g. mid-reconnect); the next tick retries
+            // and transactionTimeoutMs is the ultimate backstop.
+            logger.debug(
+              'Tx %s confirmation poll head fetch failed: %s',
+              txHash,
+              (error as Error).message,
+            )
+          })
+      }, config.chain.confirmationPollIntervalMs)
+    }
+
+    /**
+     * Opens the confirmation watch (idempotent across re-inclusions): a
+     * new-heads subscription for low latency plus a poll fallback for liveness.
+     * Both run the same check against the *current* inclusion target (read live,
+     * so a reorg that re-includes the extrinsic elsewhere is followed rather
+     * than mistaken for a drop) and resolve once `confirmationDepth` blocks have
+     * built on top and the inclusion block is still canonical.
      */
     const ensureConfirmationWatch = async () => {
       // The promise may already have settled (e.g. the timeout fired) while the
@@ -159,126 +330,19 @@ const submitTransaction = (
       if (isResolved || headsSubscribed) return
       headsSubscribed = true
       logger.debug(
-        'Tx %s: confirmation watch open — subscribed to new heads, waiting for head to reach inclusion + %d',
+        'Tx %s: confirmation watch open — new-heads subscription + %dms poll fallback, waiting for head to reach inclusion + %d',
         txHash,
+        config.chain.confirmationPollIntervalMs,
         config.chain.confirmationDepth,
       )
 
+      // Start the liveness backstop first, so confirmation still progresses even
+      // if the subscription below fails to open or later goes silent.
+      startConfirmationPoll()
+
       try {
         const unsub = await api.rpc.chain.subscribeNewHeads(async (header) => {
-          if (isResolved || confirmationChecking) return
-          // Snapshot the current inclusion target; it can change under us if a
-          // reorg re-includes the extrinsic in a new block mid-flight.
-          const targetHash = inclusionHash
-          const targetNumber = inclusionNumber
-          if (targetHash === undefined || targetNumber === undefined) return
-
-          // Block-by-block confirmation trace. For every new head while this tx
-          // is awaiting confirmation we log: the current head height, the block
-          // the tx is currently considered included in, how many confirmations
-          // have accumulated vs. how many are required, and how many blocks are
-          // still outstanding. If `remaining` fails to trend toward 0 — e.g. it
-          // stays pinned near `confirmationDepth` while `head` keeps climbing —
-          // the inclusion target is moving in lockstep with the head (repeated
-          // re-inclusion; see the RE-INCLUDED log) and the tx will never
-          // confirm. If `head` itself stops advancing, the RPC head stream has
-          // stalled. Either pattern explains a tx stuck in "publishing".
-          const headNumber = header.number.toNumber()
-          const requiredHeadNumber =
-            targetNumber + config.chain.confirmationDepth
-          const confirmations = headNumber - targetNumber
-          logger.debug(
-            'Tx %s confirmation trace: head #%d | inclusion #%d (%s) | %d/%d confirmations | need head >= #%d | %d block(s) remaining',
-            txHash,
-            headNumber,
-            targetNumber,
-            targetHash,
-            confirmations < 0 ? 0 : confirmations,
-            config.chain.confirmationDepth,
-            requiredHeadNumber,
-            Math.max(0, requiredHeadNumber - headNumber),
-          )
-
-          if (
-            !hasReachedConfirmationDepth(
-              headNumber,
-              targetNumber,
-              config.chain.confirmationDepth,
-            )
-          )
-            return
-
-          confirmationChecking = true
-          try {
-            // The block is now buried deep enough. Verify the inclusion block
-            // is still the canonical block at its height — if a reorg replaced
-            // it, our transaction is no longer on-chain.
-            const canonicalHash = (
-              await api.rpc.chain.getBlockHash(targetNumber)
-            ).toString()
-
-            // If the inclusion target changed during the async lookup (the
-            // extrinsic was re-included elsewhere), defer to the next head
-            // rather than judging against a stale target.
-            if (
-              inclusionHash !== targetHash ||
-              inclusionNumber !== targetNumber
-            ) {
-              return
-            }
-
-            // Confirmation depth reached: this is the actual publish/drop
-            // decision. Log the comparison that drives it — the hash we recorded
-            // at inclusion vs. the hash the chain now reports as canonical at
-            // that same height. A mismatch here (rather than a never-reached
-            // depth) means the block was reorged out from under a confirmed tx.
-            logger.debug(
-              'Tx %s reached confirmation depth at head #%d — canonical check @ height #%d: expected(inclusion)=%s canonical(chain)=%s => %s',
-              txHash,
-              headNumber,
-              targetNumber,
-              targetHash,
-              canonicalHash,
-              isStillCanonical(canonicalHash, targetHash)
-                ? 'MATCH → publishing'
-                : 'MISMATCH → reorged/dropping',
-            )
-
-            if (isStillCanonical(canonicalHash, targetHash)) {
-              resolveOnce({
-                success: true,
-                txHash,
-                blockHash: targetHash,
-                blockNumber: targetNumber,
-                status: 'InBlock',
-              })
-            } else {
-              logger.warn(
-                'Tx %s reorged out: inclusion block %d (%s) replaced by %s',
-                txHash,
-                targetNumber,
-                targetHash,
-                canonicalHash,
-              )
-              resolveOnce({
-                success: false,
-                txHash,
-                status: 'Reorged',
-                error: 'Inclusion block reorged out before confirmation',
-              })
-            }
-          } catch (error) {
-            // A transient RPC failure during the canonical-hash lookup must not
-            // surface as an unhandled rejection. Log and let the next head
-            // re-trigger the check; the overall timeout is the backstop.
-            logger.warn(
-              error as Error,
-              'Confirmation check failed for tx %s; retrying on next head',
-              txHash,
-            )
-          } finally {
-            confirmationChecking = false
-          }
+          await runConfirmationCheck(header.number.toNumber(), 'head-sub')
         })
 
         headsUnsub = unsub
@@ -289,15 +353,17 @@ const submitTransaction = (
           headsUnsub = undefined
         }
       } catch (error) {
-        // Failing to subscribe happens after inclusion (the nonce was already
-        // consumed on-chain), so this is transient — resolve with a status that
-        // resyncs the account rather than evicting it from the pool.
-        resolveOnce({
-          success: false,
+        // The subscription failed to open, but the poll fallback is already
+        // running and will drive confirmation to completion, so this is no
+        // longer fatal. Previously this resolved ConfirmationError, which
+        // resynced the nonce and triggered a same-nonce retry — a step in the
+        // loop that fed the incident. Log and rely on the poll;
+        // transactionTimeoutMs remains the ultimate backstop.
+        logger.warn(
+          error as Error,
+          'Tx %s: subscribeNewHeads failed to open; relying on confirmation poll fallback',
           txHash,
-          status: 'ConfirmationError',
-          error: (error as Error).message,
-        })
+        )
       }
     }
 


### PR DESCRIPTION
…heads subscription

On-chain publishing marks a tx durably published only after `confirmationDepth` blocks build on its inclusion block, observed via a per-tx `api.rpc.chain.subscribeNewHeads` subscription. A WebSocket reconnect can leave that subscription silently dead -- the socket comes back and one-shot RPC calls keep working, but the subscription never re-delivers -- so `head >= inclusion + depth` is never observed. The tx then hangs until the timeout, is retried with the same nonce, re-included, and stalls again: the "stuck in publishing" incident.

Add a poll fallback alongside the subscription:

- Extract the confirmation/canonical decision into `runConfirmationCheck`, shared by the subscription (`head-sub`) and a new `startConfirmationPoll` that ticks `getHeader()` every `CHAIN_CONFIRMATION_POLL_INTERVAL_MS` (config `confirmationPollIntervalMs`, default 6000ms ~= 1 block). getHeader is a fresh request each tick, so it drives confirmation even when the subscription is dead. `confirmationChecking` serialises the two paths; `source` is logged so the trace shows the poll carrying a tx when `head-sub` lines stop.
- Make a failed `subscribeNewHeads` open non-fatal: it used to resolve ConfirmationError (-> nonce resync -> same-nonce retry, a step in the incident loop); now it logs and relies on the poll. The timeout remains the backstop.
- Log the WS connection lifecycle (connected/disconnected/error) in substrate.ts so a reconnect is visible in the trace.

Unit-tests the confirmation watch against a mocked polkadot api + fake timers: the poll confirms when the subscription is silent, a failed subscription open still confirms via the poll, the subscription path is unchanged, and a non-canonical inclusion block at depth resolves Reorged. `submitTransaction` is exported for these tests.

Scope: does not change the separate re-inclusion-livelock path (target chasing the head); that is a distinct fix if traces ever show `remaining` not reaching 0.