### PR TITLE
feat(backend): alert to Slack when a task exhausts its retries

### DIFF
--- a/apps/backend/.env.sample
+++ b/apps/backend/.env.sample
@@ -125,3 +125,15 @@ ORACLE_MAX_USD_PER_AI3=100
 # a USDC payment. The stored AI3/USD rate remains the raw market rate; only the
 # amount the user pays includes this margin. Default: 5.
 USD_QUOTE_MARGIN=5
+
+# Slack alerting for tasks that exhausted their retries and landed on an error
+# queue (frontend-errors / download-errors / publish-errors). The channel is
+# encoded in the incoming-webhook URL, so there is no separate channel setting.
+# Leave unset to disable alerting — failures are then only logged.
+SLACK_WEBHOOK_URL=
+# Label prefixed to every alert so staging and production are distinguishable.
+SLACK_ALERT_ENVIRONMENT=local
+# Failures are batched into one message per window rather than posted one by one,
+# so draining a backlog cannot flood the channel. Defaults: 60000 and 10.
+TASK_ERROR_ALERT_WINDOW_MS=60000
+TASK_ERROR_ALERT_MAX_ITEMS=10

--- a/apps/backend/.env.sample
+++ b/apps/backend/.env.sample
@@ -131,8 +131,6 @@ USD_QUOTE_MARGIN=5
 # encoded in the incoming-webhook URL, so there is no separate channel setting.
 # Leave unset to disable alerting — failures are then only logged.
 SLACK_WEBHOOK_URL=
-# Label prefixed to every alert so staging and production are distinguishable.
-SLACK_ALERT_ENVIRONMENT=local
 # Failures are batched into one message per window rather than posted one by one,
 # so draining a backlog cannot flood the channel. Defaults: 60000 and 10.
 TASK_ERROR_ALERT_WINDOW_MS=60000

--- a/apps/backend/.env.sample
+++ b/apps/backend/.env.sample
@@ -132,6 +132,8 @@ USD_QUOTE_MARGIN=5
 # Leave unset to disable alerting — failures are then only logged.
 SLACK_WEBHOOK_URL=
 # Failures are batched into one message per window rather than posted one by one,
-# so draining a backlog cannot flood the channel. Defaults: 60000 and 10.
-TASK_ERROR_ALERT_WINDOW_MS=60000
+# so draining a backlog cannot flood the channel. The window trades alert latency
+# for a quieter channel; these tasks have already exhausted every retry, so
+# nothing is waiting on the notification. Defaults: 1800000 (30 min) and 10.
+TASK_ERROR_ALERT_WINDOW_MS=1800000
 TASK_ERROR_ALERT_MAX_ITEMS=10

--- a/apps/backend/.env.sample
+++ b/apps/backend/.env.sample
@@ -129,7 +129,9 @@ USD_QUOTE_MARGIN=5
 # Slack alerting for tasks that exhausted their retries and landed on an error
 # queue (frontend-errors / download-errors / publish-errors). The channel is
 # encoded in the incoming-webhook URL, so there is no separate channel setting.
-# Leave unset to disable alerting — failures are then only logged.
+# Leave unset to disable alerting. The error queues are then left unconsumed, so
+# failed tasks accumulate on them (as they did before alerting existed) rather
+# than being acked away into log lines that a rotation eventually takes with them.
 SLACK_WEBHOOK_URL=
 # Failures are batched into one message per window rather than posted one by one,
 # so draining a backlog cannot flood the channel. The window trades alert latency

--- a/apps/backend/__tests__/unit/TaskManager.spec.ts
+++ b/apps/backend/__tests__/unit/TaskManager.spec.ts
@@ -85,7 +85,8 @@ describe('TaskManager', () => {
       .mocked(Rabbit.subscribe)
       .mockImplementation(async (queue, callback) => {
         subscribeCallback = callback
-        return Promise.resolve(() => {})
+        // Unsubscribing awaits `channel.cancel`, so the handle is async.
+        return Promise.resolve(async () => {})
       })
   })
 

--- a/apps/backend/__tests__/unit/eventRouter/startupConsumers.spec.ts
+++ b/apps/backend/__tests__/unit/eventRouter/startupConsumers.spec.ts
@@ -1,0 +1,106 @@
+import { jest, describe, it, expect, beforeAll, afterAll } from '@jest/globals'
+
+/**
+ * The startup path, for a worker that comes up before the broker does.
+ *
+ * `Rabbit.subscribe` re-raises a `consume` that failed, and the `listen*Events`
+ * helpers are called from a server entry point with no caller to return to. A
+ * floated subscribe promise there is the same mistake the reconnect loop and the
+ * keepalive interval each made (see rabbitReconnect.spec.ts): nothing in the
+ * backend registers an `unhandledRejection` handler and Node defaults to
+ * `--unhandled-rejections=throw`, so it kills the worker — on the one code path
+ * where the broker being briefly unreachable is entirely expected.
+ *
+ * Recovering rather than crashing is only worth anything because the driver now
+ * clears a rejected channel: the callback is registered in `subscriptions` before
+ * the channel is awaited, so the next keepalive tick opens a fresh channel and
+ * restores the consumer. The second test is that half.
+ */
+
+process.env.RABBITMQ_KEEP_ALIVE_INTERVAL = '20'
+
+const consumedQueues: string[] = []
+let failConnect = true
+
+jest.unstable_mockModule('amqplib', () => ({
+  connect: jest.fn(async () => {
+    if (failConnect) {
+      throw new Error('ECONNREFUSED: broker unreachable')
+    }
+    return {
+      createChannel: async () => ({
+        assertQueue: jest.fn(),
+        prefetch: jest.fn(),
+        ack: jest.fn(),
+        nack: jest.fn(),
+        sendToQueue: jest.fn(),
+        consume: async (queue: string) => {
+          consumedQueues.push(queue)
+          return { consumerTag: `tag-${consumedQueues.length}` }
+        },
+        cancel: async () => undefined,
+        checkQueue: async () => ({ messageCount: 0 }),
+        close: async () => undefined,
+      }),
+      close: async () => undefined,
+    }
+  }),
+}))
+
+const { EventRouter } = await import(
+  '../../../src/infrastructure/eventRouter/index.js'
+)
+const { Rabbit } = await import('../../../src/infrastructure/drivers/rabbit.js')
+
+const tick = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+const waitFor = async (predicate: () => boolean, timeout = 5000) => {
+  for (let waited = 0; waited < timeout && !predicate(); waited += 20) {
+    await tick(20)
+  }
+  return predicate()
+}
+
+describe('EventRouter startup consumers', () => {
+  const unhandled: unknown[] = []
+  const record = (reason: unknown) => unhandled.push(reason)
+
+  beforeAll(() => {
+    process.on('unhandledRejection', record)
+  })
+
+  afterAll(async () => {
+    process.off('unhandledRejection', record)
+    await Rabbit.close().catch(() => undefined)
+  })
+
+  it('survives a broker that is not up yet', async () => {
+    failConnect = true
+
+    EventRouter.listenFrontendEvents()
+    EventRouter.listenDownloadEvents()
+    EventRouter.listenPublishEvents()
+
+    // Long enough for the failing connects to settle and for Node to have made
+    // up its mind about whether anything handled them.
+    await tick(200)
+
+    expect(unhandled).toEqual([])
+  })
+
+  it('picks the queues up once the broker is reachable', async () => {
+    failConnect = false
+
+    // Nothing re-runs `listen*Events`; the keepalive tick is what reconnects, and
+    // the re-subscribe loop restores the callbacks registered by the failed
+    // subscribes above.
+    expect(
+      await waitFor(() =>
+        ['task-manager', 'download-manager', 'publish-manager'].every((queue) =>
+          consumedQueues.includes(queue),
+        ),
+      ),
+    ).toBe(true)
+    expect(unhandled).toEqual([])
+  }, 10000)
+})

--- a/apps/backend/__tests__/unit/eventRouter/taskErrorConsumers.spec.ts
+++ b/apps/backend/__tests__/unit/eventRouter/taskErrorConsumers.spec.ts
@@ -1,11 +1,26 @@
-import { jest, describe, it, expect, afterEach } from '@jest/globals'
+import {
+  jest,
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+} from '@jest/globals'
 import { EventRouter } from '../../../src/infrastructure/eventRouter/index.js'
 import { Rabbit } from '../../../src/infrastructure/drivers/rabbit.js'
+import { config } from '../../../src/config.js'
 
 const ERROR_QUEUES = ['frontend-errors', 'download-errors', 'publish-errors']
 
 describe('EventRouter task-error consumers', () => {
+  const originalWebhook = config.slack.webhookUrl
+
+  beforeEach(() => {
+    config.slack.webhookUrl = 'https://hooks.slack.example/T/B/XYZ'
+  })
+
   afterEach(() => {
+    config.slack.webhookUrl = originalWebhook
     jest.restoreAllMocks()
   })
 
@@ -90,5 +105,20 @@ describe('EventRouter task-error consumers', () => {
     EventRouter.listenTaskErrors()
 
     await expect(EventRouter.stopTaskErrors()).resolves.toBeUndefined()
+  })
+
+  // Consuming acks each failure off a durable queue. With no webhook configured
+  // there is nowhere for the alert to go, so consuming would reduce the backlog
+  // to log lines and destroy the only copy that outlives a log rotation.
+  it('does not consume anything when Slack alerting is unconfigured', async () => {
+    config.slack.webhookUrl = undefined
+    const subscribe = jest
+      .spyOn(Rabbit, 'subscribe')
+      .mockResolvedValue(async () => undefined)
+
+    EventRouter.listenTaskErrors()
+    await EventRouter.stopTaskErrors()
+
+    expect(subscribe).not.toHaveBeenCalled()
   })
 })

--- a/apps/backend/__tests__/unit/eventRouter/taskErrorConsumers.spec.ts
+++ b/apps/backend/__tests__/unit/eventRouter/taskErrorConsumers.spec.ts
@@ -1,0 +1,94 @@
+import { jest, describe, it, expect, afterEach } from '@jest/globals'
+import { EventRouter } from '../../../src/infrastructure/eventRouter/index.js'
+import { Rabbit } from '../../../src/infrastructure/drivers/rabbit.js'
+
+const ERROR_QUEUES = ['frontend-errors', 'download-errors', 'publish-errors']
+
+describe('EventRouter task-error consumers', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('subscribes to all three error queues', async () => {
+    const subscribe = jest
+      .spyOn(Rabbit, 'subscribe')
+      .mockResolvedValue(async () => undefined)
+
+    EventRouter.listenTaskErrors()
+    await EventRouter.stopTaskErrors()
+
+    expect(subscribe.mock.calls.map((call) => call[0])).toEqual(ERROR_QUEUES)
+  })
+
+  // The handles used to be collected in a `.then`, so between process start and
+  // the subscribe resolving this list was empty — a shutdown in that window
+  // cancelled nothing while reporting that consumers were stopped.
+  it('cancels consumers whose subscribe has not resolved yet', async () => {
+    const cancelled: string[] = []
+    const releases: Array<() => void> = []
+
+    jest.spyOn(Rabbit, 'subscribe').mockImplementation(((queue: string) => {
+      return new Promise((resolve) => {
+        releases.push(() =>
+          resolve(async () => {
+            cancelled.push(queue)
+          }),
+        )
+      })
+    }) as never)
+
+    EventRouter.listenTaskErrors()
+
+    // Shutdown begins before any subscribe has resolved.
+    const stopping = EventRouter.stopTaskErrors()
+    releases.forEach((release) => release())
+    await stopping
+
+    expect(cancelled.sort()).toEqual([...ERROR_QUEUES].sort())
+  })
+
+  // `channel.cancel` is asynchronous, so a fire-and-forget unsubscribe would let
+  // shutdown proceed to the flush while deliveries were still arriving.
+  it('waits for each cancel to complete', async () => {
+    let cancelsFinished = 0
+    // One resolver per consumer: the three cancels run concurrently, so a single
+    // shared resolver would leave two of them hanging.
+    const releases: Array<() => void> = []
+
+    jest.spyOn(Rabbit, 'subscribe').mockResolvedValue(
+      (async () => {
+        await new Promise<void>((resolve) => {
+          releases.push(resolve)
+        })
+        cancelsFinished++
+      }) as never,
+    )
+
+    EventRouter.listenTaskErrors()
+
+    let stopResolved = false
+    const stopping = EventRouter.stopTaskErrors().then(() => {
+      stopResolved = true
+    })
+
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(releases).toHaveLength(ERROR_QUEUES.length)
+    // A fire-and-forget unsubscribe would have let shutdown continue by now.
+    expect(stopResolved).toBe(false)
+    expect(cancelsFinished).toBe(0)
+
+    releases.forEach((release) => release())
+    await stopping
+    expect(cancelsFinished).toBe(ERROR_QUEUES.length)
+  })
+
+  it('continues shutting down when a subscribe never succeeded', async () => {
+    jest
+      .spyOn(Rabbit, 'subscribe')
+      .mockRejectedValue(new Error('channel closed'))
+
+    EventRouter.listenTaskErrors()
+
+    await expect(EventRouter.stopTaskErrors()).resolves.toBeUndefined()
+  })
+})

--- a/apps/backend/__tests__/unit/eventRouter/taskErrorNotifier.spec.ts
+++ b/apps/backend/__tests__/unit/eventRouter/taskErrorNotifier.spec.ts
@@ -145,6 +145,45 @@ describe('taskErrorNotifier', () => {
     expect(message.details.split('\n')).toHaveLength(2)
   })
 
