### PR TITLE
fix(deploy): stop auto-drive-backend systemd restart loop (#792)

### DIFF
--- a/systemd/logrotate
+++ b/systemd/logrotate
@@ -1,12 +1,14 @@
+# Use copytruncate: systemd holds this log open via its `append:` StandardOutput
+# fd, so a rename+create rotation would leave the service writing to the rotated
+# (now-invisible) inode. copytruncate keeps the same inode and needs no service
+# bounce. Do NOT re-add a `postrotate systemctl restart` hook here: it bounced
+# the whole stack daily and interrupted on-chain publishing (see issue #792).
 /var/log/auto-drive-backend.log {
     daily
     rotate 7
     compress
     missingok
     notifempty
-    create 0644 ubuntu ubuntu
+    copytruncate
     su ubuntu ubuntu
-    postrotate
-        systemctl restart auto-drive-backend.service > /dev/null 2>/dev/null || true
-    endscript
 }

--- a/systemd/systemd
+++ b/systemd/systemd
@@ -1,21 +1,27 @@
 [Unit]
 Description=Auto Drive Backend Service
-After=network.target
+After=network-online.target docker.service
+Requires=docker.service
+Wants=network-online.target
 
 [Service]
+Type=oneshot
+RemainAfterExit=yes
 User=ubuntu
 Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 WorkingDirectory=/home/ubuntu/deploy
 ExecStart=/usr/bin/docker compose --env-file /home/ubuntu/deploy/auto-drive/.env -f /home/ubuntu/deploy/auto-drive/docker-compose.prod.yml up -d --remove-orphans
-Restart=always
-RestartSec=5
+ExecStop=/usr/bin/docker compose --env-file /home/ubuntu/deploy/auto-drive/.env -f /home/ubuntu/deploy/auto-drive/docker-compose.prod.yml stop
+Restart=on-failure
+RestartSec=30
 SyslogIdentifier=auto-drive-backend
 StandardOutput=append:/var/log/auto-drive-backend.log
 StandardError=append:/var/log/auto-drive-backend.log
 
-# Resource limits
-CPUQuota=90%
-MemoryMax=4G
+# NOTE: CPUQuota/MemoryMax were removed. On this Type=oneshot unit they would
+# only bound the short-lived `docker compose` CLI cgroup, not the containers
+# (which run under dockerd). Set real limits via `mem_limit` / `cpus` on the
+# services in docker-compose.prod.yml if needed.
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The auto-drive-backend systemd unit had no Type=, so it defaulted to Type=simple with ExecStart=`docker compose up -d`. Because `up -d` returns within seconds, systemd treated the service as dead and Restart=always/RestartSec=5 re-ran it every ~5s (~2.7M restarts), hammering dockerd. Combined with the logrotate postrotate `systemctl restart` hook, this bounced backend-worker repeatedly; each bounce interrupted the on-chain publish-nodes pipeline before confirmationDepth, stranding objects in the `publishing` state.

systemd/systemd:
- Type=oneshot + RemainAfterExit=yes: run compose once, then stay active(exited) instead of being seen as dead and restarted.
- Restart=on-failure, RestartSec=30; add ExecStop; order after docker.service (Requires + After).
- Drop CPUQuota/MemoryMax: they only bounded the short-lived compose CLI cgroup, not the dockerd-managed containers.

systemd/logrotate:
- Replace the stack-restarting postrotate hook with copytruncate, which is correct for systemd `append:` output (it keeps the same inode the service already holds open).

Rollout is manual on the host (daemon-reload + stop/start), per the issue.

Refs #792