### PR TITLE
fix(admin): show purchasing wallet in full with a copy button

### DIFF
--- a/apps/frontend/src/components/views/AdminPanel/AdminCredits.tsx
+++ b/apps/frontend/src/components/views/AdminPanel/AdminCredits.tsx
@@ -27,6 +27,7 @@ import type {
   OverCapIntent,
 } from '../../../services/api';
 import Link from 'next/link';
+import { CopiableText } from '../../atoms/CopiableText';
 
 // ---------------------------------------------------------------------------
 // Economics summary card
@@ -339,12 +340,14 @@ const AccountBatchGroupSection = ({
                     {batch.userPublicId.slice(0, 12)}…
                   </Link>
                 </td>
+                {/* Purchasing wallet in full (never truncated) with a copy
+                    button — refunds go back to this exact address. */}
                 <td className='px-4 py-2 font-mono text-xs'>
                   {batch.fromAddress ? (
-                    <span title={batch.fromAddress}>
-                      {batch.fromAddress.slice(0, 8)}…
-                      {batch.fromAddress.slice(-6)}
-                    </span>
+                    <CopiableText
+                      text={batch.fromAddress}
+                      className='whitespace-nowrap'
+                    />
                   ) : (
                     <span className='text-muted-foreground'>—</span>
                   )}

--- a/apps/frontend/src/components/views/AdminPanel/AdminUserCredits.tsx
+++ b/apps/frontend/src/components/views/AdminPanel/AdminUserCredits.tsx
@@ -23,6 +23,7 @@ import type { AdminUserCreditBatch } from '../../../services/api';
 import Link from 'next/link';
 import { shannonsToAi3 } from '@autonomys/auto-utils';
 import { RefundTxHashModal } from './RefundTxHashModal';
+import { CopiableText } from '../../atoms/CopiableText';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -209,6 +210,14 @@ export const AdminUserCredits = ({
     }
   }, [refundTarget, batches]);
 
+  // Destination of the out-of-band AI3 transfer for the batches in the modal.
+  // Combined refunds are constrained to one (account, purchasing wallet) pair,
+  // so the first target batch's wallet is the wallet for all of them.
+  const refundTargetWallet = useMemo(() => {
+    if (!refundTarget) return null;
+    return batches.find((b) => b.id === refundTarget[0])?.fromAddress ?? null;
+  }, [refundTarget, batches]);
+
   return (
     <div className='space-y-6 p-6'>
       {/* Header */}
@@ -287,21 +296,38 @@ export const AdminUserCredits = ({
       {/* Combined refund action bar */}
       {selectedRefundableIds.length > 0 && (
         <div className='flex flex-wrap items-center justify-between gap-3 rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 dark:border-amber-700 dark:bg-amber-900/20'>
-          <p className='text-sm text-amber-800 dark:text-amber-300'>
-            {selectedRefundableIds.length}{' '}
-            {selectedRefundableIds.length === 1 ? 'batch' : 'batches'} selected
-            {hasMultipleRefundGroups && selectedBatch && (
-              <span className='font-mono'>
-                {' '}
-                (account {selectedBatch.accountId.slice(0, 8)}…, wallet{' '}
-                {selectedBatch.fromAddress
-                  ? `${selectedBatch.fromAddress.slice(0, 8)}…`
-                  : 'unknown'}
-                )
-              </span>
-            )}{' '}
-            — one transaction hash will be recorded on all of them.
-          </p>
+          <div className='space-y-1'>
+            <p className='text-sm text-amber-800 dark:text-amber-300'>
+              {selectedRefundableIds.length}{' '}
+              {selectedRefundableIds.length === 1 ? 'batch' : 'batches'}{' '}
+              selected
+              {hasMultipleRefundGroups && selectedBatch && (
+                <span className='font-mono'>
+                  {' '}
+                  (account {selectedBatch.accountId.slice(0, 8)}…)
+                </span>
+              )}{' '}
+              — one transaction hash will be recorded on all of them.
+            </p>
+            {/* Destination of the AI3 transfer, in full and copiable: every
+                selected batch shares this purchasing wallet, and the admin
+                has to paste it into their wallet to send the refund. */}
+            {selectedBatch && (
+              <div className='flex items-center gap-2 text-xs text-amber-800 dark:text-amber-300'>
+                <span>Refund to wallet:</span>
+                {selectedBatch.fromAddress ? (
+                  <CopiableText
+                    text={selectedBatch.fromAddress}
+                    className='whitespace-nowrap font-mono'
+                  />
+                ) : (
+                  <span className='font-mono'>
+                    unknown (legacy intent — no wallet recorded)
+                  </span>
+                )}
+              </div>
+            )}
+          </div>
           <div className='flex items-center gap-2'>
             <Button
               variant='outline'
@@ -460,13 +486,16 @@ export const AdminUserCredits = ({
                       {formatAI3Paid(batch.paymentAmount)}
                     </td>
 
-                    {/* EVM wallet */}
+                    {/* EVM wallet — shown in full, never truncated: the
+                        refund transfer has to go back to this exact address,
+                        so the admin needs to read and copy all 42 chars. The
+                        table scrolls horizontally if the row gets too wide. */}
                     <td className='px-4 py-3 font-mono text-xs'>
                       {batch.fromAddress ? (
-                        <span title={batch.fromAddress}>
-                          {batch.fromAddress.slice(0, 8)}…
-                          {batch.fromAddress.slice(-6)}
-                        </span>
+                        <CopiableText
+                          text={batch.fromAddress}
+                          className='whitespace-nowrap'
+                        />
                       ) : (
                         <span className='text-muted-foreground'>—</span>
                       )}
@@ -521,6 +550,7 @@ export const AdminUserCredits = ({
         <RefundTxHashModal
           batchCount={refundTarget.length}
           suggestedRefundAi3={suggestedRefundAi3}
+          refundWalletAddress={refundTargetWallet}
           isSubmitting={isRefunding}
           errorMessage={refundError}
           onConfirm={(refundTxHash) =>

--- a/apps/frontend/src/components/views/AdminPanel/RefundTxHashModal.tsx
+++ b/apps/frontend/src/components/views/AdminPanel/RefundTxHashModal.tsx
@@ -6,6 +6,7 @@ import { AlertTriangle, X } from 'lucide-react';
 // Same regex the backend validates with — the backend rejects anything else
 // and the batch is NOT marked as refunded.
 import { EVM_TX_HASH_REGEX } from '@auto-drive/models';
+import { CopiableText } from '../../atoms/CopiableText';
 
 /**
  * Modal that collects the mandatory on-chain refund transaction hash before
@@ -17,6 +18,7 @@ import { EVM_TX_HASH_REGEX } from '@auto-drive/models';
 export const RefundTxHashModal = ({
   batchCount,
   suggestedRefundAi3,
+  refundWalletAddress,
   isSubmitting,
   errorMessage,
   onConfirm,
@@ -29,6 +31,13 @@ export const RefundTxHashModal = ({
    * the transferred amount — the transfer happens out-of-band.
    */
   suggestedRefundAi3?: string | null;
+  /**
+   * Purchasing wallet the batches were paid from — the destination of the
+   * out-of-band AI3 transfer. Shown in full and copiable so the admin can
+   * paste it straight into their wallet. Null for legacy intents with no
+   * recorded address.
+   */
+  refundWalletAddress?: string | null;
   isSubmitting: boolean;
   errorMessage: string | null;
   onConfirm: (refundTxHash: string) => void;
@@ -85,6 +94,16 @@ export const RefundTxHashModal = ({
           the entire remaining balance of the selected{' '}
           {batchCount === 1 ? 'batch' : 'batches'}.
         </p>
+
+        {refundWalletAddress && (
+          <div className='mb-4 rounded border border-border bg-muted/50 px-3 py-2 text-xs text-muted-foreground'>
+            <p className='mb-1'>Send the refund to the purchasing wallet:</p>
+            <CopiableText
+              text={refundWalletAddress}
+              className='break-all font-mono font-medium text-foreground'
+            />
+          </div>
+        )}
 
         {suggestedRefundAi3 && (
           <p className='mb-4 rounded border border-border bg-muted/50 px-3 py-2 text-xs text-muted-foreground'>


### PR DESCRIPTION
The Purchasing Wallet column on the admin credit screens was truncated to `0x123456…abcdef`, so the address the refund transfer has to go back to could not be read off the page — only hovered for a title tooltip.

- Render the full 42-char address in the Purchasing Wallet column on both the per-user credit screen and the account list, wrapped in the existing CopiableText atom so it can be copied in one click. Rows stay on one line (whitespace-nowrap) and the table containers already scroll horizontally.
- Show the destination wallet in full, with copy, in the combined-refund action bar (it replaces the truncated wallet that was only shown when batches spanned several refund groups).
- Show it again in the refund confirmation modal, where the admin is about to make the transfer and needs to paste the address into their wallet.