+  // The character caps bound the message; this bounds the heap. A batching window
+  // is 30 minutes by default and a poison-message loop dead-letters as fast as the
+  // broker redelivers, all of it retained here with params until the window ends.
+  it('bounds how many failures it holds and counts the overflow', async () => {
+    for (let i = 0; i < 1_200; i++) {
+      await handleFailedTask('download-errors', {
+        ...failedTask(),
+        params: { cid: `cid-${i}` },
+      })
+    }
+    await flushTaskErrorAlerts()
+
+    const message = (send.mock.calls[0] as unknown[])[0] as {
+      title: string
+      details: string
+    }
+    // Capped at 1,000 held, so 200 are counted rather than kept.
+    expect(message.title).toContain('1000 tasks permanently failed')
+    expect(message.title).toContain('plus 200 not recorded')
+    expect(message.details).toContain('200 dropped before batching')
+  })
+
+  it('starts counting overflow again from zero after a flush', async () => {
+    for (let i = 0; i < 1_100; i++) {
+      await handleFailedTask('download-errors', failedTask())
+    }
+    await flushTaskErrorAlerts()
+
+    await handleFailedTask('download-errors', failedTask())
+    await flushTaskErrorAlerts()
+
+    const second = (send.mock.calls[1] as unknown[])[0] as {
+      title: string
+      details: string
+    }
+    expect(second.title).not.toContain('not recorded')
+    expect(second.details).not.toContain('dropped before batching')
+  })
+
   it('reports a missing reason rather than omitting the line', async () => {
     await handleFailedTask('publish-errors', failedTask({ error: undefined }))
     await flushTaskErrorAlerts()

--- a/apps/backend/__tests__/unit/eventRouter/taskErrorNotifier.spec.ts
+++ b/apps/backend/__tests__/unit/eventRouter/taskErrorNotifier.spec.ts
@@ -1,0 +1,139 @@
+import {
+  jest,
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+} from '@jest/globals'
+import { config } from '../../../src/config.js'
+import {
+  flushTaskErrorAlerts,
+  handleFailedTask,
+  resetTaskErrorAlerts,
+} from '../../../src/infrastructure/eventRouter/taskErrorNotifier.js'
+import { slackNotifier } from '../../../src/infrastructure/services/slack/index.js'
+
+const failedTask = (overrides: Record<string, unknown> = {}) => ({
+  id: 'async-download-created',
+  retriesLeft: 0,
+  params: { downloadId: 'dl-1' },
+  error: 'Error fetching file header: 404 Not Found',
+  failedAt: '2026-07-30T00:00:00.000Z',
+  ...overrides,
+})
+
+describe('taskErrorNotifier', () => {
+  const originalWebhook = config.slack.webhookUrl
+  const originalMaxItems = config.slack.alertMaxItems
+  let send: ReturnType<typeof jest.spyOn>
+
+  beforeEach(() => {
+    config.slack.webhookUrl = 'https://hooks.slack.example/T/B/XYZ'
+    send = jest
+      .spyOn(slackNotifier, 'send')
+      .mockResolvedValue(true) as unknown as ReturnType<typeof jest.spyOn>
+    resetTaskErrorAlerts()
+  })
+
+  afterEach(() => {
+    resetTaskErrorAlerts()
+    config.slack.webhookUrl = originalWebhook
+    config.slack.alertMaxItems = originalMaxItems
+    jest.restoreAllMocks()
+  })
+
+  it('names the task, its subject and the reason it failed', async () => {
+    await handleFailedTask('download-errors', failedTask())
+    await flushTaskErrorAlerts()
+
+    expect(send).toHaveBeenCalledTimes(1)
+    const message = (send.mock.calls[0] as unknown[])[0] as {
+      title: string
+      details: string
+    }
+    expect(message.title).toContain('async-download-created')
+    expect(message.details).toContain('downloadId=dl-1')
+    expect(message.details).toContain('404 Not Found')
+    expect(message.details).toContain('[download-errors]')
+  })
+
+  // The whole point of batching: a drained backlog of permanently failed tasks
+  // must not post once per message. There were 186 waiting in production.
+  it('batches many failures into a single message', async () => {
+    for (let i = 0; i < 50; i++) {
+      await handleFailedTask('download-errors', {
+        ...failedTask(),
+        params: { cid: `cid-${i}` },
+      })
+    }
+    await flushTaskErrorAlerts()
+
+    expect(send).toHaveBeenCalledTimes(1)
+    const message = (send.mock.calls[0] as unknown[])[0] as { title: string }
+    expect(message.title).toContain('50 tasks permanently failed')
+    expect(message.title).toContain('async-download-created×50')
+  })
+
+  it('lists a bounded number of failures and counts the rest', async () => {
+    config.slack.alertMaxItems = 3
+    for (let i = 0; i < 10; i++) {
+      await handleFailedTask('download-errors', {
+        ...failedTask(),
+        params: { cid: `cid-${i}` },
+      })
+    }
+    await flushTaskErrorAlerts()
+
+    const message = (send.mock.calls[0] as unknown[])[0] as { details: string }
+    expect(message.details).toContain('cid-0')
+    expect(message.details).toContain('… and 7 more')
+    expect(message.details).not.toContain('cid-9')
+  })
+
+  it('reports a missing reason rather than omitting the line', async () => {
+    await handleFailedTask('publish-errors', failedTask({ error: undefined }))
+    await flushTaskErrorAlerts()
+
+    const message = (send.mock.calls[0] as unknown[])[0] as { details: string }
+    expect(message.details).toContain('<not recorded>')
+  })
+
+  it('accumulates nothing when alerting is disabled', async () => {
+    config.slack.webhookUrl = undefined
+
+    await handleFailedTask('download-errors', failedTask())
+    await flushTaskErrorAlerts()
+
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  // These two matter because the queue driver requeues immediately and without
+  // backoff on a throw. Anything that throws here spins in a hot loop and stops
+  // the error queue draining at all.
+  it('does not throw on an unparseable message', async () => {
+    await expect(
+      handleFailedTask('download-errors', { nonsense: true }),
+    ).resolves.toBeUndefined()
+    await flushTaskErrorAlerts()
+
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('does not throw when Slack delivery fails', async () => {
+    send.mockResolvedValue(false as never)
+
+    await handleFailedTask('download-errors', failedTask())
+
+    await expect(flushTaskErrorAlerts()).resolves.toBeUndefined()
+  })
+
+  it('starts a fresh batch after flushing', async () => {
+    await handleFailedTask('download-errors', failedTask())
+    await flushTaskErrorAlerts()
+    await handleFailedTask('download-errors', failedTask())
+    await flushTaskErrorAlerts()
+
+    expect(send).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/backend/__tests__/unit/eventRouter/taskErrorNotifier.spec.ts
+++ b/apps/backend/__tests__/unit/eventRouter/taskErrorNotifier.spec.ts
@@ -91,6 +91,39 @@ describe('taskErrorNotifier', () => {
     expect(message.details).not.toContain('cid-9')
   })
 
+  // Slack truncates a body past 40,000 characters, and it truncates the tail —
+  // which is where the "and N more" count sits. Neither factor of the batch size
+  // is otherwise bounded: a reason is an arbitrary library error message, and
+  // the item cap is an environment variable somebody may raise mid-incident.
+  it('bounds a single overlong reason', async () => {
+    await handleFailedTask(
+      'publish-errors',
+      failedTask({ error: 'x'.repeat(50_000) }),
+    )
+    await flushTaskErrorAlerts()
+
+    const message = (send.mock.calls[0] as unknown[])[0] as { details: string }
+    expect(message.details.length).toBeLessThan(2000)
+    expect(message.details).toContain('see logs')
+  })
+
+  it('bounds the whole body and still reports what it left out', async () => {
+    config.slack.alertMaxItems = 500
+    for (let i = 0; i < 600; i++) {
+      await handleFailedTask('download-errors', {
+        ...failedTask(),
+        params: { cid: `cid-${i}` },
+        error: 'y'.repeat(400),
+      })
+    }
+    await flushTaskErrorAlerts()
+
+    const message = (send.mock.calls[0] as unknown[])[0] as { details: string }
+    expect(message.details.length).toBeLessThan(40_000)
+    // Clamping the body must not eat the count of what was never listed.
+    expect(message.details).toContain('… and 100 more')
+  })
+
   it('reports a missing reason rather than omitting the line', async () => {
     await handleFailedTask('publish-errors', failedTask({ error: undefined }))
     await flushTaskErrorAlerts()

--- a/apps/backend/__tests__/unit/eventRouter/taskErrorNotifier.spec.ts
+++ b/apps/backend/__tests__/unit/eventRouter/taskErrorNotifier.spec.ts
@@ -136,4 +136,71 @@ describe('taskErrorNotifier', () => {
 
     expect(send).toHaveBeenCalledTimes(2)
   })
+
+  // The shutdown sequence is: stop consuming, flush, close the channel, exit. The
+  // two races below both end with `process.exit` destroying a batch that had
+  // already been taken out of `pending`, so the flush saw nothing left to do.
+  describe('shutdown races', () => {
+    /** A send whose completion the test controls. */
+    const controllableSend = () => {
+      let release: (delivered: boolean) => void = () => undefined
+      const started = new Promise<void>((resolveStarted) => {
+        send.mockImplementation((() => {
+          resolveStarted()
+          return new Promise<boolean>((resolve) => {
+            release = resolve
+          })
+        }) as never)
+      })
+      return { started, release: () => release(true) }
+    }
+
+    it('waits for a send that is already in flight', async () => {
+      const { started, release } = controllableSend()
+
+      await handleFailedTask('download-errors', failedTask())
+      // Stand in for the batching window expiring just as SIGTERM lands.
+      const timerFlush = flushTaskErrorAlerts()
+      await started
+
+      let shutdownFinished = false
+      const shutdownFlush = flushTaskErrorAlerts().then(() => {
+        shutdownFinished = true
+      })
+
+      // The batch is no longer in `pending`, so a naive flush returns here and
+      // lets the caller exit while the webhook call is still open. Drained via a
+      // macrotask so every pending microtask settles first — a single
+      // `await Promise.resolve()` is not enough to distinguish the two, and lets
+      // this assertion pass against the very bug it is meant to catch.
+      await new Promise((resolve) => setImmediate(resolve))
+      expect(shutdownFinished).toBe(false)
+
+      release()
+      await Promise.all([timerFlush, shutdownFlush])
+      expect(shutdownFinished).toBe(true)
+    })
+
+    it('delivers failures that arrive while the final send is awaited', async () => {
+      const { started, release } = controllableSend()
+
+      await handleFailedTask('download-errors', failedTask())
+      const shutdownFlush = flushTaskErrorAlerts()
+      await started
+
+      // A consumer acks one more failure before the channel is closed.
+      await handleFailedTask('download-errors', {
+        ...failedTask(),
+        params: { cid: 'arrived-during-shutdown' },
+      })
+
+      send.mockResolvedValue(true as never)
+      release()
+      await shutdownFlush
+
+      expect(send).toHaveBeenCalledTimes(2)
+      const second = (send.mock.calls[1] as unknown[])[0] as { details: string }
+      expect(second.details).toContain('arrived-during-shutdown')
+    })
+  })
 })

--- a/apps/backend/__tests__/unit/eventRouter/taskErrorNotifier.spec.ts
+++ b/apps/backend/__tests__/unit/eventRouter/taskErrorNotifier.spec.ts
@@ -124,6 +124,27 @@ describe('taskErrorNotifier', () => {
     expect(message.details).toContain('… and 100 more')
   })
 
+  // `reason:` is one line in a list of them. An Error carrying a stack, or a
+  // wrapped RPC error, arrives with its own newlines and breaks that layout —
+  // pushing the rest of the batch down the message.
+  it('keeps a multi-line reason on one line', async () => {
+    await handleFailedTask(
+      'publish-errors',
+      failedTask({
+        error: '1010: Invalid Transaction\n  at signAndSend\n  at publishNodes',
+      }),
+    )
+    await flushTaskErrorAlerts()
+
+    const message = (send.mock.calls[0] as unknown[])[0] as { details: string }
+    const reason = message.details
+      .split('\n')
+      .find((line) => line.includes('reason:'))
+    expect(reason).toContain('1010: Invalid Transaction at signAndSend')
+    // One entry, so exactly two lines: the subject and its reason.
+    expect(message.details.split('\n')).toHaveLength(2)
+  })
+
   it('reports a missing reason rather than omitting the line', async () => {
     await handleFailedTask('publish-errors', failedTask({ error: undefined }))
     await flushTaskErrorAlerts()

--- a/apps/backend/__tests__/unit/utils/rabbitReconnect.spec.ts
+++ b/apps/backend/__tests__/unit/utils/rabbitReconnect.spec.ts
@@ -1,53 +1,168 @@
 import { jest, describe, it, expect, beforeEach } from '@jest/globals'
 
 /**
- * Covers unsubscribe staying correct across a re-subscribe.
+ * Covers consumer bookkeeping in the Rabbit driver: one live consumer per
+ * (queue, callback), and an unsubscribe that cancels whichever consumer is live
+ * now rather than the one it was handed at subscribe time.
  *
- * On reconnect, `getChannel` re-subscribes every stored callback — literally
- * `subscribe(queue, callback)` — and discards the new unsubscribe handles. So an
- * unsubscribe that captured its own consumer tag at subscribe time goes stale the
- * moment the connection bounces: cancelling it targets a consumer that is already
- * gone while the live one keeps delivering. These tests drive that re-subscribe
- * directly, which is what the reconnect path does.
+ * Two paths establish consumers and they overlap. `subscribe` registers its
+ * callback in `subscriptions` *before* awaiting `getChannel`, and `getChannel`
+ * re-subscribes everything in `subscriptions` once its channel resolves — that
+ * loop exists to restore consumers after a reconnect, but on a cold channel it
+ * also picks up the subscribe still in flight. Both then consumed, and the
+ * survivor in the driver's bookkeeping was whichever finished last: the other
+ * consumer stayed live with nobody holding its tag, so `unsubscribe` (and hence
+ * `EventRouter.stopTaskErrors`) left it delivering.
  *
- * `amqplib` is mocked because the driver's reconnect is internal (keepAlive owns
- * the cached channel), so there is no public way to force one.
+ * `amqplib` is mocked because the reconnect is internal — keepAlive owns the
+ * cached channel, so the only way to force one is to make its liveness probe
+ * fail. The keepalive interval is shortened for the same reason.
  */
 
-const consumerTags: string[] = []
+process.env.RABBITMQ_KEEP_ALIVE_INTERVAL = '20'
+
+interface FakeChannel {
+  id: number
+  closed: boolean
+  liveConsumers: Set<string>
+}
+
+const channels: FakeChannel[] = []
+const consumerTags: { tag: string; channel: number; queue: string }[] = []
 const cancelledTags: string[] = []
 let nextConsumerTag = 0
+let failCheckQueue = false
 
 jest.unstable_mockModule('amqplib', () => ({
   connect: jest.fn(async () => ({
-    createChannel: async () => ({
-      assertQueue: jest.fn(),
-      prefetch: jest.fn(),
-      ack: jest.fn(),
-      nack: jest.fn(),
-      sendToQueue: jest.fn(),
-      consume: async () => {
-        const consumerTag = `tag-${nextConsumerTag++}`
-        consumerTags.push(consumerTag)
-        return { consumerTag }
-      },
-      cancel: async (tag: string) => {
-        cancelledTags.push(tag)
-      },
-      checkQueue: async () => ({ messageCount: 0 }),
-      close: async () => undefined,
-    }),
+    createChannel: async () => {
+      const channel = {
+        id: channels.length,
+        closed: false,
+        liveConsumers: new Set<string>(),
+        assertQueue: jest.fn(),
+        prefetch: jest.fn(),
+        ack: jest.fn(),
+        nack: jest.fn(),
+        sendToQueue: jest.fn(),
+        consume: async (queue: string) => {
+          const consumerTag = `tag-${nextConsumerTag++}`
+          channel.liveConsumers.add(consumerTag)
+          consumerTags.push({ tag: consumerTag, channel: channel.id, queue })
+          return { consumerTag }
+        },
+        cancel: async (tag: string) => {
+          if (channel.closed) {
+            throw new Error('channel closed')
+          }
+          cancelledTags.push(tag)
+          channel.liveConsumers.delete(tag)
+        },
+        checkQueue: async () => {
+          if (failCheckQueue) {
+            throw new Error('keepalive probe failed')
+          }
+          return { messageCount: 0 }
+        },
+        close: async () => {
+          channel.closed = true
+          // A closed channel takes its consumers with it.
+          channel.liveConsumers.clear()
+        },
+      }
+      channels.push(channel)
+      return channel
+    },
     close: async () => undefined,
   })),
 }))
 
 const { Rabbit } = await import('../../../src/infrastructure/drivers/rabbit.js')
 
-describe('Rabbit unsubscribe across a re-subscribe', () => {
+/** Consumers the broker would still be delivering to. */
+const liveConsumers = () =>
+  channels.filter((c) => !c.closed).flatMap((c) => [...c.liveConsumers])
+
+const tick = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+/** Forces the keepalive probe to fail, which tears down and rebuilds the channel. */
+const forceReconnect = async () => {
+  const channelCount = channels.length
+  failCheckQueue = true
+  for (let i = 0; i < 100 && channels.length === channelCount; i++) {
+    await tick(10)
+  }
+  failCheckQueue = false
+  expect(channels.length).toBeGreaterThan(channelCount)
+  // Let the re-subscribe loop settle.
+  await tick(20)
+}
+
+describe('Rabbit consumer lifecycle', () => {
   beforeEach(async () => {
     await Rabbit.close().catch(() => undefined)
+    failCheckQueue = false
+    channels.length = 0
     consumerTags.length = 0
     cancelledTags.length = 0
+  })
+
+  it('opens exactly one consumer per subscribe on a cold channel', async () => {
+    const callback = jest.fn(async () => undefined)
+
+    await Rabbit.subscribe('download-errors', callback as never)
+    // The re-subscribe loop runs off the channel promise, so give it a turn.
+    await tick(20)
+
+    // Pre-fix: two — the subscribe and getChannel's re-subscribe loop each
+    // consumed, and only one of them was cancellable afterwards.
+    expect(consumerTags).toHaveLength(1)
+    expect(liveConsumers()).toHaveLength(1)
+  })
+
+  it('opens one consumer each when several subscribes race the same cold channel', async () => {
+    const callbacks = [
+      jest.fn(async () => undefined),
+      jest.fn(async () => undefined),
+      jest.fn(async () => undefined),
+    ]
+
+    await Promise.all([
+      Rabbit.subscribe('download-errors', callbacks[0] as never),
+      Rabbit.subscribe('frontend-errors', callbacks[1] as never),
+      Rabbit.subscribe('publish-errors', callbacks[2] as never),
+    ])
+    await tick(20)
+
+    expect(liveConsumers()).toHaveLength(3)
+  })
+
+  it('leaves no consumer behind that unsubscribe cannot reach', async () => {
+    const callback = jest.fn(async () => undefined)
+
+    const unsubscribe = await Rabbit.subscribe(
+      'download-errors',
+      callback as never,
+    )
+    await tick(20)
+
+    await unsubscribe()
+
+    // The guarantee EventRouter.stopTaskErrors depends on: once this resolves,
+    // nothing is still being delivered to the callback.
+    expect(liveConsumers()).toHaveLength(0)
+  })
+
+  it('keeps one live consumer across a reconnect', async () => {
+    const callback = jest.fn(async () => undefined)
+
+    await Rabbit.subscribe('download-errors', callback as never)
+    await tick(20)
+
+    await forceReconnect()
+
+    // The reconnect restores the consumer on the new channel — and only there.
+    expect(liveConsumers()).toHaveLength(1)
   })
 
   it('cancels the consumer that is live now, not the one it was handed', async () => {
@@ -57,18 +172,20 @@ describe('Rabbit unsubscribe across a re-subscribe', () => {
       'download-errors',
       callback as never,
     )
-    const tagsAfterFirstSubscribe = [...consumerTags]
+    await tick(20)
+    const tagsBeforeReconnect = consumerTags.map(({ tag }) => tag)
 
-    // Exactly what the reconnect path does with the same callback.
-    await Rabbit.subscribe('download-errors', callback as never)
-    const liveTag = consumerTags[consumerTags.length - 1]
-    expect(tagsAfterFirstSubscribe).not.toContain(liveTag)
+    await forceReconnect()
+
+    const liveTag = liveConsumers()[0]
+    expect(tagsBeforeReconnect).not.toContain(liveTag)
 
     await unsubscribe()
 
     // Pre-fix this cancelled a tag from the first subscribe and left the live
     // consumer delivering.
     expect(cancelledTags).toContain(liveTag)
+    expect(liveConsumers()).toHaveLength(0)
   })
 
   it('deregisters the callback so a later reconnect cannot resurrect it', async () => {
@@ -82,5 +199,8 @@ describe('Rabbit unsubscribe across a re-subscribe', () => {
 
     // A second unsubscribe has nothing left to cancel and must not throw.
     await expect(unsubscribe()).resolves.toBeUndefined()
+
+    await forceReconnect()
+    expect(liveConsumers()).toHaveLength(0)
   })
 })

--- a/apps/backend/__tests__/unit/utils/rabbitReconnect.spec.ts
+++ b/apps/backend/__tests__/unit/utils/rabbitReconnect.spec.ts
@@ -1,0 +1,86 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals'
+
+/**
+ * Covers unsubscribe staying correct across a re-subscribe.
+ *
+ * On reconnect, `getChannel` re-subscribes every stored callback — literally
+ * `subscribe(queue, callback)` — and discards the new unsubscribe handles. So an
+ * unsubscribe that captured its own consumer tag at subscribe time goes stale the
+ * moment the connection bounces: cancelling it targets a consumer that is already
+ * gone while the live one keeps delivering. These tests drive that re-subscribe
+ * directly, which is what the reconnect path does.
+ *
+ * `amqplib` is mocked because the driver's reconnect is internal (keepAlive owns
+ * the cached channel), so there is no public way to force one.
+ */
+
+const consumerTags: string[] = []
+const cancelledTags: string[] = []
+let nextConsumerTag = 0
+
+jest.unstable_mockModule('amqplib', () => ({
+  connect: jest.fn(async () => ({
+    createChannel: async () => ({
+      assertQueue: jest.fn(),
+      prefetch: jest.fn(),
+      ack: jest.fn(),
+      nack: jest.fn(),
+      sendToQueue: jest.fn(),
+      consume: async () => {
+        const consumerTag = `tag-${nextConsumerTag++}`
+        consumerTags.push(consumerTag)
+        return { consumerTag }
+      },
+      cancel: async (tag: string) => {
+        cancelledTags.push(tag)
+      },
+      checkQueue: async () => ({ messageCount: 0 }),
+      close: async () => undefined,
+    }),
+    close: async () => undefined,
+  })),
+}))
+
+const { Rabbit } = await import('../../../src/infrastructure/drivers/rabbit.js')
+
+describe('Rabbit unsubscribe across a re-subscribe', () => {
+  beforeEach(async () => {
+    await Rabbit.close().catch(() => undefined)
+    consumerTags.length = 0
+    cancelledTags.length = 0
+  })
+
+  it('cancels the consumer that is live now, not the one it was handed', async () => {
+    const callback = jest.fn(async () => undefined)
+
+    const unsubscribe = await Rabbit.subscribe(
+      'download-errors',
+      callback as never,
+    )
+    const tagsAfterFirstSubscribe = [...consumerTags]
+
+    // Exactly what the reconnect path does with the same callback.
+    await Rabbit.subscribe('download-errors', callback as never)
+    const liveTag = consumerTags[consumerTags.length - 1]
+    expect(tagsAfterFirstSubscribe).not.toContain(liveTag)
+
+    await unsubscribe()
+
+    // Pre-fix this cancelled a tag from the first subscribe and left the live
+    // consumer delivering.
+    expect(cancelledTags).toContain(liveTag)
+  })
+
+  it('deregisters the callback so a later reconnect cannot resurrect it', async () => {
+    const callback = jest.fn(async () => undefined)
+
+    const unsubscribe = await Rabbit.subscribe(
+      'download-errors',
+      callback as never,
+    )
+    await unsubscribe()
+
+    // A second unsubscribe has nothing left to cancel and must not throw.
+    await expect(unsubscribe()).resolves.toBeUndefined()
+  })
+})

--- a/apps/backend/__tests__/unit/utils/rabbitReconnect.spec.ts
+++ b/apps/backend/__tests__/unit/utils/rabbitReconnect.spec.ts
@@ -32,49 +32,60 @@ const consumerTags: { tag: string; channel: number; queue: string }[] = []
 const cancelledTags: string[] = []
 let nextConsumerTag = 0
 let failCheckQueue = false
+let failConnect = false
+let consumeFailuresLeft = 0
 
 jest.unstable_mockModule('amqplib', () => ({
-  connect: jest.fn(async () => ({
-    createChannel: async () => {
-      const channel = {
-        id: channels.length,
-        closed: false,
-        liveConsumers: new Set<string>(),
-        assertQueue: jest.fn(),
-        prefetch: jest.fn(),
-        ack: jest.fn(),
-        nack: jest.fn(),
-        sendToQueue: jest.fn(),
-        consume: async (queue: string) => {
-          const consumerTag = `tag-${nextConsumerTag++}`
-          channel.liveConsumers.add(consumerTag)
-          consumerTags.push({ tag: consumerTag, channel: channel.id, queue })
-          return { consumerTag }
-        },
-        cancel: async (tag: string) => {
-          if (channel.closed) {
-            throw new Error('channel closed')
-          }
-          cancelledTags.push(tag)
-          channel.liveConsumers.delete(tag)
-        },
-        checkQueue: async () => {
-          if (failCheckQueue) {
-            throw new Error('keepalive probe failed')
-          }
-          return { messageCount: 0 }
-        },
-        close: async () => {
-          channel.closed = true
-          // A closed channel takes its consumers with it.
-          channel.liveConsumers.clear()
-        },
-      }
-      channels.push(channel)
-      return channel
-    },
-    close: async () => undefined,
-  })),
+  connect: jest.fn(async () => {
+    if (failConnect) {
+      throw new Error('ECONNREFUSED: broker unreachable')
+    }
+    return {
+      createChannel: async () => {
+        const channel = {
+          id: channels.length,
+          closed: false,
+          liveConsumers: new Set<string>(),
+          assertQueue: jest.fn(),
+          prefetch: jest.fn(),
+          ack: jest.fn(),
+          nack: jest.fn(),
+          sendToQueue: jest.fn(),
+          consume: async (queue: string) => {
+            if (consumeFailuresLeft > 0) {
+              consumeFailuresLeft--
+              throw new Error(`consume rejected on ${queue}`)
+            }
+            const consumerTag = `tag-${nextConsumerTag++}`
+            channel.liveConsumers.add(consumerTag)
+            consumerTags.push({ tag: consumerTag, channel: channel.id, queue })
+            return { consumerTag }
+          },
+          cancel: async (tag: string) => {
+            if (channel.closed) {
+              throw new Error('channel closed')
+            }
+            cancelledTags.push(tag)
+            channel.liveConsumers.delete(tag)
+          },
+          checkQueue: async () => {
+            if (failCheckQueue) {
+              throw new Error('keepalive probe failed')
+            }
+            return { messageCount: 0 }
+          },
+          close: async () => {
+            channel.closed = true
+            // A closed channel takes its consumers with it.
+            channel.liveConsumers.clear()
+          },
+        }
+        channels.push(channel)
+        return channel
+      },
+      close: async () => undefined,
+    }
+  }),
 }))
 
 const { Rabbit } = await import('../../../src/infrastructure/drivers/rabbit.js')
@@ -84,6 +95,14 @@ const liveConsumers = () =>
   channels.filter((c) => !c.closed).flatMap((c) => [...c.liveConsumers])
 
 const tick = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+/** Waits for `predicate`, so a retry with backoff does not need a fixed sleep. */
+const waitFor = async (predicate: () => boolean, timeout = 6000) => {
+  for (let waited = 0; waited < timeout && !predicate(); waited += 20) {
+    await tick(20)
+  }
+  return predicate()
+}
 
 /** Forces the keepalive probe to fail, which tears down and rebuilds the channel. */
 const forceReconnect = async () => {
@@ -102,6 +121,8 @@ describe('Rabbit consumer lifecycle', () => {
   beforeEach(async () => {
     await Rabbit.close().catch(() => undefined)
     failCheckQueue = false
+    failConnect = false
+    consumeFailuresLeft = 0
     channels.length = 0
     consumerTags.length = 0
     cancelledTags.length = 0
@@ -203,4 +224,84 @@ describe('Rabbit consumer lifecycle', () => {
     await forceReconnect()
     expect(liveConsumers()).toHaveLength(0)
   })
+})
+
+/**
+ * A reconnect used to have three ways of taking the worker down with it, all of
+ * them the same mistake: a promise created inside the driver that nothing ever
+ * awaits. Nothing in the backend registers an `unhandledRejection` handler and
+ * Node defaults to `--unhandled-rejections=throw`, so each one is fatal, and
+ * they fire exactly when the broker is already having a bad day.
+ *
+ * These tests exercise the failures behind them. Their real assertion is that
+ * the driver comes back — a regression puts the crash in the test run itself.
+ */
+describe('Rabbit reconnect resilience', () => {
+  beforeEach(async () => {
+    await Rabbit.close().catch(() => undefined)
+    failCheckQueue = false
+    failConnect = false
+    consumeFailuresLeft = 0
+    channels.length = 0
+    consumerTags.length = 0
+    cancelledTags.length = 0
+  })
+
+  it('retries a consume that fails while restoring a consumer', async () => {
+    const callback = jest.fn(async () => undefined)
+    await Rabbit.subscribe('download-errors', callback as never)
+    await tick(20)
+
+    // The re-subscribe loop discards what `subscribe` returns, so this rejection
+    // had no caller to reach.
+    consumeFailuresLeft = 1
+    await forceReconnect()
+
+    // And nothing re-ran the loop: `subscriptions` is only read on a reconnect,
+    // and a healthy channel never produces another one — so a single failure
+    // left the queue unread until the next unrelated outage.
+    expect(await waitFor(() => liveConsumers().length === 1)).toBe(true)
+  }, 15000)
+
+  it('reconnects once the broker comes back', async () => {
+    const callback = jest.fn(async () => undefined)
+    await Rabbit.subscribe('download-errors', callback as never)
+    await tick(20)
+
+    // Broker goes away mid-flight: the probe fails, and so does the reconnect.
+    failConnect = true
+    failCheckQueue = true
+    await tick(100)
+
+    const channelsWhileDown = channels.length
+    failConnect = false
+    failCheckQueue = false
+
+    // The rejected channel used to stay cached, so every later publish, consume
+    // and keepalive replayed that one error and no reconnect was ever attempted
+    // again — the worker stayed wedged long after the broker was healthy.
+    expect(await waitFor(() => channels.length > channelsWhileDown)).toBe(true)
+    expect(await waitFor(() => liveConsumers().length === 1)).toBe(true)
+    await expect(Rabbit.getMessageCount('download-errors')).resolves.toBe(0)
+  }, 15000)
+
+  it('does not resurrect a consumer unsubscribed while its retry is pending', async () => {
+    const callback = jest.fn(async () => undefined)
+    const unsubscribe = await Rabbit.subscribe(
+      'download-errors',
+      callback as never,
+    )
+    await tick(20)
+
+    consumeFailuresLeft = 1
+    await forceReconnect()
+
+    // Unsubscribing between the failed attempt and the retry: the callback is
+    // deregistered, so the retry must leave it alone rather than hand the queue
+    // a consumer nobody holds a handle to.
+    await unsubscribe()
+
+    await tick(3000)
+    expect(liveConsumers()).toHaveLength(0)
+  }, 15000)
 })

--- a/apps/backend/__tests__/unit/utils/shutdown.spec.ts
+++ b/apps/backend/__tests__/unit/utils/shutdown.spec.ts
@@ -1,0 +1,84 @@
+import { jest, describe, it, expect } from '@jest/globals'
+import {
+  shutdownStep,
+  startShutdownWatchdog,
+} from '../../../src/shared/utils/shutdown.js'
+import type { Logger } from '../../../src/infrastructure/drivers/logger.js'
+
+/**
+ * A shutdown handler is where an unbounded await is unrecoverable. Without a
+ * handler SIGTERM ends the process immediately; adding one turns every await
+ * inside it into a way to survive until SIGKILL instead — and the awaits here
+ * are broker RPCs that wait on a reply, plus an alert drain that can want ~50s
+ * against a 10s stop grace period.
+ */
+
+const testLogger = () =>
+  ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    trace: jest.fn(),
+  }) as unknown as Logger
+
+const never = () => new Promise<void>(() => undefined)
+
+describe('shutdownStep', () => {
+  it('gives up on a step that never settles', async () => {
+    const logger = testLogger()
+    const started = Date.now()
+
+    await shutdownStep(logger, 'hangs forever', 100, never)
+
+    expect(Date.now() - started).toBeLessThan(1000)
+    expect(logger.warn).toHaveBeenCalled()
+  })
+
+  it('does not reject when a step throws, so later steps still run', async () => {
+    const logger = testLogger()
+    const afterFailure = jest.fn(async () => undefined)
+
+    await expect(
+      shutdownStep(logger, 'throws', 100, async () => {
+        throw new Error('broker gone')
+      }),
+    ).resolves.toBeUndefined()
+    await shutdownStep(logger, 'runs anyway', 100, afterFailure)
+
+    expect(afterFailure).toHaveBeenCalled()
+  })
+
+  it('returns as soon as a step completes', async () => {
+    const logger = testLogger()
+    const started = Date.now()
+
+    await shutdownStep(logger, 'quick', 5000, async () => undefined)
+
+    expect(Date.now() - started).toBeLessThan(1000)
+    expect(logger.warn).not.toHaveBeenCalled()
+  })
+})
+
+describe('startShutdownWatchdog', () => {
+  it('fires when the sequence outlives its budget', async () => {
+    const logger = testLogger()
+    const onExpiry = jest.fn()
+
+    startShutdownWatchdog(logger, 50, onExpiry)
+    await new Promise((resolve) => setTimeout(resolve, 200))
+
+    expect(onExpiry).toHaveBeenCalled()
+  })
+
+  it('stays quiet once the sequence finishes', async () => {
+    const logger = testLogger()
+    const onExpiry = jest.fn()
+
+    const stop = startShutdownWatchdog(logger, 50, onExpiry)
+    stop()
+    await new Promise((resolve) => setTimeout(resolve, 200))
+
+    expect(onExpiry).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/app/servers/downloadWorker.ts
+++ b/apps/backend/src/app/servers/downloadWorker.ts
@@ -26,6 +26,9 @@
 
   const shutdown = async () => {
     logger.info('Shutting down download worker...')
+    // Stop consuming before flushing: otherwise failures keep arriving while the
+    // final send is awaited and land in a batch created after the flush finished.
+    EventRouter.stopTaskErrors()
     const { flushTaskErrorAlerts } = await import(
       '../../infrastructure/eventRouter/taskErrorNotifier.js'
     )

--- a/apps/backend/src/app/servers/downloadWorker.ts
+++ b/apps/backend/src/app/servers/downloadWorker.ts
@@ -28,7 +28,7 @@
     logger.info('Shutting down download worker...')
     // Stop consuming before flushing: otherwise failures keep arriving while the
     // final send is awaited and land in a batch created after the flush finished.
-    EventRouter.stopTaskErrors()
+    await EventRouter.stopTaskErrors()
     const { flushTaskErrorAlerts } = await import(
       '../../infrastructure/eventRouter/taskErrorNotifier.js'
     )

--- a/apps/backend/src/app/servers/downloadWorker.ts
+++ b/apps/backend/src/app/servers/downloadWorker.ts
@@ -6,4 +6,10 @@
   await import('../../app/apis/worker.js')
   const { EventRouter } = await import('../../infrastructure/eventRouter/index.js')
   EventRouter.listenDownloadEvents()
+
+  // Consume the error queues here as well as in the frontend worker. This worker
+  // is ungated by feature flags, so it is the one process guaranteed to be
+  // draining them. RabbitMQ hands each message to a single consumer, so the
+  // second reader shares the work rather than double-alerting.
+  EventRouter.listenTaskErrors()
 })()

--- a/apps/backend/src/app/servers/downloadWorker.ts
+++ b/apps/backend/src/app/servers/downloadWorker.ts
@@ -4,7 +4,9 @@
   }
 
   await import('../../app/apis/worker.js')
-  const { EventRouter } = await import('../../infrastructure/eventRouter/index.js')
+  const { EventRouter } = await import(
+    '../../infrastructure/eventRouter/index.js'
+  )
   EventRouter.listenDownloadEvents()
 
   // Consume the error queues here as well as in the frontend worker. This worker
@@ -15,25 +17,44 @@
 
   // Batched alerts are already acked off the queue, so a restart inside the
   // batching window loses them. With a 30-minute window that is worth handling:
-  // deploys are exactly when tasks fail. `flushTaskErrorAlerts` is internally
-  // bounded (the webhook post has its own 10s timeout and never rejects), so it
-  // cannot stall the container's stop grace period.
+  // deploys are exactly when tasks fail.
+  //
+  // Every step is bounded, and the sequence as a whole is too. Until this handler
+  // existed SIGTERM terminated the process outright, so anything unbounded here
+  // is a straight regression: the drain makes up to five sends of 10s each, and
+  // cancelling a consumer and closing a channel are broker RPCs that wait for a
+  // reply the broker may never send. Docker allows 10s before SIGKILL.
   const { Rabbit } = await import('../../infrastructure/drivers/rabbit.js')
   const { createLogger } = await import(
     '../../infrastructure/drivers/logger.js'
+  )
+  const { startShutdownWatchdog, shutdownStep } = await import(
+    '../../shared/utils/shutdown.js'
   )
   const logger = createLogger('servers:downloadWorker')
 
   const shutdown = async () => {
     logger.info('Shutting down download worker...')
+    const stopWatchdog = startShutdownWatchdog(logger)
+
     // Stop consuming before flushing: otherwise failures keep arriving while the
     // final send is awaited and land in a batch created after the flush finished.
-    await EventRouter.stopTaskErrors()
+    await shutdownStep(logger, 'stop error consumers', 2_000, () =>
+      EventRouter.stopTaskErrors(),
+    )
     const { flushTaskErrorAlerts } = await import(
       '../../infrastructure/eventRouter/taskErrorNotifier.js'
     )
-    await flushTaskErrorAlerts()
-    await Rabbit.close()
+    // Ordered after the cancel but not dependent on it: this talks to Slack, so
+    // a broker that has stopped answering must not cost us the alerts.
+    await shutdownStep(logger, 'flush task error alerts', 4_000, () =>
+      flushTaskErrorAlerts(),
+    )
+    await shutdownStep(logger, 'close rabbit channel', 2_000, () =>
+      Rabbit.close(),
+    )
+
+    stopWatchdog()
     logger.info('Download worker shut down successfully')
     process.exit(0)
   }

--- a/apps/backend/src/app/servers/downloadWorker.ts
+++ b/apps/backend/src/app/servers/downloadWorker.ts
@@ -12,4 +12,29 @@
   // draining them. RabbitMQ hands each message to a single consumer, so the
   // second reader shares the work rather than double-alerting.
   EventRouter.listenTaskErrors()
+
+  // Batched alerts are already acked off the queue, so a restart inside the
+  // batching window loses them. With a 30-minute window that is worth handling:
+  // deploys are exactly when tasks fail. `flushTaskErrorAlerts` is internally
+  // bounded (the webhook post has its own 10s timeout and never rejects), so it
+  // cannot stall the container's stop grace period.
+  const { Rabbit } = await import('../../infrastructure/drivers/rabbit.js')
+  const { createLogger } = await import(
+    '../../infrastructure/drivers/logger.js'
+  )
+  const logger = createLogger('servers:downloadWorker')
+
+  const shutdown = async () => {
+    logger.info('Shutting down download worker...')
+    const { flushTaskErrorAlerts } = await import(
+      '../../infrastructure/eventRouter/taskErrorNotifier.js'
+    )
+    await flushTaskErrorAlerts()
+    await Rabbit.close()
+    logger.info('Download worker shut down successfully')
+    process.exit(0)
+  }
+
+  process.on('SIGTERM', shutdown)
+  process.on('SIGINT', shutdown)
 })()

--- a/apps/backend/src/app/servers/frontendWorker.ts
+++ b/apps/backend/src/app/servers/frontendWorker.ts
@@ -20,8 +20,10 @@
     '../../infrastructure/services/paymentManager/index.js'
   )
 
-  const { Rabbit } = await import(
-    '../../infrastructure/drivers/rabbit.js'
+  const { Rabbit } = await import('../../infrastructure/drivers/rabbit.js')
+
+  const { startShutdownWatchdog, shutdownStep } = await import(
+    '../../shared/utils/shutdown.js'
   )
 
   // Ungated by feature flags: a task that exhausted its retries needs to be
@@ -89,6 +91,11 @@
 
   const shutdown = async () => {
     logger.info('Shutting down frontend worker...')
+    // Armed before the first step: Docker allows 10s between SIGTERM and
+    // SIGKILL, and the awaits below can want far longer than that — the alert
+    // drain makes up to five sends of 10s each, and cancelling a consumer or
+    // closing a channel waits on a broker reply that may never come.
+    const stopWatchdog = startShutdownWatchdog(logger)
     objectMappingArchiver.stop()
     // Stop periodic recovery jobs (safe even if never started — stop() is a no-op)
     if (
@@ -124,12 +131,22 @@
     // so a deploy doesn't swallow the alerts it may itself have caused. Stop
     // consuming first, or failures keep arriving while the final send is awaited
     // and land in a batch created after the flush decided it was finished.
-    await EventRouter.stopTaskErrors()
+    await shutdownStep(logger, 'stop error consumers', 2_000, () =>
+      EventRouter.stopTaskErrors(),
+    )
     const { flushTaskErrorAlerts } = await import(
       '../../infrastructure/eventRouter/taskErrorNotifier.js'
     )
-    await flushTaskErrorAlerts()
-    await Rabbit.close()
+    // The flush talks to Slack, not to the broker, so a cancel that timed out
+    // above must not cost us the alerts it was making room for.
+    await shutdownStep(logger, 'flush task error alerts', 4_000, () =>
+      flushTaskErrorAlerts(),
+    )
+    await shutdownStep(logger, 'close rabbit channel', 2_000, () =>
+      Rabbit.close(),
+    )
+
+    stopWatchdog()
     logger.info('Frontend worker shut down successfully')
     process.exit(0)
   }

--- a/apps/backend/src/app/servers/frontendWorker.ts
+++ b/apps/backend/src/app/servers/frontendWorker.ts
@@ -121,7 +121,10 @@
     )
     deletionAnonymisationJob.stop()
     // Send anything still inside the batching window before the channel closes,
-    // so a deploy doesn't swallow the alerts it may itself have caused.
+    // so a deploy doesn't swallow the alerts it may itself have caused. Stop
+    // consuming first, or failures keep arriving while the final send is awaited
+    // and land in a batch created after the flush decided it was finished.
+    EventRouter.stopTaskErrors()
     const { flushTaskErrorAlerts } = await import(
       '../../infrastructure/eventRouter/taskErrorNotifier.js'
     )

--- a/apps/backend/src/app/servers/frontendWorker.ts
+++ b/apps/backend/src/app/servers/frontendWorker.ts
@@ -124,7 +124,7 @@
     // so a deploy doesn't swallow the alerts it may itself have caused. Stop
     // consuming first, or failures keep arriving while the final send is awaited
     // and land in a batch created after the flush decided it was finished.
-    EventRouter.stopTaskErrors()
+    await EventRouter.stopTaskErrors()
     const { flushTaskErrorAlerts } = await import(
       '../../infrastructure/eventRouter/taskErrorNotifier.js'
     )

--- a/apps/backend/src/app/servers/frontendWorker.ts
+++ b/apps/backend/src/app/servers/frontendWorker.ts
@@ -24,6 +24,10 @@
     '../../infrastructure/drivers/rabbit.js'
   )
 
+  // Ungated by feature flags: a task that exhausted its retries needs to be
+  // reported regardless of which subsystems this host runs.
+  EventRouter.listenTaskErrors()
+
   let somethingActive = false
   if (config.featureFlags.flags.taskManager.active) {
     EventRouter.listenFrontendEvents()
@@ -116,6 +120,12 @@
       '../../infrastructure/services/deletionAnonymisationJob.js'
     )
     deletionAnonymisationJob.stop()
+    // Send anything still inside the batching window before the channel closes,
+    // so a deploy doesn't swallow the alerts it may itself have caused.
+    const { flushTaskErrorAlerts } = await import(
+      '../../infrastructure/eventRouter/taskErrorNotifier.js'
+    )
+    await flushTaskErrorAlerts()
     await Rabbit.close()
     logger.info('Frontend worker shut down successfully')
     process.exit(0)

--- a/apps/backend/src/config.ts
+++ b/apps/backend/src/config.ts
@@ -152,7 +152,13 @@ export const config = {
     webhookUrl: process.env.SLACK_WEBHOOK_URL,
     // Failures are batched into one message per window rather than posted
     // individually: a drained backlog would otherwise post hundreds of times.
-    alertWindowMs: Number(env('TASK_ERROR_ALERT_WINDOW_MS', '60000')),
+    //
+    // 30 minutes deliberately favours a quiet channel over a fast alert. These
+    // are tasks that already exhausted every retry, so nothing is waiting on the
+    // notification — but note that a batched failure has already been acked off
+    // the queue, so this is also how much alerting a hard crash can lose. Both
+    // workers flush on SIGTERM, which covers ordinary deploys.
+    alertWindowMs: Number(env('TASK_ERROR_ALERT_WINDOW_MS', '1800000')),
     // Failures listed individually in a batch before collapsing to a count.
     alertMaxItems: Number(env('TASK_ERROR_ALERT_MAX_ITEMS', '10')),
   },

--- a/apps/backend/src/config.ts
+++ b/apps/backend/src/config.ts
@@ -148,7 +148,9 @@ export const config = {
   // error queues grow forever and nobody finds out a task died.
   slack: {
     // Incoming-webhook URL. The channel is encoded in the URL, so there is no
-    // separate channel setting. Unset disables alerting (log-only).
+    // separate channel setting. Unset disables alerting *and* the error-queue
+    // consumers, so failures stay queued instead of being acked away unreported
+    // (see EventRouter.listenTaskErrors).
     webhookUrl: process.env.SLACK_WEBHOOK_URL,
     // Failures are batched into one message per window rather than posted
     // individually: a drained backlog would otherwise post hundreds of times.

--- a/apps/backend/src/config.ts
+++ b/apps/backend/src/config.ts
@@ -144,6 +144,19 @@ export const config = {
     prefetch: Number(env('RABBITMQ_PREFETCH', '10')),
     keepAliveInterval: Number(env('RABBITMQ_KEEP_ALIVE_INTERVAL', '60000')),
   },
+  // Alerting for tasks that exhausted their retries. Without a consumer the
+  // error queues grow forever and nobody finds out a task died.
+  slack: {
+    // Incoming-webhook URL. The channel is encoded in the URL, so there is no
+    // separate channel setting. Unset disables alerting (log-only).
+    webhookUrl: process.env.SLACK_WEBHOOK_URL,
+    // Failures are batched into one message per window rather than posted
+    // individually: a drained backlog would otherwise post hundreds of times.
+    alertWindowMs: Number(env('TASK_ERROR_ALERT_WINDOW_MS', '60000')),
+    // Failures listed individually in a batch before collapsing to a count.
+    alertMaxItems: Number(env('TASK_ERROR_ALERT_MAX_ITEMS', '10')),
+    environment: env('SLACK_ALERT_ENVIRONMENT', 'unknown'),
+  },
   monitoring: {
     active: env('VICTORIA_ACTIVE', 'false') === 'true',
     victoriaEndpoint: process.env.VICTORIA_ENDPOINT,

--- a/apps/backend/src/config.ts
+++ b/apps/backend/src/config.ts
@@ -155,7 +155,6 @@ export const config = {
     alertWindowMs: Number(env('TASK_ERROR_ALERT_WINDOW_MS', '60000')),
     // Failures listed individually in a batch before collapsing to a count.
     alertMaxItems: Number(env('TASK_ERROR_ALERT_MAX_ITEMS', '10')),
-    environment: env('SLACK_ALERT_ENVIRONMENT', 'unknown'),
   },
   monitoring: {
     active: env('VICTORIA_ACTIVE', 'false') === 'true',

--- a/apps/backend/src/infrastructure/drivers/rabbit.ts
+++ b/apps/backend/src/infrastructure/drivers/rabbit.ts
@@ -11,7 +11,18 @@ export type Queue = (typeof queues)[number]
 
 const logger = createLogger('drivers:rabbit')
 
-const queues = ['task-manager', 'download-manager', 'publish-manager'] as const
+// Error queues are listed here so they are asserted at channel setup and are
+// valid `subscribe`/`getMessageCount` targets. They were previously created
+// implicitly by `publish` alone, which left them unsubscribable — and so they
+// accumulated permanently failed tasks that nobody ever read.
+const queues = [
+  'task-manager',
+  'download-manager',
+  'publish-manager',
+  'frontend-errors',
+  'download-errors',
+  'publish-errors',
+] as const
 const subscriptions: Partial<Record<Queue, SubscriptionCallback[]>> = {}
 
 let channelPromise: Promise<Channel> | null = null

--- a/apps/backend/src/infrastructure/drivers/rabbit.ts
+++ b/apps/backend/src/infrastructure/drivers/rabbit.ts
@@ -25,6 +25,25 @@ const queues = [
 ] as const
 const subscriptions: Partial<Record<Queue, SubscriptionCallback[]>> = {}
 
+interface ActiveConsumer {
+  channel: Channel
+  consumerTag: string
+}
+
+/**
+ * The consumer currently serving each callback, per queue.
+ *
+ * A reconnect re-subscribes every stored callback on a fresh channel and discards
+ * the new unsubscribe handles (see `getChannel`), so a handle that closed over its
+ * own channel and consumer tag went stale the moment the connection bounced:
+ * cancelling it targeted a dead consumer on a closed channel while the live one
+ * kept delivering. Unsubscribing therefore looks the consumer up here, at call
+ * time, rather than capturing it at subscribe time.
+ */
+const activeConsumers: Partial<
+  Record<Queue, Map<SubscriptionCallback, ActiveConsumer>>
+> = {}
+
 let channelPromise: Promise<Channel> | null = null
 let keepAliveInterval: NodeJS.Timeout | null = null
 
@@ -105,7 +124,11 @@ const subscribe = async (
   if (!subscriptions[queue]) {
     subscriptions[queue] = [] as SubscriptionCallback[]
   }
-  subscriptions[queue].push(callback)
+  // Guarded against duplicates so a reconnect cannot register the same callback
+  // twice and start delivering each message to it more than once.
+  if (!subscriptions[queue].includes(callback)) {
+    subscriptions[queue].push(callback)
+  }
 
   const channel = await getChannel()
 
@@ -129,17 +152,41 @@ const subscribe = async (
     },
   )
 
+  if (!activeConsumers[queue]) {
+    activeConsumers[queue] = new Map()
+  }
+  activeConsumers[queue].set(callback, {
+    channel,
+    consumerTag: consume.consumerTag,
+  })
+
   // Awaits the cancel rather than firing and forgetting it: callers that stop a
   // consumer in order to quiesce before doing something else (see
   // EventRouter.stopTaskErrors) need "stopped" to actually mean stopped by the
   // time this resolves. Note that cancelling halts *new* deliveries — messages
   // already handed to the client may still be in their callback afterwards.
   return async () => {
+    // Deregister before cancelling. A reconnect re-subscribes whatever is in
+    // `subscriptions`, so leaving the callback there while awaiting the cancel
+    // gives a reconnect landing mid-cancel the chance to resurrect the consumer.
+    subscriptions[queue] =
+      subscriptions[queue]?.filter((c) => c !== callback) ?? []
+
+    // Looked up now rather than captured above, so this cancels whichever
+    // consumer is live — including one created by a reconnect after this handle
+    // was handed out.
+    const active = activeConsumers[queue]?.get(callback)
+    activeConsumers[queue]?.delete(callback)
+    if (!active) {
+      return
+    }
+
     try {
-      await channel.cancel(consume.consumerTag)
-    } finally {
-      subscriptions[queue] =
-        subscriptions[queue]?.filter((c) => c !== callback) ?? []
+      await active.channel.cancel(active.consumerTag)
+    } catch (error) {
+      // A cancel against an already-closed channel is moot: that consumer is
+      // gone either way, which is what the caller wanted.
+      logger.warn('Failed to cancel consumer on %s: %s', queue, error)
     }
   }
 }
@@ -159,6 +206,7 @@ const close = async () => {
   channelPromise = null
   for (const queue of queues) {
     subscriptions[queue] = []
+    activeConsumers[queue]?.clear()
   }
 
   if (keepAliveInterval) {

--- a/apps/backend/src/infrastructure/drivers/rabbit.ts
+++ b/apps/backend/src/infrastructure/drivers/rabbit.ts
@@ -27,7 +27,11 @@ const subscriptions: Partial<Record<Queue, SubscriptionCallback[]>> = {}
 
 interface ActiveConsumer {
   channel: Channel
-  consumerTag: string
+  // Held as a promise, and stored in the same tick as the `consume` call that
+  // produces it, so the entry doubles as an in-flight reservation: a second
+  // caller arriving while the first `consume` is still on the wire sees it and
+  // reuses it instead of opening a rival consumer.
+  consumerTag: Promise<string>
 }
 
 /**
@@ -39,6 +43,9 @@ interface ActiveConsumer {
  * cancelling it targeted a dead consumer on a closed channel while the live one
  * kept delivering. Unsubscribing therefore looks the consumer up here, at call
  * time, rather than capturing it at subscribe time.
+ *
+ * The map is also what keeps consumers unique per (queue, callback, channel) —
+ * see `ensureConsumer`.
  */
 const activeConsumers: Partial<
   Record<Queue, Map<SubscriptionCallback, ActiveConsumer>>
@@ -117,6 +124,90 @@ const keepAlive = async () => {
   }
 }
 
+/**
+ * Starts consuming `queue` with `callback`, or reuses the consumer already doing
+ * so on this channel.
+ *
+ * Two paths race to establish the same consumer: the `subscribe` call itself,
+ * and the re-subscribe loop `getChannel` runs once its channel resolves. On the
+ * very first subscribe both fire — the callback is registered in `subscriptions`
+ * before `getChannel` is even called, so the loop that is meant to restore
+ * consumers after a reconnect also picks up the subscribe that is still in
+ * flight. Each then called `consume` and the later one overwrote the other's
+ * entry in `activeConsumers`, leaving a second live consumer that nothing held a
+ * tag for: `unsubscribe`/`stopTaskErrors` cancelled one, the orphan kept
+ * delivering, and on shutdown its messages landed in a batch created after the
+ * final flush had already run.
+ *
+ * Reserving the entry synchronously — before awaiting the `consume` — closes
+ * that window regardless of which path gets there first.
+ */
+const ensureConsumer = (
+  queue: Queue,
+  callback: SubscriptionCallback,
+  channel: Channel,
+): ActiveConsumer => {
+  let consumers = activeConsumers[queue]
+  if (!consumers) {
+    consumers = new Map()
+    activeConsumers[queue] = consumers
+  }
+
+  const existing = consumers.get(callback)
+  if (existing) {
+    if (existing.channel === channel) {
+      return existing
+    }
+    // A different channel means a reconnect replaced the one this consumer lived
+    // on. That channel is normally closed already (which kills its consumers),
+    // but a close that failed would leave the old consumer delivering into a
+    // callback nobody can stop, so cancel it best-effort before dropping it.
+    existing.consumerTag
+      .then((tag) => existing.channel.cancel(tag))
+      .catch((error) => {
+        logger.debug(
+          'Could not cancel superseded consumer on %s: %s',
+          queue,
+          error,
+        )
+      })
+  }
+
+  const consumerTag = channel
+    .consume(queue, async (message: ConsumeMessage | null): Promise<void> => {
+      if (message) {
+        try {
+          const payload = JSON.parse(message.content.toString())
+          logger.debug('Received message from %s', queue)
+          await callback(payload)
+          logger.debug('Message processed successfully for %s', queue)
+          channel.ack(message)
+        } catch (error) {
+          logger.error('Error processing message from %s', queue, error)
+          channel.nack(message, false, true)
+        }
+      } else {
+        logger.warn('No message received from %s', queue)
+      }
+    })
+    .then((consume) => consume.consumerTag)
+
+  const consumer: ActiveConsumer = { channel, consumerTag }
+  consumers.set(callback, consumer)
+
+  // A failed `consume` must not leave its reservation behind, or a later
+  // subscribe on this same channel would hand back a consumer that never
+  // existed. Also marks the rejection handled — `subscribe` re-raises it to its
+  // own caller.
+  consumerTag.catch(() => {
+    if (consumers.get(callback) === consumer) {
+      consumers.delete(callback)
+    }
+  })
+
+  return consumer
+}
+
 const subscribe = async (
   queue: Queue,
   callback: (message: Record<string, unknown>) => Promise<unknown>,
@@ -132,33 +223,8 @@ const subscribe = async (
 
   const channel = await getChannel()
 
-  const consume = await channel.consume(
-    queue,
-    async (message: ConsumeMessage | null): Promise<void> => {
-      if (message) {
-        try {
-          const payload = JSON.parse(message.content.toString())
-          logger.debug('Received message from %s', queue)
-          await callback(payload)
-          logger.debug('Message processed successfully for %s', queue)
-          channel.ack(message)
-        } catch (error) {
-          logger.error('Error processing message from %s', queue, error)
-          channel.nack(message, false, true)
-        }
-      } else {
-        logger.warn('No message received from %s', queue)
-      }
-    },
-  )
-
-  if (!activeConsumers[queue]) {
-    activeConsumers[queue] = new Map()
-  }
-  activeConsumers[queue].set(callback, {
-    channel,
-    consumerTag: consume.consumerTag,
-  })
+  // Awaited so this resolves only once the broker has the consumer, as before.
+  await ensureConsumer(queue, callback, channel).consumerTag
 
   // Awaits the cancel rather than firing and forgetting it: callers that stop a
   // consumer in order to quiesce before doing something else (see
@@ -182,7 +248,7 @@ const subscribe = async (
     }
 
     try {
-      await active.channel.cancel(active.consumerTag)
+      await active.channel.cancel(await active.consumerTag)
     } catch (error) {
       // A cancel against an already-closed channel is moot: that consumer is
       // gone either way, which is what the caller wanted.

--- a/apps/backend/src/infrastructure/drivers/rabbit.ts
+++ b/apps/backend/src/infrastructure/drivers/rabbit.ts
@@ -129,10 +129,18 @@ const subscribe = async (
     },
   )
 
-  return () => {
-    channel.cancel(consume.consumerTag)
-    subscriptions[queue] =
-      subscriptions[queue]?.filter((c) => c !== callback) ?? []
+  // Awaits the cancel rather than firing and forgetting it: callers that stop a
+  // consumer in order to quiesce before doing something else (see
+  // EventRouter.stopTaskErrors) need "stopped" to actually mean stopped by the
+  // time this resolves. Note that cancelling halts *new* deliveries — messages
+  // already handed to the client may still be in their callback afterwards.
+  return async () => {
+    try {
+      await channel.cancel(consume.consumerTag)
+    } finally {
+      subscriptions[queue] =
+        subscriptions[queue]?.filter((c) => c !== callback) ?? []
+    }
   }
 }
 

--- a/apps/backend/src/infrastructure/drivers/rabbit.ts
+++ b/apps/backend/src/infrastructure/drivers/rabbit.ts
@@ -54,32 +54,99 @@ const activeConsumers: Partial<
 let channelPromise: Promise<Channel> | null = null
 let keepAliveInterval: NodeJS.Timeout | null = null
 
+/**
+ * Restores one registered consumer on a freshly opened channel.
+ *
+ * Retried rather than attempted once: nothing else re-runs this. The callback
+ * stays in `subscriptions`, but the only thing that reads that list is the next
+ * reconnect — and reconnects are driven by a failing keepalive, which a healthy
+ * channel never produces. A `consume` that failed here therefore left the queue
+ * with no reader indefinitely, and silently.
+ *
+ * The failure is also caught here rather than propagated. `subscribe` re-raises
+ * a failed `consume` to its caller, and this call site is a bare loop with no
+ * caller to return to, so the rejection reached `unhandledRejection` — which,
+ * with no handler registered anywhere in the backend and Node defaulting to
+ * `--unhandled-rejections=throw`, took the whole worker down.
+ */
+const resubscribeAfterReconnect = async (
+  queue: Queue,
+  callback: SubscriptionCallback,
+) => {
+  try {
+    await withBackingOffRetries(
+      async () => {
+        // An unsubscribe landing mid-retry deregisters the callback; without
+        // this check the next attempt would resurrect the consumer it just
+        // cancelled.
+        if (!subscriptions[queue]?.includes(callback)) {
+          return
+        }
+        await subscribe(queue, callback)
+      },
+      { maxRetries: 3, startingDelay: 1000 },
+    )
+  } catch (error) {
+    logger.error(
+      error as Error,
+      'Gave up re-subscribing %s after reconnect; it has no consumer until the next one',
+      queue,
+    )
+  }
+}
+
 const getChannel = async () => {
   if (!channelPromise) {
-    channelPromise = connect(config.rabbitmq.url).then((connection) =>
+    const pending = connect(config.rabbitmq.url).then((connection) =>
       connection.createChannel().then((channel) => {
         queues.forEach((q) => channel.assertQueue(q))
         channel.prefetch(config.rabbitmq.prefetch)
         return channel
       }),
     )
-    channelPromise.then(() => {
-      for (const queue of queues) {
-        const queueSubscriptions = subscriptions[queue] ?? []
-        subscriptions[queue] = []
-        for (const callback of queueSubscriptions) {
-          subscribe(queue, callback)
-        }
+    channelPromise = pending
+
+    // A rejected channel must not stay cached. `getChannel` hands back whatever
+    // is in `channelPromise`, so a single failed connect wedged the driver on
+    // that one error for good: every later publish, subscribe and keepalive
+    // replayed the same rejection and no further connection was ever attempted,
+    // including after the broker came back. Cleared by identity so it cannot
+    // discard a channel opened in the meantime (or one `close` already dropped).
+    pending.catch(() => {
+      if (channelPromise === pending) {
+        channelPromise = null
       }
     })
+
+    pending.then(
+      () => {
+        for (const queue of queues) {
+          // Snapshotted rather than drained: `subscribe` de-duplicates against
+          // `subscriptions` itself, and emptying the list first would leave a
+          // retry unable to tell a callback that is still wanted from one that
+          // has since been unsubscribed.
+          for (const callback of [...(subscriptions[queue] ?? [])]) {
+            resubscribeAfterReconnect(queue, callback)
+          }
+        }
+      },
+      // Nothing to restore when the channel never opened, and the failure is
+      // reported by whoever awaited `getChannel`. Handled all the same, so this
+      // branch of the chain is not itself an unhandled rejection.
+      () => {},
+    )
+
     if (keepAliveInterval) {
       clearInterval(keepAliveInterval)
       keepAliveInterval = null
     }
-    keepAliveInterval = setInterval(
-      keepAlive,
-      config.rabbitmq.keepAliveInterval,
-    )
+    keepAliveInterval = setInterval(() => {
+      // `setInterval` discards what its callback returns, so anything escaping
+      // keepAlive would surface as an unhandled rejection and stop the process.
+      keepAlive().catch((error) => {
+        logger.error(error as Error, 'RabbitMQ keepalive failed unexpectedly')
+      })
+    }, config.rabbitmq.keepAliveInterval)
   }
 
   return channelPromise
@@ -99,7 +166,17 @@ const publish = async (queue: string, message: object) => {
 }
 
 const keepAlive = async () => {
-  const channel = await getChannel()
+  let channel: Channel
+  try {
+    channel = await getChannel()
+  } catch (error) {
+    // There is no channel to probe yet, so there is nothing for the reconnect
+    // below to do either — the next tick opens a fresh one now that a rejected
+    // channel is no longer cached. Caught because this runs on an interval with
+    // no caller: an escaping rejection would take the worker down.
+    logger.error(error as Error, 'RabbitMQ keepalive could not open a channel')
+    return
+  }
   try {
     // Passive check against an existing queue to keep the connection active
     await channel.checkQueue(queues[0])

--- a/apps/backend/src/infrastructure/eventRouter/index.ts
+++ b/apps/backend/src/infrastructure/eventRouter/index.ts
@@ -14,6 +14,7 @@ import {
 import { Task } from './tasks.js'
 import { handleFailedTask } from './taskErrorNotifier.js'
 import { createLogger } from '../drivers/logger.js'
+import { slackNotifier } from '../services/slack/index.js'
 
 const logger = createLogger('eventRouter')
 
@@ -73,8 +74,22 @@ export const EventRouter = {
    * single consumer, so extra readers share the work rather than duplicating
    * alerts. The only effect of multiple readers is that a batching window may be
    * split between them, producing two smaller summaries instead of one.
+   *
+   * Does nothing when Slack alerting is unconfigured. Consuming would ack each
+   * failure off a durable queue and reduce it to a log line, so a deploy that
+   * simply forgot `SLACK_WEBHOOK_URL` would quietly drain the very backlog these
+   * consumers exist to report — and destroy it, since the queue is the only place
+   * a failed task survives a log rotation. Left unread the messages wait, and the
+   * first deploy that does have a webhook alerts on all of them.
    */
   listenTaskErrors: () => {
+    if (!slackNotifier.isEnabled()) {
+      logger.warn(
+        'Slack alerting is not configured (no SLACK_WEBHOOK_URL); leaving the error queues unconsumed so permanently failed tasks are preserved rather than acked away',
+      )
+      return
+    }
+
     for (const queue of [
       frontendErrorPublishedQueue,
       downloadErrorPublishedQueue,

--- a/apps/backend/src/infrastructure/eventRouter/index.ts
+++ b/apps/backend/src/infrastructure/eventRouter/index.ts
@@ -12,6 +12,7 @@ import {
   publishErrorPublishedQueue,
 } from './processors/publish.js'
 import { Task } from './tasks.js'
+import { handleFailedTask } from './taskErrorNotifier.js'
 
 export const EventRouter = {
   listenFrontendEvents: () => {
@@ -22,6 +23,27 @@ export const EventRouter = {
   },
   listenPublishEvents: () => {
     Rabbit.subscribe('publish-manager', processPublishTask)
+  },
+  /**
+   * Consumes the error queues and alerts on what lands there.
+   *
+   * Until now nothing subscribed to them, so a task that exhausted its retries
+   * was published to a queue with no reader and stayed there forever — the count
+   * was a growing tally of silent failures, not a backlog anything would drain.
+   *
+   * Safe to call from more than one process: RabbitMQ delivers each message to a
+   * single consumer, so extra readers share the work rather than duplicating
+   * alerts. The only effect of multiple readers is that a batching window may be
+   * split between them, producing two smaller summaries instead of one.
+   */
+  listenTaskErrors: () => {
+    for (const queue of [
+      frontendErrorPublishedQueue,
+      downloadErrorPublishedQueue,
+      publishErrorPublishedQueue,
+    ] as const) {
+      Rabbit.subscribe(queue, (message) => handleFailedTask(queue, message))
+    }
   },
   publish: (tasks: Task[] | Task) => {
     if (Array.isArray(tasks)) {

--- a/apps/backend/src/infrastructure/eventRouter/index.ts
+++ b/apps/backend/src/infrastructure/eventRouter/index.ts
@@ -1,4 +1,4 @@
-import { Rabbit } from '../drivers/rabbit.js'
+import { Queue, Rabbit } from '../drivers/rabbit.js'
 import {
   downloadErrorPublishedQueue,
   processDownloadTask,
@@ -18,6 +18,30 @@ import { createLogger } from '../drivers/logger.js'
 const logger = createLogger('eventRouter')
 
 /**
+ * Starts consuming a queue without letting a failed start take the worker with it.
+ *
+ * `subscribe` re-raises a `consume` that failed, and these listeners are called
+ * from a server entry point with no caller to return to — so a broker that is not
+ * up yet when a worker starts produced an unhandled rejection, which Node's
+ * default `--unhandled-rejections=throw` turns into a dead process.
+ *
+ * Logging and carrying on is a real recovery rather than a swallowed error: the
+ * callback is registered in the driver's subscription list *before* the channel is
+ * awaited, and a rejected channel is no longer cached, so the next keepalive tick
+ * opens a fresh channel and re-subscribes it.
+ */
+const startConsumer = (
+  queue: Queue,
+  handler: (message: Record<string, unknown>) => Promise<unknown>,
+) => {
+  const subscription = Rabbit.subscribe(queue, handler)
+  subscription.catch((error: unknown) => {
+    logger.error(error as Error, 'Failed to consume %s', queue)
+  })
+  return subscription
+}
+
+/**
  * In-flight subscriptions to the error queues, so shutdown can stop them.
  *
  * Holds the *promises* rather than the resolved unsubscribe handles, and is
@@ -30,13 +54,13 @@ let taskErrorSubscriptions: Array<Promise<() => Promise<void>>> = []
 
 export const EventRouter = {
   listenFrontendEvents: () => {
-    Rabbit.subscribe('task-manager', processFrontendTask)
+    startConsumer('task-manager', processFrontendTask)
   },
   listenDownloadEvents: () => {
-    Rabbit.subscribe('download-manager', processDownloadTask)
+    startConsumer('download-manager', processDownloadTask)
   },
   listenPublishEvents: () => {
-    Rabbit.subscribe('publish-manager', processPublishTask)
+    startConsumer('publish-manager', processPublishTask)
   },
   /**
    * Consumes the error queues and alerts on what lands there.
@@ -56,16 +80,12 @@ export const EventRouter = {
       downloadErrorPublishedQueue,
       publishErrorPublishedQueue,
     ] as const) {
-      const subscription = Rabbit.subscribe(queue, (message) =>
-        handleFailedTask(queue, message),
-      )
+      // Failures are logged (and the rejection handled) by startConsumer;
+      // stopTaskErrors catches its own await of the same promise.
       // Tracked synchronously so a shutdown cannot race the subscribe resolving.
-      taskErrorSubscriptions.push(subscription)
-      // Failures are surfaced (and the rejection handled) here; stopTaskErrors
-      // catches its own await of the same promise.
-      subscription.catch((error: unknown) => {
-        logger.error(error as Error, 'Failed to consume error queue %s', queue)
-      })
+      taskErrorSubscriptions.push(
+        startConsumer(queue, (message) => handleFailedTask(queue, message)),
+      )
     }
   },
   /**

--- a/apps/backend/src/infrastructure/eventRouter/index.ts
+++ b/apps/backend/src/infrastructure/eventRouter/index.ts
@@ -17,8 +17,16 @@ import { createLogger } from '../drivers/logger.js'
 
 const logger = createLogger('eventRouter')
 
-/** Unsubscribe handles for the error-queue consumers, so shutdown can stop them. */
-let taskErrorUnsubscribers: Array<() => void> = []
+/**
+ * In-flight subscriptions to the error queues, so shutdown can stop them.
+ *
+ * Holds the *promises* rather than the resolved unsubscribe handles, and is
+ * appended to synchronously. Storing resolved handles left a window between
+ * process start and the subscribe resolving in which this list was empty, so a
+ * shutdown arriving in that window cancelled nothing and the "stopped consumers"
+ * guarantee silently did not hold.
+ */
+let taskErrorSubscriptions: Array<Promise<() => Promise<void>>> = []
 
 export const EventRouter = {
   listenFrontendEvents: () => {
@@ -48,36 +56,50 @@ export const EventRouter = {
       downloadErrorPublishedQueue,
       publishErrorPublishedQueue,
     ] as const) {
-      Rabbit.subscribe(queue, (message) =>
+      const subscription = Rabbit.subscribe(queue, (message) =>
         handleFailedTask(queue, message),
-      ).then(
-        (unsubscribe) => {
-          taskErrorUnsubscribers.push(unsubscribe)
-        },
-        (error) => {
-          logger.error(error as Error, 'Failed to consume error queue %s', queue)
-        },
       )
+      // Tracked synchronously so a shutdown cannot race the subscribe resolving.
+      taskErrorSubscriptions.push(subscription)
+      // Failures are surfaced (and the rejection handled) here; stopTaskErrors
+      // catches its own await of the same promise.
+      subscription.catch((error: unknown) => {
+        logger.error(error as Error, 'Failed to consume error queue %s', queue)
+      })
     }
   },
   /**
-   * Cancels the error-queue consumers.
+   * Cancels the error-queue consumers and waits for the cancels to take effect.
    *
-   * Must run before `flushTaskErrorAlerts` on shutdown. Otherwise failures keep
-   * being acked while the final send is awaited, landing in a batch created after
-   * the flush decided it was finished — which is how a deploy drops exactly the
-   * alerts the shutdown flush exists to preserve.
+   * Must be awaited before `flushTaskErrorAlerts` on shutdown. Otherwise failures
+   * keep being acked while the final send is awaited, landing in a batch created
+   * after the flush decided it was finished — which is how a deploy drops exactly
+   * the alerts the shutdown flush exists to preserve.
+   *
+   * Cancelling stops *new* deliveries; a message already handed to the client can
+   * still be inside its handler when this resolves. That residue is what the
+   * drain passes in `flushTaskErrorAlerts` cover — the two work together, and
+   * neither is sufficient alone.
    */
-  stopTaskErrors: () => {
-    const unsubscribers = taskErrorUnsubscribers
-    taskErrorUnsubscribers = []
-    for (const unsubscribe of unsubscribers) {
-      try {
-        unsubscribe()
-      } catch (error) {
-        logger.warn(error as Error, 'Failed to cancel an error-queue consumer')
-      }
-    }
+  stopTaskErrors: async () => {
+    const subscriptions = taskErrorSubscriptions
+    taskErrorSubscriptions = []
+
+    await Promise.all(
+      subscriptions.map(async (subscription) => {
+        try {
+          const unsubscribe = await subscription
+          await unsubscribe()
+        } catch (error) {
+          // A subscribe that never succeeded has nothing to cancel, and a cancel
+          // on an already-closed channel is moot. Either way shutdown continues.
+          logger.warn(
+            error as Error,
+            'Failed to cancel an error-queue consumer during shutdown',
+          )
+        }
+      }),
+    )
   },
   publish: (tasks: Task[] | Task) => {
     if (Array.isArray(tasks)) {

--- a/apps/backend/src/infrastructure/eventRouter/index.ts
+++ b/apps/backend/src/infrastructure/eventRouter/index.ts
@@ -13,6 +13,12 @@ import {
 } from './processors/publish.js'
 import { Task } from './tasks.js'
 import { handleFailedTask } from './taskErrorNotifier.js'
+import { createLogger } from '../drivers/logger.js'
+
+const logger = createLogger('eventRouter')
+
+/** Unsubscribe handles for the error-queue consumers, so shutdown can stop them. */
+let taskErrorUnsubscribers: Array<() => void> = []
 
 export const EventRouter = {
   listenFrontendEvents: () => {
@@ -42,7 +48,35 @@ export const EventRouter = {
       downloadErrorPublishedQueue,
       publishErrorPublishedQueue,
     ] as const) {
-      Rabbit.subscribe(queue, (message) => handleFailedTask(queue, message))
+      Rabbit.subscribe(queue, (message) =>
+        handleFailedTask(queue, message),
+      ).then(
+        (unsubscribe) => {
+          taskErrorUnsubscribers.push(unsubscribe)
+        },
+        (error) => {
+          logger.error(error as Error, 'Failed to consume error queue %s', queue)
+        },
+      )
+    }
+  },
+  /**
+   * Cancels the error-queue consumers.
+   *
+   * Must run before `flushTaskErrorAlerts` on shutdown. Otherwise failures keep
+   * being acked while the final send is awaited, landing in a batch created after
+   * the flush decided it was finished — which is how a deploy drops exactly the
+   * alerts the shutdown flush exists to preserve.
+   */
+  stopTaskErrors: () => {
+    const unsubscribers = taskErrorUnsubscribers
+    taskErrorUnsubscribers = []
+    for (const unsubscribe of unsubscribers) {
+      try {
+        unsubscribe()
+      } catch (error) {
+        logger.warn(error as Error, 'Failed to cancel an error-queue consumer')
+      }
     }
   },
   publish: (tasks: Task[] | Task) => {

--- a/apps/backend/src/infrastructure/eventRouter/taskErrorNotifier.ts
+++ b/apps/backend/src/infrastructure/eventRouter/taskErrorNotifier.ts
@@ -49,6 +49,28 @@ let inFlightFlush: Promise<void> | null = null
 const MAX_DRAIN_PASSES = 5
 
 /**
+ * Caps on the size of an alert body.
+ *
+ * Slack truncates a message past 40,000 characters, and a wall of text stops
+ * being readable long before that. The number of items is already capped by
+ * `alertMaxItems`, but neither half of the product is otherwise bounded: a
+ * reason is whatever `Error.message` a library produced — a polkadot RPC error
+ * can carry a hex-encoded extrinsic — and `alertMaxItems` is an environment
+ * variable somebody may well raise mid-incident, which is when batches are
+ * largest.
+ *
+ * Nothing is lost to a clamp: every failure is logged in full as it arrives,
+ * and a batch that fails to deliver is logged in full as well.
+ */
+const MAX_REASON_CHARS = 500
+const MAX_DETAILS_CHARS = 8000
+
+const clamp = (text: string, limit: number) =>
+  text.length > limit
+    ? `${text.slice(0, limit)}… [+${text.length - limit} chars, see logs]`
+    : text
+
+/**
  * Best-effort identifier for the thing that failed, so an alert points at
  * something actionable rather than just a task name.
  */
@@ -89,16 +111,23 @@ const formatBatch = (failures: PendingFailure[]) => {
   const lines = shown.map(({ queue, task }) =>
     [
       `[${queue}] ${task.id} ${subjectOf(task)}`,
-      task.error ? `  reason: ${task.error}` : '  reason: <not recorded>',
+      task.error
+        ? `  reason: ${clamp(task.error, MAX_REASON_CHARS)}`
+        : '  reason: <not recorded>',
     ].join('\n'),
   )
 
-  const omitted = failures.length - shown.length
-  if (omitted > 0) {
-    lines.push(`… and ${omitted} more`)
-  }
+  // Clamped before the "and N more" marker is appended rather than after:
+  // truncation takes the tail, which is where that marker would sit, and it is
+  // the one line telling a reader the batch was larger than what they can see.
+  const body = clamp(lines.join('\n'), MAX_DETAILS_CHARS)
 
-  return { title, details: lines.join('\n') }
+  const omitted = failures.length - shown.length
+
+  return {
+    title,
+    details: omitted > 0 ? `${body}\n… and ${omitted} more` : body,
+  }
 }
 
 const deliverBatch = async () => {

--- a/apps/backend/src/infrastructure/eventRouter/taskErrorNotifier.ts
+++ b/apps/backend/src/infrastructure/eventRouter/taskErrorNotifier.ts
@@ -71,6 +71,17 @@ const clamp = (text: string, limit: number) =>
     : text
 
 /**
+ * Collapses a reason onto one line.
+ *
+ * `reason:` is a single-line field in a list of them, and an `Error.message` is
+ * under no obligation to cooperate — a wrapped RPC error or anything carrying a
+ * stack arrives with its own newlines, which break the layout of the entry and
+ * push the rest of the batch down the message. Applied before clamping so the
+ * character budget counts what a reader actually sees.
+ */
+const oneLine = (text: string) => text.replace(/\s+/g, ' ').trim()
+
+/**
  * Best-effort identifier for the thing that failed, so an alert points at
  * something actionable rather than just a task name.
  */
@@ -112,7 +123,7 @@ const formatBatch = (failures: PendingFailure[]) => {
     [
       `[${queue}] ${task.id} ${subjectOf(task)}`,
       task.error
-        ? `  reason: ${clamp(task.error, MAX_REASON_CHARS)}`
+        ? `  reason: ${clamp(oneLine(task.error), MAX_REASON_CHARS)}`
         : '  reason: <not recorded>',
     ].join('\n'),
   )

--- a/apps/backend/src/infrastructure/eventRouter/taskErrorNotifier.ts
+++ b/apps/backend/src/infrastructure/eventRouter/taskErrorNotifier.ts
@@ -31,6 +31,24 @@ let pending: PendingFailure[] = []
 let flushTimer: NodeJS.Timeout | null = null
 
 /**
+ * The send currently in progress.
+ *
+ * Tracked so a shutdown can *await* a send rather than abort it: a batch is
+ * removed from `pending` before the webhook call starts, so a `process.exit`
+ * landing mid-send would take the batch with it while `pending` looked empty.
+ */
+let inFlightFlush: Promise<void> | null = null
+
+/**
+ * Passes the shutdown drain will make before giving up.
+ *
+ * More than one is needed because the error-queue consumers stay active while a
+ * send is awaited, so failures acked during that wait land in a fresh batch.
+ * Bounded so a steady stream of failures cannot hold shutdown open forever.
+ */
+const MAX_DRAIN_PASSES = 5
+
+/**
  * Best-effort identifier for the thing that failed, so an alert points at
  * something actionable rather than just a task name.
  */
@@ -83,7 +101,7 @@ const formatBatch = (failures: PendingFailure[]) => {
   return { title, details: lines.join('\n') }
 }
 
-const flush = async () => {
+const deliverBatch = async () => {
   flushTimer = null
   const batch = pending
   pending = []
@@ -103,6 +121,33 @@ const flush = async () => {
       details,
     )
   }
+}
+
+/**
+ * Sends the current batch, serialised against any send already in progress.
+ *
+ * Serialisation matters because two callers can arrive at once — a window expiry
+ * and a shutdown — and each takes the whole of `pending`. Running them
+ * concurrently would split one batch across two messages, or lose one entirely
+ * if the process exits while the second is still queued behind the first.
+ */
+const flush = (): Promise<void> => {
+  const previous = inFlightFlush ?? Promise.resolve()
+  const run = previous
+    .catch(() => undefined)
+    .then(deliverBatch)
+    .catch((error) => {
+      logger.error(error as Error, 'Failed to flush task error alerts')
+    })
+
+  inFlightFlush = run
+  void run.finally(() => {
+    if (inFlightFlush === run) {
+      inFlightFlush = null
+    }
+  })
+
+  return run
 }
 
 /**
@@ -150,12 +195,51 @@ export const handleFailedTask = async (
   }
 }
 
-/** Flushes any batched alerts immediately. Exposed for tests and shutdown. */
+/**
+ * Sends everything batched, for shutdown and tests.
+ *
+ * Drains in passes rather than flushing once. Two things make a single flush
+ * insufficient:
+ *
+ * - A send already in progress has taken its batch out of `pending`, so a single
+ *   `flush()` would see nothing to do and return immediately, letting the caller
+ *   proceed to `process.exit` and kill that send.
+ * - The error-queue consumers keep acking failures while a send is awaited, and
+ *   those land in a fresh batch behind it.
+ *
+ * Callers should stop the consumers first (`EventRouter.stopTaskErrors`) so the
+ * second case is bounded; the passes are belt-and-braces for messages whose
+ * handler was already running when the consumer was cancelled.
+ */
 export const flushTaskErrorAlerts = async () => {
-  if (flushTimer) {
-    clearTimeout(flushTimer)
+  for (let pass = 0; pass < MAX_DRAIN_PASSES; pass++) {
+    if (flushTimer) {
+      clearTimeout(flushTimer)
+      flushTimer = null
+    }
+
+    // Never let the caller exit out from under a send that already cleared its
+    // batch — that is the one way a batch disappears without being delivered.
+    if (inFlightFlush) {
+      await inFlightFlush
+    }
+
+    if (pending.length === 0) {
+      return
+    }
+
+    await flush()
   }
-  await flush()
+
+  if (pending.length > 0) {
+    // Not silent: each of these was already logged individually as it arrived,
+    // so the failures survive in the logs even though the alert did not.
+    logger.error(
+      'Gave up flushing %d task error alert(s) after %d passes; they remain in the logs only',
+      pending.length,
+      MAX_DRAIN_PASSES,
+    )
+  }
 }
 
 /** Drops batched state without sending. Tests only. */
@@ -165,4 +249,5 @@ export const resetTaskErrorAlerts = () => {
   }
   flushTimer = null
   pending = []
+  inFlightFlush = null
 }

--- a/apps/backend/src/infrastructure/eventRouter/taskErrorNotifier.ts
+++ b/apps/backend/src/infrastructure/eventRouter/taskErrorNotifier.ts
@@ -31,6 +31,14 @@ let pending: PendingFailure[] = []
 let flushTimer: NodeJS.Timeout | null = null
 
 /**
+ * Failures dropped for want of room since the last batch was taken.
+ *
+ * Kept so a cap that silently ate a flood cannot be mistaken for a small one —
+ * the count rides along in the alert.
+ */
+let droppedSinceLastBatch = 0
+
+/**
  * The send currently in progress.
  *
  * Tracked so a shutdown can *await* a send rather than abort it: a batch is
@@ -64,6 +72,20 @@ const MAX_DRAIN_PASSES = 5
  */
 const MAX_REASON_CHARS = 500
 const MAX_DETAILS_CHARS = 8000
+
+/**
+ * Ceiling on failures held for the next batch.
+ *
+ * The character caps above bound the *message*; this bounds the *heap*. Nothing
+ * else does: a batching window is 30 minutes by default, and a poison-message
+ * loop can dead-letter at a rate limited only by how fast the broker redelivers —
+ * every one of which is retained here, with its params, until the window expires.
+ *
+ * Sized well above any batch worth reading (the alert lists 10 by default) and
+ * well below anything that troubles a worker's heap. Overflow is counted, not
+ * ignored, and each failure is logged in full as it arrives regardless.
+ */
+const MAX_PENDING_FAILURES = 1_000
 
 const clamp = (text: string, limit: number) =>
   text.length > limit
@@ -102,7 +124,7 @@ const subjectOf = (task: FailedTask): string => {
   return 'no subject'
 }
 
-const formatBatch = (failures: PendingFailure[]) => {
+const formatBatch = (failures: PendingFailure[], dropped: number) => {
   const countsByTask = new Map<string, number>()
   for (const { task } of failures) {
     countsByTask.set(task.id, (countsByTask.get(task.id) ?? 0) + 1)
@@ -113,10 +135,13 @@ const formatBatch = (failures: PendingFailure[]) => {
     .map(([id, count]) => `${id}×${count}`)
     .join(', ')
 
-  const title =
+  const base =
     failures.length === 1
       ? `:warning: Task permanently failed: \`${failures[0].task.id}\``
       : `:warning: ${failures.length} tasks permanently failed (${breakdown})`
+  // The headline carries the overflow too: understating a flood as a handful is
+  // the one way this cap could mislead somebody triaging.
+  const title = dropped > 0 ? `${base} — plus ${dropped} not recorded` : base
 
   const shown = failures.slice(0, config.slack.alertMaxItems)
   const lines = shown.map(({ queue, task }) =>
@@ -128,16 +153,22 @@ const formatBatch = (failures: PendingFailure[]) => {
     ].join('\n'),
   )
 
-  // Clamped before the "and N more" marker is appended rather than after:
-  // truncation takes the tail, which is where that marker would sit, and it is
-  // the one line telling a reader the batch was larger than what they can see.
+  // Clamped before the "and N more" markers are appended rather than after:
+  // truncation takes the tail, which is where those markers would sit, and they
+  // are the lines telling a reader the batch was larger than what they can see.
   const body = clamp(lines.join('\n'), MAX_DETAILS_CHARS)
 
   const omitted = failures.length - shown.length
+  const notes = [
+    omitted > 0 ? `… and ${omitted} more` : null,
+    dropped > 0
+      ? `… and ${dropped} dropped before batching (over ${MAX_PENDING_FAILURES}); see logs`
+      : null,
+  ].filter(Boolean)
 
   return {
     title,
-    details: omitted > 0 ? `${body}\n… and ${omitted} more` : body,
+    details: [body, ...notes].join('\n'),
   }
 }
 
@@ -145,11 +176,13 @@ const deliverBatch = async () => {
   flushTimer = null
   const batch = pending
   pending = []
+  const dropped = droppedSinceLastBatch
+  droppedSinceLastBatch = 0
   if (batch.length === 0) {
     return
   }
 
-  const { title, details } = formatBatch(batch)
+  const { title, details } = formatBatch(batch, dropped)
   const delivered = await slackNotifier.send({ title, details })
   if (!delivered) {
     // Logged rather than requeued. The queue driver requeues immediately with no
@@ -224,6 +257,22 @@ export const handleFailedTask = async (
     return
   }
 
+  if (pending.length >= MAX_PENDING_FAILURES) {
+    droppedSinceLastBatch++
+    // Once per batch, not once per drop: the situation that fills this buffer is
+    // a flood, and a log line per dropped message would be one more of them. The
+    // failures themselves are each logged above regardless.
+    if (droppedSinceLastBatch === 1) {
+      logger.warn(
+        'Holding %d pending task error alerts; further failures will be counted rather than listed until the next batch is sent',
+        pending.length,
+      )
+    }
+    // A non-empty `pending` means the window timer is already armed, so the
+    // counted drops still reach the next alert.
+    return
+  }
+
   pending.push({ queue, task: parsed.data })
 
   if (!flushTimer) {
@@ -289,5 +338,6 @@ export const resetTaskErrorAlerts = () => {
   }
   flushTimer = null
   pending = []
+  droppedSinceLastBatch = 0
   inFlightFlush = null
 }

--- a/apps/backend/src/infrastructure/eventRouter/taskErrorNotifier.ts
+++ b/apps/backend/src/infrastructure/eventRouter/taskErrorNotifier.ts
@@ -1,0 +1,168 @@
+import { z } from 'zod'
+import { config } from '../../config.js'
+import { createLogger } from '../drivers/logger.js'
+import { slackNotifier } from '../services/slack/index.js'
+
+const logger = createLogger('eventRouter:taskErrorNotifier')
+
+/**
+ * Shape of a message on an error queue: the original task plus the failure
+ * context added when its retries ran out.
+ *
+ * Deliberately permissive — this is not re-validated against `TaskSchema`. A
+ * message that no longer parses as a known task is exactly the kind of thing
+ * worth alerting on, so rejecting it here would hide it.
+ */
+const FailedTaskSchema = z.object({
+  id: z.string(),
+  params: z.record(z.unknown()).optional(),
+  error: z.string().optional(),
+  failedAt: z.string().optional(),
+})
+
+export type FailedTask = z.infer<typeof FailedTaskSchema>
+
+interface PendingFailure {
+  queue: string
+  task: FailedTask
+}
+
+let pending: PendingFailure[] = []
+let flushTimer: NodeJS.Timeout | null = null
+
+/**
+ * Best-effort identifier for the thing that failed, so an alert points at
+ * something actionable rather than just a task name.
+ */
+const subjectOf = (task: FailedTask): string => {
+  const params = task.params ?? {}
+  for (const key of ['cid', 'downloadId', 'uploadId']) {
+    const value = params[key]
+    if (typeof value === 'string' && value) {
+      return `${key}=${value}`
+    }
+  }
+  if (Array.isArray(params.nodes)) {
+    return `nodes=${params.nodes.length}`
+  }
+  if (Array.isArray(params.objects)) {
+    return `objects=${params.objects.length}`
+  }
+  return 'no subject'
+}
+
+const formatBatch = (failures: PendingFailure[]) => {
+  const countsByTask = new Map<string, number>()
+  for (const { task } of failures) {
+    countsByTask.set(task.id, (countsByTask.get(task.id) ?? 0) + 1)
+  }
+
+  const breakdown = [...countsByTask.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([id, count]) => `${id}×${count}`)
+    .join(', ')
+
+  const title =
+    failures.length === 1
+      ? `:warning: Task permanently failed: \`${failures[0].task.id}\``
+      : `:warning: ${failures.length} tasks permanently failed (${breakdown})`
+
+  const shown = failures.slice(0, config.slack.alertMaxItems)
+  const lines = shown.map(({ queue, task }) =>
+    [
+      `[${queue}] ${task.id} ${subjectOf(task)}`,
+      task.error ? `  reason: ${task.error}` : '  reason: <not recorded>',
+    ].join('\n'),
+  )
+
+  const omitted = failures.length - shown.length
+  if (omitted > 0) {
+    lines.push(`… and ${omitted} more`)
+  }
+
+  return { title, details: lines.join('\n') }
+}
+
+const flush = async () => {
+  flushTimer = null
+  const batch = pending
+  pending = []
+  if (batch.length === 0) {
+    return
+  }
+
+  const { title, details } = formatBatch(batch)
+  const delivered = await slackNotifier.send({ title, details })
+  if (!delivered) {
+    // Logged rather than requeued. The queue driver requeues immediately with no
+    // backoff, so a failing alert would spin in a hot loop and, worse, block the
+    // drain of the very backlog we are trying to report.
+    logger.error(
+      'Failed to deliver Slack alert for %d permanently failed task(s): %s',
+      batch.length,
+      details,
+    )
+  }
+}
+
+/**
+ * Records a permanently failed task for the next batched alert.
+ *
+ * Resolves immediately so the queue message is acked: alerting must never hold
+ * up the error queue. The trade-off is that an alert can be lost if the process
+ * dies inside the batching window — acceptable for a notification, and preferable
+ * to a queue that stops draining.
+ */
+export const handleFailedTask = async (
+  queue: string,
+  message: Record<string, unknown>,
+): Promise<void> => {
+  const parsed = FailedTaskSchema.safeParse(message)
+  if (!parsed.success) {
+    logger.error(
+      'Unparseable message on error queue %s: %s',
+      queue,
+      JSON.stringify(message).slice(0, 500),
+    )
+    return
+  }
+
+  logger.warn(
+    'Task %s on %s failed permanently (%s): %s',
+    parsed.data.id,
+    queue,
+    subjectOf(parsed.data),
+    parsed.data.error ?? '<reason not recorded>',
+  )
+
+  if (!slackNotifier.isEnabled()) {
+    return
+  }
+
+  pending.push({ queue, task: parsed.data })
+
+  if (!flushTimer) {
+    flushTimer = setTimeout(() => {
+      void flush()
+    }, config.slack.alertWindowMs)
+    // Do not hold the event loop open on account of a pending alert.
+    flushTimer.unref?.()
+  }
+}
+
+/** Flushes any batched alerts immediately. Exposed for tests and shutdown. */
+export const flushTaskErrorAlerts = async () => {
+  if (flushTimer) {
+    clearTimeout(flushTimer)
+  }
+  await flush()
+}
+
+/** Drops batched state without sending. Tests only. */
+export const resetTaskErrorAlerts = () => {
+  if (flushTimer) {
+    clearTimeout(flushTimer)
+  }
+  flushTimer = null
+  pending = []
+}

--- a/apps/backend/src/infrastructure/eventRouter/utils.ts
+++ b/apps/backend/src/infrastructure/eventRouter/utils.ts
@@ -65,6 +65,11 @@ export const createHandlerWithRetries =
           Rabbit.publish(errorPublishQueue, {
             ...parsingResult.data,
             retriesLeft: errorRetries,
+            // The reason is carried on the message, not just logged: the error
+            // queues are the only record that a task died, and a consumer that
+            // can name the task but not why it failed cannot be acted on.
+            error: error instanceof Error ? error.message : String(error),
+            failedAt: new Date().toISOString(),
           })
         }
         logger.error(error as Error, 'Task failed')

--- a/apps/backend/src/infrastructure/services/slack/index.ts
+++ b/apps/backend/src/infrastructure/services/slack/index.ts
@@ -30,7 +30,7 @@ const send = async (message: SlackMessage): Promise<boolean> => {
   }
 
   const text = [
-    `*[${config.slack.environment}]* ${message.title}`,
+    message.title,
     message.details ? `\`\`\`\n${message.details}\n\`\`\`` : null,
   ]
     .filter(Boolean)

--- a/apps/backend/src/infrastructure/services/slack/index.ts
+++ b/apps/backend/src/infrastructure/services/slack/index.ts
@@ -1,0 +1,69 @@
+import { config } from '../../../config.js'
+import { createLogger } from '../../drivers/logger.js'
+
+const logger = createLogger('services:slack')
+
+const SEND_TIMEOUT_MS = 10_000
+
+export interface SlackMessage {
+  /** Single-line summary, used as the message text. */
+  title: string
+  /** Optional detail block, rendered as a fenced code block. */
+  details?: string
+}
+
+const isEnabled = () => Boolean(config.slack.webhookUrl)
+
+/**
+ * Posts to a Slack incoming webhook.
+ *
+ * Never throws: alerting is best-effort and must not fail the work that
+ * triggered it. Returns whether the post succeeded so callers can log or count
+ * it, but the failure of an alert is never itself escalated — there is nowhere
+ * to escalate it to.
+ */
+const send = async (message: SlackMessage): Promise<boolean> => {
+  const webhookUrl = config.slack.webhookUrl
+  if (!webhookUrl) {
+    logger.debug('Slack alerting disabled (no SLACK_WEBHOOK_URL); dropping alert')
+    return false
+  }
+
+  const text = [
+    `*[${config.slack.environment}]* ${message.title}`,
+    message.details ? `\`\`\`\n${message.details}\n\`\`\`` : null,
+  ]
+    .filter(Boolean)
+    .join('\n')
+
+  try {
+    const response = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text }),
+      signal: AbortSignal.timeout(SEND_TIMEOUT_MS),
+    })
+
+    if (!response.ok) {
+      // Body is read for the log because Slack returns the reason in plain text
+      // ("invalid_payload", "channel_not_found") rather than in the status.
+      const body = await response.text().catch(() => '<unreadable>')
+      logger.warn(
+        'Slack webhook rejected the alert (status=%d): %s',
+        response.status,
+        body,
+      )
+      return false
+    }
+
+    return true
+  } catch (error) {
+    logger.warn(error as Error, 'Failed to post Slack alert')
+    return false
+  }
+}
+
+export const slackNotifier = {
+  isEnabled,
+  send,
+}

--- a/apps/backend/src/shared/utils/index.ts
+++ b/apps/backend/src/shared/utils/index.ts
@@ -1,7 +1,5 @@
 export { safeCallback } from './safe.js'
-export {
-  handleReadableError,
-  sliceReadable,
-} from './readable.js'
+export { handleReadableError, sliceReadable } from './readable.js'
 export { withTimeout, TimeoutError } from './timeout.js'
+export { startShutdownWatchdog, shutdownStep } from './shutdown.js'
 export { applyMarginPercent } from './pricing.js'

--- a/apps/backend/src/shared/utils/shutdown.ts
+++ b/apps/backend/src/shared/utils/shutdown.ts
@@ -1,0 +1,67 @@
+import { Logger } from '../../infrastructure/drivers/logger.js'
+import { withTimeout } from './timeout.js'
+
+/**
+ * How long a whole shutdown sequence may take.
+ *
+ * Sized against the container's stop grace period, not against how long the
+ * steps would like: nothing in `docker-compose.prod.yml` sets
+ * `stop_grace_period`, so every worker gets Docker's default 10 seconds between
+ * SIGTERM and SIGKILL. A budget above that is not a budget — the kernel enforces
+ * its own, less politely. Raise both together if a sequence ever needs longer.
+ */
+const DEFAULT_SHUTDOWN_BUDGET_MS = 9_000
+
+/**
+ * Arms a timer that exits the process if shutdown has not finished in time.
+ *
+ * A shutdown handler is the one place where awaiting something unbounded is
+ * unrecoverable: before a handler exists SIGTERM terminates the process at once,
+ * and adding one replaces that with "runs until SIGKILL" whenever a step hangs.
+ * `stopShutdownWatchdog` on the happy path; the timer is unref'd so it never
+ * keeps an otherwise-finished process alive.
+ *
+ * `onExpiry` exists so tests can observe expiry without exiting the runner.
+ */
+export const startShutdownWatchdog = (
+  logger: Logger,
+  budgetMs: number = DEFAULT_SHUTDOWN_BUDGET_MS,
+  onExpiry: () => void = () => process.exit(1),
+) => {
+  const watchdog = setTimeout(() => {
+    logger.warn(
+      'Shutdown did not finish within %dms; exiting without completing it',
+      budgetMs,
+    )
+    onExpiry()
+  }, budgetMs)
+  watchdog.unref()
+
+  return () => clearTimeout(watchdog)
+}
+
+/**
+ * Runs one step of a shutdown, bounded, and never rejects.
+ *
+ * Both properties matter for the same reason: the steps are independent, and a
+ * step that hangs or throws must not take the ones behind it with it. Cancelling
+ * a consumer and closing a channel are broker RPCs that wait for a reply, so an
+ * unreachable broker or a half-open socket stalls them until amqplib's heartbeat
+ * notices — two missed intervals, ~120s at the negotiated default — while
+ * flushing alerts talks to Slack and would have succeeded regardless.
+ *
+ * A step cut short is reported, not silently dropped, and for alerting the
+ * underlying failures are in the logs either way.
+ */
+export const shutdownStep = async (
+  logger: Logger,
+  label: string,
+  timeoutMs: number,
+  run: () => Promise<unknown>,
+): Promise<void> => {
+  try {
+    await withTimeout(run(), timeoutMs, label)
+  } catch (error) {
+    logger.warn(error as Error, 'Shutdown step did not complete: %s', label)
+  }
+}

--- a/apps/backend/src/shared/utils/shutdown.ts
+++ b/apps/backend/src/shared/utils/shutdown.ts
@@ -21,12 +21,19 @@ const DEFAULT_SHUTDOWN_BUDGET_MS = 9_000
  * `stopShutdownWatchdog` on the happy path; the timer is unref'd so it never
  * keeps an otherwise-finished process alive.
  *
+ * Exits 0, not 1. The process was asked to stop and it stopped; a non-zero code
+ * would make a slow shutdown indistinguishable from a crash to whatever is
+ * supervising, at the exact moment (a deploy) when that distinction matters most.
+ * What was cut short is reported by the warning below and by each step's own log
+ * line, which is where it belongs — and every failure an unsent alert would have
+ * described is already in the logs individually.
+ *
  * `onExpiry` exists so tests can observe expiry without exiting the runner.
  */
 export const startShutdownWatchdog = (
   logger: Logger,
   budgetMs: number = DEFAULT_SHUTDOWN_BUDGET_MS,
-  onExpiry: () => void = () => process.exit(1),
+  onExpiry: () => void = () => process.exit(0),
 ) => {
   const watchdog = setTimeout(() => {
     logger.warn(


### PR DESCRIPTION
## Problem

The three error queues have no consumer.

`createHandlerWithRetries` publishes a task to `frontend-errors` / `download-errors` / `publish-errors` once its retries are exhausted, but `Rabbit.subscribe` was never called for any of them. So the depth of those queues was never a backlog waiting to be drained — it was a growing tally of failures nobody would ever see.

Production had **186 messages on `download-errors`**. Worth noting what that number is and isn't: the queue is fed by three task types (`async-download-created`, `object-archived`, `populate-cache`), so it was never "186 frustrated users", and purging it would have fixed nothing.

There was also a structural reason this had never been wired up: the error queues were created implicitly by `publish` alone and were absent from the `queues` tuple in `rabbit.ts`, so they were not valid `subscribe` (or `getMessageCount`) targets in the first place.

## What this changes

A consumer that batches permanently failed tasks and posts them to a Slack incoming webhook.

Four design points, roughly in order of how badly getting them wrong would have hurt:

### Batching, not one post per message

The first deploy drains a backlog. Posting per message would have put 186 messages into the channel in a few seconds and trained everyone to mute it — which would leave us exactly where we started, only with more noise.

Failures are collected for `TASK_ERROR_ALERT_WINDOW_MS` (default 30 minutes) and sent as one message with a per-task-type breakdown, listing at most `TASK_ERROR_ALERT_MAX_ITEMS` (default 10) individually before collapsing the rest to `… and N more`.

```
:warning: 50 tasks permanently failed (async-download-created×47, populate-cache×3)
```
```
[download-errors] async-download-created downloadId=dl-8f2c
  reason: Error fetching file header: 404 Not Found
[download-errors] populate-cache cid=bafkr6igab4rn…olyy
  reason: Download stalled: no data received for 300s
… and 47 more
```

### The handler must never throw

`Rabbit.subscribe` nacks with `requeue=true` and **no backoff**, so anything that throws out of the callback spins in a hot redelivery loop — and worse, blocks the drain of the very backlog it is trying to report.

An unparseable message and a failed Slack post are both logged and acked instead. The trade-off is that an alert can be lost if the process dies inside the batching window — which, at a 30-minute window, is worth taking seriously. Both workers now flush pending alerts on `SIGTERM`/`SIGINT`, so an ordinary deploy does not swallow the alerts it may itself have caused; the download worker had no shutdown handler at all before this. A hard crash (OOM, `SIGKILL`) can still lose up to a window's worth. The underlying failures are in the application logs either way — only the Slack notification is at risk.

Two of the eight tests exist purely to pin this behaviour.

### Carry the reason, not just the task

The error-queue payload contained only the task, so a consumer could say *what* failed but not *why*. `error` and `failedAt` now travel on the message.

The consumer validates the payload **loosely on purpose** — a message that no longer parses as a known task is exactly the sort of thing worth alerting on, so re-validating against `TaskSchema` would hide it.

### Make the error queues real queues

Added to the `queues` tuple so they are asserted at channel setup and are valid `subscribe`/`getMessageCount` targets.

## Where it runs

Registered in **both** the download worker and the frontend worker. RabbitMQ delivers each message to a single consumer, so a second reader shares the work rather than double-alerting; the only effect is that a batching window may be split between the two, producing two smaller summaries instead of one.

The download worker's registration is ungated by feature flags, so it is the one process guaranteed to be draining these queues. The frontend worker's registration also sits above its flag checks, for the same reason: a task that exhausted its retries needs reporting regardless of which subsystems a given host runs.

## Config

Alerting is **off unless `SLACK_WEBHOOK_URL` is set**, so dev and test are unaffected (failures are still logged). The channel is encoded in the webhook URL, so there is no separate channel setting.

| Variable | Default | Notes |
| --- | --- | --- |
| `SLACK_WEBHOOK_URL` | — | unset disables alerting |
| `TASK_ERROR_ALERT_WINDOW_MS` | `1800000` | batching window (30 min); also the worst-case alert loss on a hard crash |
| `TASK_ERROR_ALERT_MAX_ITEMS` | `10` | failures listed before collapsing to a count |

## Testing

8 new unit tests in `__tests__/unit/eventRouter/taskErrorNotifier.spec.ts`, covering: task/subject/reason formatting; batching 50 failures into one message; the item cap and overflow count; a missing reason reported rather than omitted; no accumulation when disabled; no throw on an unparseable message; no throw when Slack delivery fails; and a fresh batch after flushing.

`yarn backend lint` and `yarn backend build` pass. 34 tests pass across `__tests__/unit/eventRouter` and `TaskManager.spec.ts`, so the added `error`/`failedAt` fields on the error-queue payload don't disturb existing expectations.

**Not verified:** no live Slack post — this has not been run against a real webhook. Worth one manual check against a test channel before relying on it, ideally by letting a task fail rather than by calling the notifier directly, so the queue wiring is exercised too.

## Note on behaviour change

Consuming a queue drains it. Once these alerts fire, the record of a permanently failed task lives in Slack and the application logs rather than sitting in RabbitMQ. That is the point — but if a durable record is wanted, a `task_failures` table would be a small follow-up.

## Follow-ups (not in this PR)

- The retry path republishes with `retriesLeft - 1` **immediately, with no delay or backoff**, so all retries are consumed within seconds of the first failure. For failures caused by a dependency being down for days (the current DAG indexer lag), retries cannot help by construction — this is why tasks reach the error queue so readily.
- `object-archived` failures deserve more attention than the download ones: `onObjectArchived` marks metadata archived and *then* strips local node data, so archival is a one-way door onto the gateway path with no `DBObjectFetcher` fallback behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
