### PR TITLE
fix(uploads): make completeUpload idempotent and stop the frontend-errors dead-letter loop

### DIFF
--- a/apps/backend/__tests__/unit/core/completionRetryIdempotency.spec.ts
+++ b/apps/backend/__tests__/unit/core/completionRetryIdempotency.spec.ts
@@ -10,11 +10,17 @@ import {
   DEFAULT_MAX_CHUNK_SIZE,
   MetadataType,
   cidToString,
+  stringToCid,
 } from '@autonomys/auto-dag-data'
 import { UploadType } from '@auto-drive/models'
-import { ok } from 'neverthrow'
+import { err, ok } from 'neverthrow'
 import { UploadFileProcessingUseCase } from '../../../src/core/uploads/uploadProcessing.js'
-import { UploadPartsChangedError } from '../../../src/core/uploads/errors.js'
+import {
+  UnrecoverableUploadError,
+  UploadPartsChangedError,
+} from '../../../src/core/uploads/errors.js'
+import { BlockstoreUseCases } from '../../../src/core/uploads/blockstore.js'
+import { ObjectNotFoundError } from '../../../src/errors/index.js'
 import {
   NodesUseCases,
   createNodeDeduplicator,
@@ -29,6 +35,7 @@ import { nodesRepository } from '../../../src/infrastructure/repositories/object
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 const UPLOAD_ID = 'upload-retry-1'
+const ROOT_CID = 'bafkr6icio4rqi75syx2xkxwmnnnwx3gzmnbjmtnqoydtfcxrjuqvvxxs4u'
 
 // The root node types are the ones blockstore_root_node_unique_idx covers.
 const ROOT_NODE_TYPES = [MetadataType.File, MetadataType.Folder]
@@ -491,5 +498,48 @@ describe('migrateFromBlockstoreToNodesTable over repeated content', () => {
     expect(insertedBatches.every((batch) => batch.length > 0)).toBe(true)
     // Each distinct node written exactly once, across every batch.
     expect(insertedBatches.flat()).toHaveLength(distinctCids.size)
+  })
+
+  // The guard on this used to be `if (!metadata) return` against a neverthrow
+  // Result, which is always truthy — so it never fired and migration proceeded
+  // without metadata, writing nodes that nothing would ever publish. Unrecoverable
+  // is the honest verdict: the metadata is written before the upload reaches
+  // MIGRATING, so a missing row cannot be fixed by retrying.
+  it('parks an upload whose root has no metadata instead of migrating it', async () => {
+    installFakeBlockstore()
+
+    const uploadEntry = {
+      id: UPLOAD_ID,
+      root_upload_id: UPLOAD_ID,
+      type: UploadType.FILE,
+      name: 'orphan.bin',
+      upload_options: null,
+    } as any
+    jest
+      .spyOn(uploadsRepository, 'getUploadEntryById')
+      .mockResolvedValue(uploadEntry)
+    jest
+      .spyOn(uploadsRepository, 'getUploadsByRoot')
+      .mockResolvedValue([uploadEntry])
+    jest
+      .spyOn(BlockstoreUseCases, 'getFileUploadIdCID')
+      .mockResolvedValue(stringToCid(ROOT_CID))
+    jest
+      .spyOn(ObjectUseCases, 'getMetadata')
+      .mockResolvedValue(err(new ObjectNotFoundError('not found')))
+    const removeNodes = jest
+      .spyOn(nodesRepository, 'removeNodeByRootCid')
+      .mockResolvedValue(undefined as any)
+    const saveNodes = jest
+      .spyOn(nodesRepository, 'saveNodes')
+      .mockResolvedValue(undefined)
+
+    await expect(
+      NodesUseCases.migrateFromBlockstoreToNodesTable(UPLOAD_ID),
+    ).rejects.toBeInstanceOf(UnrecoverableUploadError)
+    // Nothing written, and nothing deleted either: the check happens before the
+    // clear-and-reinsert.
+    expect(removeNodes).not.toHaveBeenCalled()
+    expect(saveNodes).not.toHaveBeenCalled()
   })
 })

--- a/apps/backend/__tests__/unit/core/completionRetryIdempotency.spec.ts
+++ b/apps/backend/__tests__/unit/core/completionRetryIdempotency.spec.ts
@@ -14,6 +14,7 @@ import {
 import { UploadType } from '@auto-drive/models'
 import { ok } from 'neverthrow'
 import { UploadFileProcessingUseCase } from '../../../src/core/uploads/uploadProcessing.js'
+import { UploadPartsChangedError } from '../../../src/core/uploads/errors.js'
 import {
   NodesUseCases,
   createNodeDeduplicator,
@@ -210,6 +211,114 @@ describe('completeUploadProcessing retry idempotency', () => {
     // Exactly one root row, and one root CID — the shape getRootNodeCID accepts.
     expect(store.countOf(MetadataType.File)).toBe(1)
     expect(store.distinctCidsOf(MetadataType.File)).toBe(1)
+  })
+
+  // The limit of that resume. Reusing the derived root is right only while the
+  // upload still holds the bytes it was derived from, and `part A, failed
+  // complete, part B, complete` is legal at every step: uploadChunk has no status
+  // guard, the failed completion released the row to PENDING, and S3 permits
+  // UploadPart after a failed CompleteMultipartUpload. Silently returning A's CID
+  // would hand the client a truncated object to store and reference.
+  it('refuses to reuse a root node once more parts have been stored', async () => {
+    installFakeBlockstore()
+
+    // Part A: one full chunk and a tail, i.e. the ordinary mid-upload state.
+    const partA = Buffer.alloc(DEFAULT_MAX_CHUNK_SIZE + 1000, 1)
+    let storedBytes = BigInt(partA.byteLength)
+    let storedInfo: any = {
+      upload_id: UPLOAD_ID,
+      last_processed_part_index: null,
+      pending_bytes: null,
+      created_at: new Date(),
+      updated_at: new Date(),
+    }
+
+    jest
+      .spyOn(fileProcessingInfoRepository, 'getFileProcessingInfoByUploadId')
+      .mockImplementation(async () => storedInfo)
+    jest
+      .spyOn(fileProcessingInfoRepository, 'updateFileProcessingInfo')
+      .mockImplementation(async (info: any) => {
+        storedInfo = { ...info }
+        return storedInfo
+      })
+    jest
+      .spyOn(filePartsRepository, 'getUploadFilePartsSize')
+      .mockImplementation(async () => storedBytes)
+
+    const upload = {
+      id: UPLOAD_ID,
+      root_upload_id: UPLOAD_ID,
+      type: UploadType.FILE,
+      name: 'grew.bin',
+      upload_options: null,
+    } as any
+    jest.spyOn(uploadsRepository, 'getUploadEntryById').mockResolvedValue(upload)
+
+    await UploadFileProcessingUseCase.processChunk(UPLOAD_ID, partA, 0)
+    const firstCid =
+      await UploadFileProcessingUseCase.completeUploadProcessing(upload)
+
+    // Part B arrives while the upload is PENDING again after the failed
+    // completion, then the client completes a second time.
+    const partB = Buffer.alloc(DEFAULT_MAX_CHUNK_SIZE, 2)
+    await UploadFileProcessingUseCase.processChunk(UPLOAD_ID, partB, 1)
+    storedBytes += BigInt(partB.byteLength)
+
+    await expect(
+      UploadFileProcessingUseCase.completeUploadProcessing(upload),
+    ).rejects.toThrow(UploadPartsChangedError)
+    // Not a 500, and not retryable: the client has to abort and start again.
+    await expect(
+      UploadFileProcessingUseCase.completeUploadProcessing(upload),
+    ).rejects.toMatchObject({ statusCode: 400 })
+
+    // The truncated CID is never handed back.
+    expect(cidToString(firstCid)).toBeDefined()
+  })
+
+  // The resume itself must keep working: same parts, same root, no error. This is
+  // the advertised "top up your credits and retry" flow.
+  it('still reuses the root node when the stored parts are unchanged', async () => {
+    installFakeBlockstore()
+
+    const part = Buffer.alloc(DEFAULT_MAX_CHUNK_SIZE + 500, 7)
+    let storedInfo: any = {
+      upload_id: UPLOAD_ID,
+      last_processed_part_index: null,
+      pending_bytes: null,
+      created_at: new Date(),
+      updated_at: new Date(),
+    }
+    jest
+      .spyOn(fileProcessingInfoRepository, 'getFileProcessingInfoByUploadId')
+      .mockImplementation(async () => storedInfo)
+    jest
+      .spyOn(fileProcessingInfoRepository, 'updateFileProcessingInfo')
+      .mockImplementation(async (info: any) => {
+        storedInfo = { ...info }
+        return storedInfo
+      })
+    jest
+      .spyOn(filePartsRepository, 'getUploadFilePartsSize')
+      .mockResolvedValue(BigInt(part.byteLength))
+
+    const upload = {
+      id: UPLOAD_ID,
+      root_upload_id: UPLOAD_ID,
+      type: UploadType.FILE,
+      name: 'unchanged.bin',
+      upload_options: null,
+    } as any
+    jest.spyOn(uploadsRepository, 'getUploadEntryById').mockResolvedValue(upload)
+
+    await UploadFileProcessingUseCase.processChunk(UPLOAD_ID, part, 0)
+    const firstCid =
+      await UploadFileProcessingUseCase.completeUploadProcessing(upload)
+    const secondCid =
+      await UploadFileProcessingUseCase.completeUploadProcessing(upload)
+
+    expect(cidToString(secondCid)).toBe(cidToString(firstCid))
   })
 
   // Guards the other half: even if some future path does re-put the root node,

--- a/apps/backend/__tests__/unit/core/completionRetryIdempotency.spec.ts
+++ b/apps/backend/__tests__/unit/core/completionRetryIdempotency.spec.ts
@@ -1,0 +1,278 @@
+import {
+  jest,
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+} from '@jest/globals'
+import { MetadataType, cidToString } from '@autonomys/auto-dag-data'
+import { UploadType } from '@auto-drive/models'
+import { UploadFileProcessingUseCase } from '../../../src/core/uploads/uploadProcessing.js'
+import { createNodeDeduplicator } from '../../../src/core/objects/nodes.js'
+import { blockstoreRepository } from '../../../src/infrastructure/repositories/uploads/blockstore.js'
+import { fileProcessingInfoRepository } from '../../../src/infrastructure/repositories/uploads/fileProcessingInfo.js'
+import { filePartsRepository } from '../../../src/infrastructure/repositories/uploads/fileParts.js'
+import { uploadsRepository } from '../../../src/infrastructure/repositories/uploads/uploads.js'
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const UPLOAD_ID = 'upload-retry-1'
+
+// The root node types are the ones blockstore_root_node_unique_idx covers.
+const ROOT_NODE_TYPES = [MetadataType.File, MetadataType.Folder]
+
+/**
+ * In-memory stand-in for uploads.blockstore that reproduces the SQL semantics
+ * the code depends on: rows ordered by an ascending surrogate key, duplicates
+ * permitted for chunk rows, and ON CONFLICT DO NOTHING against the partial
+ * unique index on the root node types.
+ *
+ * Faking at the repository layer rather than the blockstore layer keeps the real
+ * MultiUploadBlockstore in the test, so the DAG is built by the same code that
+ * builds it in production.
+ */
+const installFakeBlockstore = () => {
+  const rows: Array<{
+    sort_id: number
+    upload_id: string
+    cid: string
+    node_type: MetadataType
+    node_size: bigint
+    data: Buffer
+  }> = []
+  let nextSortId = 1
+
+  jest
+    .spyOn(blockstoreRepository, 'addBlockstoreEntry')
+    .mockImplementation(async (uploadId, cid, nodeType, nodeSize, data) => {
+      const violatesRootUnique =
+        ROOT_NODE_TYPES.includes(nodeType) &&
+        rows.some((r) => r.upload_id === uploadId && r.cid === cid)
+      if (violatesRootUnique) return
+
+      rows.push({
+        sort_id: nextSortId++,
+        upload_id: uploadId,
+        cid,
+        node_type: nodeType,
+        node_size: nodeSize,
+        data,
+      })
+    })
+
+  const byUpload = (uploadId: string) =>
+    rows
+      .filter((r) => r.upload_id === uploadId)
+      .sort((a, b) => a.sort_id - b.sort_id)
+
+  jest
+    .spyOn(blockstoreRepository, 'getByType')
+    .mockImplementation(async (uploadId, nodeType) =>
+      byUpload(uploadId).filter((r) => r.node_type === nodeType).map(
+        (r) => ({ ...r, node_size: r.node_size.toString() }) as any,
+      ),
+    )
+
+  jest
+    .spyOn(blockstoreRepository, 'getByCid')
+    .mockImplementation(
+      async (uploadId, cid) =>
+        (byUpload(uploadId)
+          .filter((r) => r.cid === cid)
+          .map((r) => ({ ...r, node_size: r.node_size.toString() }))
+          .at(0) as any) ?? null,
+    )
+
+  jest
+    .spyOn(blockstoreRepository, 'getByCIDWithoutData')
+    .mockImplementation(
+      async (uploadId, cid) =>
+        (byUpload(uploadId)
+          .filter((r) => r.cid === cid)
+          .map((r) => ({ ...r, node_size: r.node_size.toString() }))
+          .at(0) as any) ?? null,
+    )
+
+  jest
+    .spyOn(blockstoreRepository, 'getBlockstoreEntriesWithoutData')
+    .mockImplementation(
+      async (uploadId) =>
+        byUpload(uploadId).map(
+          (r) => ({ ...r, node_size: r.node_size.toString() }) as any,
+        ),
+    )
+
+  // The DAG builder deletes nodes it has folded into a parent. Mirrors the SQL,
+  // which deletes every row for that (upload_id, cid) — not just one.
+  jest
+    .spyOn(blockstoreRepository, 'deleteBlockstoreEntry')
+    .mockImplementation(async (uploadId, cid) => {
+      for (let i = rows.length - 1; i >= 0; i--) {
+        if (rows[i].upload_id === uploadId && rows[i].cid === cid) {
+          rows.splice(i, 1)
+        }
+      }
+    })
+
+  return {
+    rows,
+    countOf: (nodeType: MetadataType) =>
+      rows.filter((r) => r.node_type === nodeType).length,
+    distinctCidsOf: (nodeType: MetadataType) =>
+      new Set(rows.filter((r) => r.node_type === nodeType).map((r) => r.cid))
+        .size,
+  }
+}
+
+describe('completeUploadProcessing retry idempotency', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  // The claim is released back to PENDING when completion FAILS, and the
+  // documented failure (`Not enough upload credits`) is thrown by
+  // handleFileUploadFinalization strictly AFTER the root node has been written.
+  // So the "top up and retry" flow re-enters here — and used to re-put the tail
+  // chunk that pending_bytes still held, gaining an extra DAG link and deriving a
+  // DIFFERENT root CID. Two distinct root CIDs is the unrecoverable shape:
+  // getRootNodeCID refuses it and every later retry appends another root row.
+  it('derives the same root CID when completion is retried after a failure', async () => {
+    const store = installFakeBlockstore()
+
+    // A tail that never filled a chunk, i.e. pending_bytes is set at completion.
+    const pendingBytes = Buffer.from('the unflushed tail of the last part')
+    let storedInfo: any = {
+      upload_id: UPLOAD_ID,
+      last_processed_part_index: 0,
+      pending_bytes: pendingBytes,
+      created_at: new Date(),
+      updated_at: new Date(),
+    }
+
+    jest
+      .spyOn(fileProcessingInfoRepository, 'getFileProcessingInfoByUploadId')
+      .mockImplementation(async () => storedInfo)
+    const updateInfo = jest
+      .spyOn(fileProcessingInfoRepository, 'updateFileProcessingInfo')
+      .mockImplementation(async (info) => {
+        storedInfo = { ...info }
+        return storedInfo
+      })
+    jest
+      .spyOn(filePartsRepository, 'getUploadFilePartsSize')
+      .mockResolvedValue(BigInt(pendingBytes.byteLength))
+    jest.spyOn(uploadsRepository, 'getUploadEntryById').mockResolvedValue({
+      id: UPLOAD_ID,
+      root_upload_id: UPLOAD_ID,
+      type: UploadType.FILE,
+      name: 'tail.txt',
+      upload_options: null,
+    } as any)
+
+    const upload = { id: UPLOAD_ID, type: UploadType.FILE } as any
+
+    const firstCid = await UploadFileProcessingUseCase.completeUploadProcessing(
+      upload,
+    )
+    // The tail is consumed, so a retry cannot flush it a second time.
+    expect(updateInfo).toHaveBeenCalledWith(
+      expect.objectContaining({ pending_bytes: null }),
+    )
+    expect(storedInfo.pending_bytes).toBeNull()
+
+    // The reason re-derivation cannot be allowed: the chunker consumed the chunk
+    // it folded into the root (get -> delete -> put). There is nothing left to
+    // rebuild the same DAG from, so a second derivation would produce a root over
+    // a different link set — a different CID, which is the unrecoverable shape.
+    expect(store.countOf(MetadataType.FileChunk)).toBe(0)
+
+    // Simulates the retry after `Not enough upload credits`.
+    const secondCid = await UploadFileProcessingUseCase.completeUploadProcessing(
+      upload,
+    )
+
+    expect(cidToString(secondCid)).toBe(cidToString(firstCid))
+    // Exactly one root row, and one root CID — the shape getRootNodeCID accepts.
+    expect(store.countOf(MetadataType.File)).toBe(1)
+    expect(store.distinctCidsOf(MetadataType.File)).toBe(1)
+  })
+
+  // Guards the other half: even if some future path does re-put the root node,
+  // the ON CONFLICT DO NOTHING keeps it a single row rather than a duplicate.
+  it('absorbs a repeated root node write instead of duplicating the row', async () => {
+    const store = installFakeBlockstore()
+
+    await blockstoreRepository.addBlockstoreEntry(
+      UPLOAD_ID,
+      'bafkr6icio4rqi75syx2xkxwmnnnwx3gzmnbjmtnqoydtfcxrjuqvvxxs4u',
+      MetadataType.File,
+      BigInt(10),
+      Buffer.from('root'),
+    )
+    await blockstoreRepository.addBlockstoreEntry(
+      UPLOAD_ID,
+      'bafkr6icio4rqi75syx2xkxwmnnnwx3gzmnbjmtnqoydtfcxrjuqvvxxs4u',
+      MetadataType.File,
+      BigInt(10),
+      Buffer.from('root'),
+    )
+
+    expect(store.countOf(MetadataType.File)).toBe(1)
+  })
+
+  // Chunks are deliberately NOT covered by the unique index: a file containing
+  // two identical chunks legitimately stores two rows with the same CID, and the
+  // DAG builder iterates every chunk row to build its links.
+  it('still stores two identical chunk rows', async () => {
+    const store = installFakeBlockstore()
+
+    for (let i = 0; i < 2; i++) {
+      await blockstoreRepository.addBlockstoreEntry(
+        UPLOAD_ID,
+        'bafkr6ie5s3iyyqjmnwqzuz5rzsnfhpvgvbrhfpwbcnbnqvbcqchbmqvxqm',
+        MetadataType.FileChunk,
+        BigInt(5),
+        Buffer.from('chunk'),
+      )
+    }
+
+    expect(store.countOf(MetadataType.FileChunk)).toBe(2)
+  })
+})
+
+describe('createNodeDeduplicator', () => {
+  const node = (cid: string) => ({ cid: cid as any })
+
+  // The bug this replaces: uniqueNodes was built per batch, so a duplicate more
+  // than BATCH_SIZE rows away from its original survived into nodes, where
+  // nodes.cid has no unique constraint and getCidsByRootCid has no DISTINCT.
+  it('drops a duplicate that arrives in a later batch', () => {
+    const takeUnseen = createNodeDeduplicator(UPLOAD_ID)
+    const firstBatch = Array.from({ length: 100 }, (_, i) => node(`cid-${i}`))
+
+    expect(takeUnseen(firstBatch)).toHaveLength(100)
+    // The duplicate of cid-0 lands 100 rows later, in the next batch.
+    expect(takeUnseen([node('cid-0')])).toHaveLength(0)
+    expect(takeUnseen([node('cid-100')])).toHaveLength(1)
+  })
+
+  it('still drops a duplicate within a single batch', () => {
+    const takeUnseen = createNodeDeduplicator(UPLOAD_ID)
+
+    expect(takeUnseen([node('a'), node('a'), node('b')])).toHaveLength(2)
+  })
+
+  it('keeps deduplication scoped to one upload', () => {
+    const first = createNodeDeduplicator('upload-a')
+    const second = createNodeDeduplicator('upload-b')
+
+    expect(first([node('shared')])).toHaveLength(1)
+    // A node shared between two objects must still be written for each.
+    expect(second([node('shared')])).toHaveLength(1)
+  })
+})

--- a/apps/backend/__tests__/unit/core/completionRetryIdempotency.spec.ts
+++ b/apps/backend/__tests__/unit/core/completionRetryIdempotency.spec.ts
@@ -6,14 +6,24 @@ import {
   beforeEach,
   afterEach,
 } from '@jest/globals'
-import { MetadataType, cidToString } from '@autonomys/auto-dag-data'
+import {
+  DEFAULT_MAX_CHUNK_SIZE,
+  MetadataType,
+  cidToString,
+} from '@autonomys/auto-dag-data'
 import { UploadType } from '@auto-drive/models'
+import { ok } from 'neverthrow'
 import { UploadFileProcessingUseCase } from '../../../src/core/uploads/uploadProcessing.js'
-import { createNodeDeduplicator } from '../../../src/core/objects/nodes.js'
+import {
+  NodesUseCases,
+  createNodeDeduplicator,
+} from '../../../src/core/objects/nodes.js'
+import { ObjectUseCases } from '../../../src/core/objects/object.js'
 import { blockstoreRepository } from '../../../src/infrastructure/repositories/uploads/blockstore.js'
 import { fileProcessingInfoRepository } from '../../../src/infrastructure/repositories/uploads/fileProcessingInfo.js'
 import { filePartsRepository } from '../../../src/infrastructure/repositories/uploads/fileParts.js'
 import { uploadsRepository } from '../../../src/infrastructure/repositories/uploads/uploads.js'
+import { nodesRepository } from '../../../src/infrastructure/repositories/objects/nodes.js'
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -274,5 +284,103 @@ describe('createNodeDeduplicator', () => {
     expect(first([node('shared')])).toHaveLength(1)
     // A node shared between two objects must still be written for each.
     expect(second([node('shared')])).toHaveLength(1)
+  })
+})
+
+// The deduplicator's unit tests above exercise the filter in isolation, where an
+// empty result is harmless. It is not harmless at the call site: saveNodes([])
+// renders `INSERT INTO nodes (...) VALUES ` and Postgres answers `syntax error at
+// end of input`. So this drives the real migration over a real upload, which is
+// also the only way to show the case is reachable without any broken rows.
+describe('migrateFromBlockstoreToNodesTable over repeated content', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('writes one row per distinct node and never an empty insert', async () => {
+    const store = installFakeBlockstore()
+
+    let info: any = {
+      upload_id: UPLOAD_ID,
+      last_processed_part_index: null,
+      pending_bytes: null,
+      created_at: new Date(),
+      updated_at: new Date(),
+    }
+    jest
+      .spyOn(fileProcessingInfoRepository, 'getFileProcessingInfoByUploadId')
+      .mockImplementation(async () => info)
+    jest
+      .spyOn(fileProcessingInfoRepository, 'updateFileProcessingInfo')
+      .mockImplementation(async (next: any) => {
+        info = { ...next }
+        return info
+      })
+
+    let uploadedBytes = BigInt(0)
+    jest
+      .spyOn(filePartsRepository, 'getUploadFilePartsSize')
+      .mockImplementation(async () => uploadedBytes)
+
+    const uploadEntry = {
+      id: UPLOAD_ID,
+      root_upload_id: UPLOAD_ID,
+      type: UploadType.FILE,
+      name: 'zeros.bin',
+      upload_options: null,
+    } as any
+    jest
+      .spyOn(uploadsRepository, 'getUploadEntryById')
+      .mockResolvedValue(uploadEntry)
+    jest
+      .spyOn(uploadsRepository, 'getUploadsByRoot')
+      .mockResolvedValue([uploadEntry])
+    jest
+      .spyOn(ObjectUseCases, 'getMetadata')
+      .mockResolvedValue(ok({ type: 'file' } as any))
+    jest
+      .spyOn(nodesRepository, 'removeNodeByRootCid')
+      .mockResolvedValue(undefined as any)
+
+    // 14 MB of zeros, streamed part by part through the real chunker exactly as
+    // uploadChunk's drain loop does. Every full chunk is byte-identical, so one
+    // CID covers 225 of the 226 chunk rows — and getAllKeys yields one key per
+    // ROW. The second batch of 100 is therefore entirely already-seen, which is
+    // what the per-batch Map could never produce. Roughly 200 identical
+    // consecutive chunks (about 13 MB at DEFAULT_MAX_CHUNK_SIZE=65066) is the
+    // threshold; sparse files, zero-padded disk images and padded archives all
+    // clear it.
+    const PART_SIZE = 1024 * 1024
+    const PARTS = 14
+    expect(PARTS * PART_SIZE).toBeGreaterThan(200 * DEFAULT_MAX_CHUNK_SIZE)
+    for (let i = 0; i < PARTS; i++) {
+      await UploadFileProcessingUseCase.processChunk(
+        UPLOAD_ID,
+        Buffer.alloc(PART_SIZE, 0),
+        i,
+      )
+      uploadedBytes += BigInt(PART_SIZE)
+    }
+    await UploadFileProcessingUseCase.completeUploadProcessing(uploadEntry)
+
+    const distinctCids = new Set(store.rows.map((r) => r.cid))
+    expect(store.rows.length).toBeGreaterThan(200)
+    expect(distinctCids.size).toBeLessThan(store.rows.length)
+
+    const insertedBatches: unknown[][] = []
+    jest
+      .spyOn(nodesRepository, 'saveNodes')
+      .mockImplementation(async (nodes) => {
+        insertedBatches.push(nodes)
+        return undefined
+      })
+
+    await NodesUseCases.migrateFromBlockstoreToNodesTable(UPLOAD_ID)
+
+    // The regression: one of these batches was empty, and the insert built from
+    // it was not valid SQL.
+    expect(insertedBatches.every((batch) => batch.length > 0)).toBe(true)
+    // Each distinct node written exactly once, across every batch.
+    expect(insertedBatches.flat()).toHaveLength(distinctCids.size)
   })
 })

--- a/apps/backend/__tests__/unit/core/uploadCompletionIdempotency.spec.ts
+++ b/apps/backend/__tests__/unit/core/uploadCompletionIdempotency.spec.ts
@@ -97,7 +97,10 @@ describe('UploadsUseCases.completeUpload idempotency', () => {
   it('refuses to process when another call holds the completion claim', async () => {
     jest
       .spyOn(uploadsRepository, 'getUploadEntryById')
-      .mockResolvedValue({ ...upload, status: UploadStatus.PENDING })
+      // First read races the winner; the re-read after losing the claim shows the
+      // winner still working.
+      .mockResolvedValueOnce({ ...upload, status: UploadStatus.PENDING })
+      .mockResolvedValue({ ...upload, status: UploadStatus.COMPLETING })
     const claim = jest
       .spyOn(uploadsRepository, 'claimUploadForCompletion')
       .mockResolvedValue(false)
@@ -113,6 +116,47 @@ describe('UploadsUseCases.completeUpload idempotency', () => {
       config.uploads.completionClaimStaleMs,
     )
     expect(processing).not.toHaveBeenCalled()
+  })
+
+  // Losing the claim is not proof that a completion is still running: the winner
+  // can finish everything between our status read and the compare-and-swap. That
+  // retry has to get its CID, not a spurious failure.
+  it('returns the CID when the claim is lost to a winner that already finished', async () => {
+    jest
+      .spyOn(uploadsRepository, 'getUploadEntryById')
+      .mockResolvedValueOnce({ ...upload, status: UploadStatus.PENDING })
+      .mockResolvedValue({ ...upload, status: UploadStatus.MIGRATING })
+    jest
+      .spyOn(uploadsRepository, 'claimUploadForCompletion')
+      .mockResolvedValue(false)
+    jest.spyOn(BlockstoreUseCases, 'getUploadCID').mockResolvedValue(CID as any)
+    const processing = jest
+      .spyOn(UploadFileProcessingUseCase, 'completeUploadProcessing')
+      .mockResolvedValue(CID as any)
+    const publish = jest.spyOn(EventRouter, 'publish').mockReturnValue()
+
+    const result = await UploadsUseCases.completeUpload(mockUser, upload.id)
+
+    expect(result).toBe(CID)
+    expect(processing).not.toHaveBeenCalled()
+    // Still re-drives migration, exactly like the plain already-completed path.
+    expect(publish).toHaveBeenCalledTimes(1)
+    const [tasks] = publish.mock.calls[0] as any
+    expect(tasks[0].id).toBe('migrate-upload-nodes')
+  })
+
+  it('reports a not-found upload when the claim is lost and the row is gone', async () => {
+    jest
+      .spyOn(uploadsRepository, 'getUploadEntryById')
+      .mockResolvedValueOnce({ ...upload, status: UploadStatus.PENDING })
+      .mockResolvedValue(null)
+    jest
+      .spyOn(uploadsRepository, 'claimUploadForCompletion')
+      .mockResolvedValue(false)
+
+    await expect(
+      UploadsUseCases.completeUpload(mockUser, upload.id),
+    ).rejects.toThrow(/Upload not found/)
   })
 
   it('claims the upload before processing and only then flips it to MIGRATING', async () => {

--- a/apps/backend/__tests__/unit/core/uploadCompletionIdempotency.spec.ts
+++ b/apps/backend/__tests__/unit/core/uploadCompletionIdempotency.spec.ts
@@ -22,6 +22,7 @@ import {
   UploadType,
   UserWithOrganization,
 } from '@auto-drive/models'
+import { BadRequestError } from '../../../src/errors/index.js'
 import { MetadataType } from '@autonomys/auto-dag-data'
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -86,6 +87,12 @@ describe('UploadsUseCases.completeUpload idempotency', () => {
       .spyOn(UploadFileProcessingUseCase, 'completeUploadProcessing')
       .mockResolvedValue(CID as any)
 
+    // An HttpError, not a bare Error: the caller's fault, not ours. Both flatten
+    // to a 500 through handleInternalError today, but the type is what makes this
+    // a 4xx for free once that is fixed.
+    await expect(
+      UploadsUseCases.completeUpload(mockUser, upload.id),
+    ).rejects.toBeInstanceOf(BadRequestError)
     await expect(
       UploadsUseCases.completeUpload(mockUser, upload.id),
     ).rejects.toThrow(/is failed/)
@@ -139,10 +146,11 @@ describe('UploadsUseCases.completeUpload idempotency', () => {
 
     expect(result).toBe(CID)
     expect(processing).not.toHaveBeenCalled()
-    // Still re-drives migration, exactly like the plain already-completed path.
-    expect(publish).toHaveBeenCalledTimes(1)
-    const [tasks] = publish.mock.calls[0] as any
-    expect(tasks[0].id).toBe('migrate-upload-nodes')
+    // No re-drive on this path, unlike the plain already-completed one: the
+    // winner reached MIGRATING while this call was in flight, so it has just
+    // enqueued the migrate task itself and a re-drive would be a guaranteed
+    // duplicate on every concurrent retry.
+    expect(publish).not.toHaveBeenCalled()
   })
 
   it('reports a not-found upload when the claim is lost and the row is gone', async () => {
@@ -276,6 +284,64 @@ describe('UploadsUseCases.completeUpload idempotency', () => {
       `status:${UploadStatus.MIGRATING}`,
     ])
     expect(release).not.toHaveBeenCalled()
+  })
+
+  // The snapshot read before the compare-and-swap can be stale by the time the
+  // claim is won, and finalizeCompletedUpload writes the whole row back — so a
+  // stale snapshot would revert whatever a concurrent writer had changed.
+  it('processes the row as it stands after the claim, not the pre-claim snapshot', async () => {
+    jest
+      .spyOn(uploadsRepository, 'getUploadEntryById')
+      // Pre-claim snapshot, then the row as it stands once the claim is held.
+      .mockResolvedValueOnce({
+        ...upload,
+        status: UploadStatus.PENDING,
+        mime_type: 'application/octet-stream',
+      })
+      .mockResolvedValue({
+        ...upload,
+        status: UploadStatus.COMPLETING,
+        mime_type: 'text/plain',
+      })
+    jest
+      .spyOn(uploadsRepository, 'claimUploadForCompletion')
+      .mockResolvedValue(true)
+    const processing = jest
+      .spyOn(UploadFileProcessingUseCase, 'completeUploadProcessing')
+      .mockResolvedValue(CID as any)
+    jest
+      .spyOn(UploadFileProcessingUseCase, 'handleFileUploadFinalization')
+      .mockResolvedValue(CID)
+    const updateEntry = jest
+      .spyOn(uploadsRepository, 'updateUploadEntry')
+      .mockImplementation(async (entry) => entry)
+    jest.spyOn(EventRouter, 'publish').mockReturnValue()
+    jest
+      .spyOn(fileProcessingInfoRepository, 'getFileProcessingInfoByUploadId')
+      .mockResolvedValue({
+        upload_id: upload.id,
+        last_processed_part_index: 0,
+      } as any)
+    jest
+      .spyOn(filePartsRepository, 'getChunkByUploadIdAndPartIndex')
+      .mockResolvedValue(null as any)
+    jest
+      .spyOn(filePartsRepository, 'getPartIndicesGreaterThan')
+      .mockResolvedValue([])
+
+    await UploadsUseCases.completeUpload(mockUser, upload.id)
+
+    expect(processing).toHaveBeenCalledWith(
+      expect.objectContaining({ mime_type: 'text/plain' }),
+    )
+    // The flip to MIGRATING carries the fresh row forward rather than writing the
+    // pre-claim snapshot's fields back over it.
+    expect(updateEntry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mime_type: 'text/plain',
+        status: UploadStatus.MIGRATING,
+      }),
+    )
   })
 
   // A failed completion must hand the upload back: COMPLETING is not swept by

--- a/apps/backend/__tests__/unit/core/uploadCompletionIdempotency.spec.ts
+++ b/apps/backend/__tests__/unit/core/uploadCompletionIdempotency.spec.ts
@@ -1,0 +1,189 @@
+import {
+  jest,
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+} from '@jest/globals'
+import { UploadsUseCases } from '../../../src/core/uploads/uploads.js'
+import { BlockstoreUseCases } from '../../../src/core/uploads/blockstore.js'
+import { UploadFileProcessingUseCase } from '../../../src/core/uploads/uploadProcessing.js'
+import { UnrecoverableUploadError } from '../../../src/core/uploads/errors.js'
+import { uploadsRepository } from '../../../src/infrastructure/repositories/uploads/uploads.js'
+import { blockstoreRepository } from '../../../src/infrastructure/repositories/uploads/blockstore.js'
+import { EventRouter } from '../../../src/infrastructure/eventRouter/index.js'
+import { NodesUseCases } from '../../../src/core/objects/nodes.js'
+import {
+  UploadStatus,
+  UploadType,
+  UserWithOrganization,
+} from '@auto-drive/models'
+import { MetadataType } from '@autonomys/auto-dag-data'
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const CID = 'bafkr6icio4rqi75syx2xkxwmnnnwx3gzmnbjmtnqoydtfcxrjuqvvxxs4u'
+
+const mockUser: UserWithOrganization = {
+  oauthProvider: 'google',
+  oauthUserId: 'user1',
+} as any
+
+const upload = {
+  id: 'upload123',
+  root_upload_id: 'upload123',
+  type: UploadType.FILE,
+  status: UploadStatus.MIGRATING,
+  oauth_provider: 'google',
+  oauth_user_id: 'user1',
+} as any
+
+const entry = (cid: string) =>
+  ({ upload_id: upload.id, cid, node_type: MetadataType.File }) as any
+
+describe('UploadsUseCases.completeUpload idempotency', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  // The bug that filled frontend-errors: a retried complete call re-ran the
+  // completion processing, which re-INSERTed the root node into
+  // uploads.blockstore and left the upload permanently unmigratable.
+  it('does not re-run completion processing for an already-completed upload', async () => {
+    jest
+      .spyOn(uploadsRepository, 'getUploadEntryById')
+      .mockResolvedValue(upload)
+    jest.spyOn(BlockstoreUseCases, 'getUploadCID').mockResolvedValue(CID as any)
+    const processing = jest
+      .spyOn(UploadFileProcessingUseCase, 'completeUploadProcessing')
+      .mockResolvedValue(CID as any)
+    const publish = jest.spyOn(EventRouter, 'publish').mockReturnValue()
+
+    const result = await UploadsUseCases.completeUpload(mockUser, upload.id)
+
+    expect(processing).not.toHaveBeenCalled()
+    expect(result).toBe(CID)
+    // The repeat call re-drives migration, so a lost one-shot migrate task heals.
+    expect(publish).toHaveBeenCalledTimes(1)
+    const [tasks] = publish.mock.calls[0] as any
+    expect(tasks[0].id).toBe('migrate-upload-nodes')
+    expect(tasks[0].params.uploadId).toBe(upload.id)
+  })
+
+  it('refuses to complete an upload in a terminal state', async () => {
+    jest
+      .spyOn(uploadsRepository, 'getUploadEntryById')
+      .mockResolvedValue({ ...upload, status: UploadStatus.FAILED })
+    const processing = jest
+      .spyOn(UploadFileProcessingUseCase, 'completeUploadProcessing')
+      .mockResolvedValue(CID as any)
+
+    await expect(
+      UploadsUseCases.completeUpload(mockUser, upload.id),
+    ).rejects.toThrow(/is failed/)
+    expect(processing).not.toHaveBeenCalled()
+  })
+})
+
+describe('BlockstoreUseCases root CID resolution', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  // Production rows written before the completeUpload guard: byte-identical
+  // duplicates of the same root node. Their data is intact, so they must migrate.
+  it('accepts duplicate root rows that all carry the same CID', async () => {
+    jest
+      .spyOn(blockstoreRepository, 'getByType')
+      .mockResolvedValue([entry(CID), entry(CID), entry(CID)])
+
+    const cid = await BlockstoreUseCases.getFileUploadIdCID(upload.id)
+
+    expect(cid.toString()).toBe(CID)
+  })
+
+  it('rejects genuinely ambiguous root rows as unrecoverable', async () => {
+    jest
+      .spyOn(blockstoreRepository, 'getByType')
+      .mockResolvedValue([
+        entry(CID),
+        entry('bafkr6ie5s3iyyqjmnwqzuz5rzsnfhpvgvbrhfpwbcnbnqvbcqchbmqvxqm'),
+      ])
+
+    await expect(
+      BlockstoreUseCases.getFileUploadIdCID(upload.id),
+    ).rejects.toBeInstanceOf(UnrecoverableUploadError)
+  })
+
+  it('rejects a missing root row as unrecoverable', async () => {
+    jest.spyOn(blockstoreRepository, 'getByType').mockResolvedValue([])
+
+    await expect(
+      BlockstoreUseCases.getFileUploadIdCID(upload.id),
+    ).rejects.toBeInstanceOf(UnrecoverableUploadError)
+  })
+})
+
+describe('UploadsUseCases.processMigration unrecoverable handling', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  // Without this the task burns its retries, dead-letters into the unconsumed
+  // frontend-errors queue, stays MIGRATING, and is re-driven by the recovery
+  // sweep every staleness window — growing the queue without bound.
+  it('parks the upload as failed and acks instead of retrying forever', async () => {
+    jest
+      .spyOn(uploadsRepository, 'getUploadEntryById')
+      .mockResolvedValue(upload)
+    jest
+      .spyOn(BlockstoreUseCases, 'getUploadCID')
+      .mockRejectedValue(
+        new UnrecoverableUploadError('no root node', upload.id),
+      )
+    const migrate = jest
+      .spyOn(NodesUseCases, 'migrateFromBlockstoreToNodesTable')
+      .mockResolvedValue(undefined)
+    const setStatus = jest
+      .spyOn(uploadsRepository, 'updateUploadStatusByRootUploadId')
+      .mockResolvedValue(undefined)
+
+    await expect(
+      UploadsUseCases.processMigration(upload.id),
+    ).resolves.toBeUndefined()
+
+    expect(setStatus).toHaveBeenCalledWith(upload.id, UploadStatus.FAILED)
+    expect(migrate).not.toHaveBeenCalled()
+  })
+
+  // A transient failure must still retry — only permanent shapes are parked.
+  it('rethrows a transient failure so the task retries', async () => {
+    jest
+      .spyOn(uploadsRepository, 'getUploadEntryById')
+      .mockResolvedValue(upload)
+    jest
+      .spyOn(BlockstoreUseCases, 'getUploadCID')
+      .mockRejectedValue(new Error('connection terminated unexpectedly'))
+    const setStatus = jest
+      .spyOn(uploadsRepository, 'updateUploadStatusByRootUploadId')
+      .mockResolvedValue(undefined)
+
+    await expect(UploadsUseCases.processMigration(upload.id)).rejects.toThrow(
+      /connection terminated/,
+    )
+    expect(setStatus).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/__tests__/unit/core/uploadCompletionIdempotency.spec.ts
+++ b/apps/backend/__tests__/unit/core/uploadCompletionIdempotency.spec.ts
@@ -37,12 +37,13 @@ const mockUser: UserWithOrganization = {
   oauthUserId: 'user1',
 } as any
 
-// updated_at is deliberately old: a migration re-drive is rate-limited by the
-// recovery sweep's staleness window, so the default fixture is one the sweep
-// would already be re-driving.
-const staleUpdatedAt = new Date(
-  Date.now() - config.migrationRecovery.stalenessMs - 1_000,
-)
+// The default fixture is an upload the recovery sweep would already be
+// re-driving: a re-drive is rate-limited by the sweep's staleness window.
+//
+// Stubbed through getUploadAgeMs rather than by backdating updated_at, because
+// that is where the age comes from — Postgres computes it, so that the answer
+// does not depend on the process and the database agreeing about time zones.
+const staleAgeMs = config.migrationRecovery.stalenessMs + 1_000
 
 const upload = {
   id: 'upload123',
@@ -51,8 +52,11 @@ const upload = {
   status: UploadStatus.MIGRATING,
   oauth_provider: 'google',
   oauth_user_id: 'user1',
-  updated_at: staleUpdatedAt,
+  updated_at: new Date(),
 } as any
+
+const stubUploadAgeMs = (ageMs: number) =>
+  jest.spyOn(uploadsRepository, 'getUploadAgeMs').mockResolvedValue(ageMs)
 
 const entry = (cid: string) =>
   ({ upload_id: upload.id, cid, node_type: MetadataType.File }) as any
@@ -73,6 +77,7 @@ describe('UploadsUseCases.completeUpload idempotency', () => {
     jest
       .spyOn(uploadsRepository, 'getUploadEntryById')
       .mockResolvedValue(upload)
+    stubUploadAgeMs(staleAgeMs)
     jest.spyOn(BlockstoreUseCases, 'getUploadCID').mockResolvedValue(CID as any)
     const processing = jest
       .spyOn(UploadFileProcessingUseCase, 'completeUploadProcessing')
@@ -142,10 +147,10 @@ describe('UploadsUseCases.completeUpload idempotency', () => {
   // rate-limited to the recovery sweep's window; a client retrying in a loop must
   // not multiply that against a large object.
   it('does not re-drive migration for an upload that just started migrating', async () => {
-    jest.spyOn(uploadsRepository, 'getUploadEntryById').mockResolvedValue({
-      ...upload,
-      updated_at: new Date(),
-    })
+    jest
+      .spyOn(uploadsRepository, 'getUploadEntryById')
+      .mockResolvedValue(upload)
+    stubUploadAgeMs(1_000)
     jest.spyOn(BlockstoreUseCases, 'getUploadCID').mockResolvedValue(CID as any)
     const publish = jest.spyOn(EventRouter, 'publish').mockReturnValue()
 
@@ -428,8 +433,8 @@ describe('UploadsUseCases.abortUpload with a completion claim', () => {
     jest.spyOn(uploadsRepository, 'getUploadEntryById').mockResolvedValue({
       ...upload,
       status: UploadStatus.COMPLETING,
-      updated_at: new Date(),
     })
+    stubUploadAgeMs(1_000)
     const remove = jest
       .spyOn(uploadsRepository, 'deleteEntriesByRootUploadId')
       .mockResolvedValue(undefined)
@@ -448,10 +453,8 @@ describe('UploadsUseCases.abortUpload with a completion claim', () => {
     jest.spyOn(uploadsRepository, 'getUploadEntryById').mockResolvedValue({
       ...upload,
       status: UploadStatus.COMPLETING,
-      updated_at: new Date(
-        Date.now() - config.uploads.completionClaimStaleMs - 1_000,
-      ),
     })
+    stubUploadAgeMs(config.uploads.completionClaimStaleMs + 1_000)
     jest
       .spyOn(uploadsRepository, 'deleteEntriesByRootUploadId')
       .mockResolvedValue(undefined)
@@ -468,6 +471,32 @@ describe('UploadsUseCases.abortUpload with a completion claim', () => {
     const result = await UploadsUseCases.abortUpload(mockUser, upload.id)
 
     expect(result.isOk()).toBe(true)
+  })
+
+  // The decision must come from the age Postgres computes, not from parsing
+  // updated_at. That column is `timestamp` with no zone, so node-postgres reads it
+  // in the process's zone: a process an hour ahead of the database saw every claim
+  // as an hour older than it was, and a claim taken seconds ago read as stale —
+  // which is exactly how this used to tear down a LIVE completion, the one thing
+  // the stale-claim exception promises not to do.
+  it('ignores a misleading updated_at and trusts the age from Postgres', async () => {
+    jest.spyOn(uploadsRepository, 'getUploadEntryById').mockResolvedValue({
+      ...upload,
+      status: UploadStatus.COMPLETING,
+      // What a +1h zone skew makes a seconds-old claim look like in JS.
+      updated_at: new Date(
+        Date.now() - config.uploads.completionClaimStaleMs - 1_000,
+      ),
+    })
+    stubUploadAgeMs(2_000)
+    const remove = jest
+      .spyOn(uploadsRepository, 'deleteEntriesByRootUploadId')
+      .mockResolvedValue(undefined)
+
+    const result = await UploadsUseCases.abortUpload(mockUser, upload.id)
+
+    expect(result.isErr()).toBe(true)
+    expect(remove).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/backend/__tests__/unit/core/uploadCompletionIdempotency.spec.ts
+++ b/apps/backend/__tests__/unit/core/uploadCompletionIdempotency.spec.ts
@@ -23,6 +23,7 @@ import {
   UserWithOrganization,
 } from '@auto-drive/models'
 import { BadRequestError } from '../../../src/errors/index.js'
+import { UploadCompletionInProgressError } from '../../../src/core/uploads/errors.js'
 import { MetadataType } from '@autonomys/auto-dag-data'
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -34,6 +35,13 @@ const mockUser: UserWithOrganization = {
   oauthUserId: 'user1',
 } as any
 
+// updated_at is deliberately old: a migration re-drive is rate-limited by the
+// recovery sweep's staleness window, so the default fixture is one the sweep
+// would already be re-driving.
+const staleUpdatedAt = new Date(
+  Date.now() - config.migrationRecovery.stalenessMs - 1_000,
+)
+
 const upload = {
   id: 'upload123',
   root_upload_id: 'upload123',
@@ -41,6 +49,7 @@ const upload = {
   status: UploadStatus.MIGRATING,
   oauth_provider: 'google',
   oauth_user_id: 'user1',
+  updated_at: staleUpdatedAt,
 } as any
 
 const entry = (cid: string) =>
@@ -115,14 +124,33 @@ describe('UploadsUseCases.completeUpload idempotency', () => {
       .spyOn(UploadFileProcessingUseCase, 'completeUploadProcessing')
       .mockResolvedValue(CID as any)
 
+    // A dedicated type, not a generic bad request: the S3 route maps it to a
+    // retryable 503 SlowDown, which is unreachable if the failure is opaque.
     await expect(
       UploadsUseCases.completeUpload(mockUser, upload.id),
-    ).rejects.toThrow(/already being completed/)
+    ).rejects.toBeInstanceOf(UploadCompletionInProgressError)
     expect(claim).toHaveBeenCalledWith(
       upload.id,
       config.uploads.completionClaimStaleMs,
     )
     expect(processing).not.toHaveBeenCalled()
+  })
+
+  // A re-drive is a removeNodeByRootCid plus a full node re-insert, so it is
+  // rate-limited to the recovery sweep's window; a client retrying in a loop must
+  // not multiply that against a large object.
+  it('does not re-drive migration for an upload that just started migrating', async () => {
+    jest.spyOn(uploadsRepository, 'getUploadEntryById').mockResolvedValue({
+      ...upload,
+      updated_at: new Date(),
+    })
+    jest.spyOn(BlockstoreUseCases, 'getUploadCID').mockResolvedValue(CID as any)
+    const publish = jest.spyOn(EventRouter, 'publish').mockReturnValue()
+
+    const result = await UploadsUseCases.completeUpload(mockUser, upload.id)
+
+    expect(result).toBe(CID)
+    expect(publish).not.toHaveBeenCalled()
   })
 
   // Losing the claim is not proof that a completion is still running: the winner
@@ -380,6 +408,64 @@ describe('UploadsUseCases.completeUpload idempotency', () => {
     ).rejects.toThrow(/Not enough upload credits/)
     expect(release).toHaveBeenCalledWith(upload.id)
     expect(updateEntry).not.toHaveBeenCalled()
+  })
+})
+
+describe('UploadsUseCases.abortUpload with a completion claim', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  // A live completion is working, not stranded. Tearing its rows out from under a
+  // running DAG build would be worse than making the client wait.
+  it('refuses to abort an upload whose completion is still running', async () => {
+    jest.spyOn(uploadsRepository, 'getUploadEntryById').mockResolvedValue({
+      ...upload,
+      status: UploadStatus.COMPLETING,
+      updated_at: new Date(),
+    })
+    const remove = jest
+      .spyOn(uploadsRepository, 'deleteEntriesByRootUploadId')
+      .mockResolvedValue(undefined)
+
+    const result = await UploadsUseCases.abortUpload(mockUser, upload.id)
+
+    expect(result.isErr()).toBe(true)
+    expect(remove).not.toHaveBeenCalled()
+  })
+
+  // Once the claim is stale the process that held it is gone. Without this the
+  // new COMPLETING state would make a stranded upload un-abortable for a full
+  // hour — S3 AbortMultipartUpload answering NoSuchUpload the whole time — where
+  // the equivalent stranded PENDING row can be aborted at once.
+  it('aborts an upload whose completion claim has gone stale', async () => {
+    jest.spyOn(uploadsRepository, 'getUploadEntryById').mockResolvedValue({
+      ...upload,
+      status: UploadStatus.COMPLETING,
+      updated_at: new Date(
+        Date.now() - config.uploads.completionClaimStaleMs - 1_000,
+      ),
+    })
+    jest
+      .spyOn(uploadsRepository, 'deleteEntriesByRootUploadId')
+      .mockResolvedValue(undefined)
+    jest
+      .spyOn(blockstoreRepository, 'deleteBlockstoreEntries')
+      .mockResolvedValue(undefined)
+    jest
+      .spyOn(filePartsRepository, 'deleteChunksByUploadId')
+      .mockResolvedValue(undefined)
+    jest
+      .spyOn(fileProcessingInfoRepository, 'deleteFileProcessingInfo')
+      .mockResolvedValue(undefined)
+
+    const result = await UploadsUseCases.abortUpload(mockUser, upload.id)
+
+    expect(result.isOk()).toBe(true)
   })
 })
 

--- a/apps/backend/__tests__/unit/core/uploadCompletionIdempotency.spec.ts
+++ b/apps/backend/__tests__/unit/core/uploadCompletionIdempotency.spec.ts
@@ -12,6 +12,9 @@ import { UploadFileProcessingUseCase } from '../../../src/core/uploads/uploadPro
 import { UnrecoverableUploadError } from '../../../src/core/uploads/errors.js'
 import { uploadsRepository } from '../../../src/infrastructure/repositories/uploads/uploads.js'
 import { blockstoreRepository } from '../../../src/infrastructure/repositories/uploads/blockstore.js'
+import { fileProcessingInfoRepository } from '../../../src/infrastructure/repositories/uploads/fileProcessingInfo.js'
+import { filePartsRepository } from '../../../src/infrastructure/repositories/uploads/fileParts.js'
+import { config } from '../../../src/config.js'
 import { EventRouter } from '../../../src/infrastructure/eventRouter/index.js'
 import { NodesUseCases } from '../../../src/core/objects/nodes.js'
 import {
@@ -87,6 +90,124 @@ describe('UploadsUseCases.completeUpload idempotency', () => {
       UploadsUseCases.completeUpload(mockUser, upload.id),
     ).rejects.toThrow(/is failed/)
     expect(processing).not.toHaveBeenCalled()
+  })
+
+  // The status read is not a guard by itself: two overlapping calls both observe
+  // PENDING. Only the caller that wins the atomic claim may process the upload.
+  it('refuses to process when another call holds the completion claim', async () => {
+    jest
+      .spyOn(uploadsRepository, 'getUploadEntryById')
+      .mockResolvedValue({ ...upload, status: UploadStatus.PENDING })
+    const claim = jest
+      .spyOn(uploadsRepository, 'claimUploadForCompletion')
+      .mockResolvedValue(false)
+    const processing = jest
+      .spyOn(UploadFileProcessingUseCase, 'completeUploadProcessing')
+      .mockResolvedValue(CID as any)
+
+    await expect(
+      UploadsUseCases.completeUpload(mockUser, upload.id),
+    ).rejects.toThrow(/already being completed/)
+    expect(claim).toHaveBeenCalledWith(
+      upload.id,
+      config.uploads.completionClaimStaleMs,
+    )
+    expect(processing).not.toHaveBeenCalled()
+  })
+
+  it('claims the upload before processing and only then flips it to MIGRATING', async () => {
+    jest
+      .spyOn(uploadsRepository, 'getUploadEntryById')
+      .mockResolvedValue({ ...upload, status: UploadStatus.PENDING })
+    const order: string[] = []
+    jest
+      .spyOn(uploadsRepository, 'claimUploadForCompletion')
+      .mockImplementation(async () => {
+        order.push('claim')
+        return true
+      })
+    jest
+      .spyOn(UploadFileProcessingUseCase, 'completeUploadProcessing')
+      .mockImplementation(async () => {
+        order.push('processing')
+        return CID as any
+      })
+    jest
+      .spyOn(UploadFileProcessingUseCase, 'handleFileUploadFinalization')
+      .mockResolvedValue(CID)
+    jest
+      .spyOn(uploadsRepository, 'updateUploadEntry')
+      .mockImplementation(async (entry) => {
+        order.push(`status:${entry.status}`)
+        return entry
+      })
+    jest.spyOn(EventRouter, 'publish').mockReturnValue()
+    const release = jest
+      .spyOn(uploadsRepository, 'releaseUploadCompletionClaim')
+      .mockResolvedValue(undefined)
+    // A FILE upload drains its parts first; both helpers read the same cursor.
+    jest
+      .spyOn(fileProcessingInfoRepository, 'getFileProcessingInfoByUploadId')
+      .mockResolvedValue({
+        upload_id: upload.id,
+        last_processed_part_index: 0,
+      } as any)
+    jest
+      .spyOn(filePartsRepository, 'getChunkByUploadIdAndPartIndex')
+      .mockResolvedValue(null as any)
+    jest
+      .spyOn(filePartsRepository, 'getPartIndicesGreaterThan')
+      .mockResolvedValue([])
+
+    const result = await UploadsUseCases.completeUpload(mockUser, upload.id)
+
+    expect(result).toBe(CID)
+    // MIGRATING is only reached after the root node exists, so the migration
+    // recovery sweep can never select a still-completing upload.
+    expect(order).toEqual([
+      'claim',
+      'processing',
+      `status:${UploadStatus.MIGRATING}`,
+    ])
+    expect(release).not.toHaveBeenCalled()
+  })
+
+  // A failed completion must hand the upload back: COMPLETING is not swept by
+  // migration recovery, so a stranded claim would be invisible.
+  it('releases the claim when completion fails so the client can retry', async () => {
+    jest
+      .spyOn(uploadsRepository, 'getUploadEntryById')
+      .mockResolvedValue({ ...upload, status: UploadStatus.PENDING })
+    jest
+      .spyOn(uploadsRepository, 'claimUploadForCompletion')
+      .mockResolvedValue(true)
+    jest
+      .spyOn(UploadFileProcessingUseCase, 'completeUploadProcessing')
+      .mockRejectedValue(new Error('Not enough upload credits'))
+    const release = jest
+      .spyOn(uploadsRepository, 'releaseUploadCompletionClaim')
+      .mockResolvedValue(undefined)
+    const updateEntry = jest
+      .spyOn(uploadsRepository, 'updateUploadEntry')
+      .mockImplementation(async (entry) => entry)
+    jest
+      .spyOn(fileProcessingInfoRepository, 'getFileProcessingInfoByUploadId')
+      .mockResolvedValue({
+        upload_id: upload.id,
+        last_processed_part_index: 0,
+      } as any)
+    jest
+      .spyOn(filePartsRepository, 'getChunkByUploadIdAndPartIndex')
+      .mockResolvedValue(null as any)
+    jest
+      .spyOn(filePartsRepository, 'getPartIndicesGreaterThan')
+      .mockResolvedValue([])
+
+    await expect(
+      UploadsUseCases.completeUpload(mockUser, upload.id),
+    ).rejects.toThrow(/Not enough upload credits/)
+    expect(release).toHaveBeenCalledWith(upload.id)
+    expect(updateEntry).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/backend/__tests__/unit/core/uploadCompletionIdempotency.spec.ts
+++ b/apps/backend/__tests__/unit/core/uploadCompletionIdempotency.spec.ts
@@ -159,6 +159,68 @@ describe('UploadsUseCases.completeUpload idempotency', () => {
     ).rejects.toThrow(/Upload not found/)
   })
 
+  // The winner can fail fast (insufficient credits, a gap in the stored parts)
+  // and hand the upload back before the loser re-reads it. Nothing holds the
+  // claim at that point, so telling the client to "retry once it finishes" would
+  // be wrong — take the claim instead.
+  it('takes the claim when the winner already released it', async () => {
+    jest
+      .spyOn(uploadsRepository, 'getUploadEntryById')
+      .mockResolvedValue({ ...upload, status: UploadStatus.PENDING })
+    const claim = jest
+      .spyOn(uploadsRepository, 'claimUploadForCompletion')
+      .mockResolvedValueOnce(false)
+      .mockResolvedValue(true)
+    const processing = jest
+      .spyOn(UploadFileProcessingUseCase, 'completeUploadProcessing')
+      .mockResolvedValue(CID as any)
+    jest
+      .spyOn(UploadFileProcessingUseCase, 'handleFileUploadFinalization')
+      .mockResolvedValue(CID)
+    jest
+      .spyOn(uploadsRepository, 'updateUploadEntry')
+      .mockImplementation(async (entry) => entry)
+    jest.spyOn(EventRouter, 'publish').mockReturnValue()
+    jest
+      .spyOn(fileProcessingInfoRepository, 'getFileProcessingInfoByUploadId')
+      .mockResolvedValue({
+        upload_id: upload.id,
+        last_processed_part_index: 0,
+      } as any)
+    jest
+      .spyOn(filePartsRepository, 'getChunkByUploadIdAndPartIndex')
+      .mockResolvedValue(null as any)
+    jest
+      .spyOn(filePartsRepository, 'getPartIndicesGreaterThan')
+      .mockResolvedValue([])
+
+    const result = await UploadsUseCases.completeUpload(mockUser, upload.id)
+
+    expect(result).toBe(CID)
+    expect(claim).toHaveBeenCalledTimes(2)
+    expect(processing).toHaveBeenCalledTimes(1)
+  })
+
+  // Exactly one re-attempt: a sibling that keeps failing and releasing must not
+  // turn the claim path into a loop.
+  it('gives up after one re-attempt when the claim keeps being taken', async () => {
+    jest
+      .spyOn(uploadsRepository, 'getUploadEntryById')
+      .mockResolvedValue({ ...upload, status: UploadStatus.PENDING })
+    const claim = jest
+      .spyOn(uploadsRepository, 'claimUploadForCompletion')
+      .mockResolvedValue(false)
+    const processing = jest
+      .spyOn(UploadFileProcessingUseCase, 'completeUploadProcessing')
+      .mockResolvedValue(CID as any)
+
+    await expect(
+      UploadsUseCases.completeUpload(mockUser, upload.id),
+    ).rejects.toThrow(/already being completed/)
+    expect(claim).toHaveBeenCalledTimes(2)
+    expect(processing).not.toHaveBeenCalled()
+  })
+
   it('claims the upload before processing and only then flips it to MIGRATING', async () => {
     jest
       .spyOn(uploadsRepository, 'getUploadEntryById')

--- a/apps/backend/__tests__/unit/core/uploadCompletionIdempotency.spec.ts
+++ b/apps/backend/__tests__/unit/core/uploadCompletionIdempotency.spec.ts
@@ -9,7 +9,10 @@ import {
 import { UploadsUseCases } from '../../../src/core/uploads/uploads.js'
 import { BlockstoreUseCases } from '../../../src/core/uploads/blockstore.js'
 import { UploadFileProcessingUseCase } from '../../../src/core/uploads/uploadProcessing.js'
-import { UnrecoverableUploadError } from '../../../src/core/uploads/errors.js'
+import {
+  UnrecoverableUploadError,
+  UploadCompletionInProgressError,
+} from '../../../src/core/uploads/errors.js'
 import { uploadsRepository } from '../../../src/infrastructure/repositories/uploads/uploads.js'
 import { blockstoreRepository } from '../../../src/infrastructure/repositories/uploads/blockstore.js'
 import { fileProcessingInfoRepository } from '../../../src/infrastructure/repositories/uploads/fileProcessingInfo.js'
@@ -23,7 +26,6 @@ import {
   UserWithOrganization,
 } from '@auto-drive/models'
 import { BadRequestError } from '../../../src/errors/index.js'
-import { UploadCompletionInProgressError } from '../../../src/core/uploads/errors.js'
 import { MetadataType } from '@autonomys/auto-dag-data'
 
 /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/apps/backend/__tests__/unit/repositories/nodes.spec.ts
+++ b/apps/backend/__tests__/unit/repositories/nodes.spec.ts
@@ -92,6 +92,15 @@ describe('Nodes Repository', () => {
     expect(result2?.cid).toBe(nodes[1].cid)
   })
 
+  // Against real Postgres, because the failure is a real Postgres one: pg-format
+  // expands `VALUES %L` over an empty array to nothing, so without the guard this
+  // sends `INSERT INTO nodes (...) VALUES ` and raises `syntax error at end of
+  // input`. A migration batch whose every node was already written by an earlier
+  // batch arrives here empty, and writing nothing must be a no-op.
+  it('should treat saving zero nodes as a no-op', async () => {
+    await expect(nodesRepository.saveNodes([])).resolves.toBeUndefined()
+  })
+
   it('should get nodes by head CID', async () => {
     const headCid = 'test-head-cid-for-query'
     const nodes: Node[] = [

--- a/apps/backend/__tests__/unit/repositories/uploads.spec.ts
+++ b/apps/backend/__tests__/unit/repositories/uploads.spec.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeAll, afterAll } from '@jest/globals'
+import { UploadStatus, UploadType } from '@auto-drive/models'
+import { uploadsRepository } from '../../../src/infrastructure/repositories/uploads/uploads.js'
+import { getDatabase } from '../../../src/infrastructure/drivers/pg.js'
+import { dbMigration } from '../../utils/dbMigrate.js'
+
+const UPLOAD_ID = 'age-helper-upload'
+
+describe('Uploads Repository', () => {
+  beforeAll(async () => {
+    await dbMigration.up()
+  })
+
+  afterAll(async () => {
+    await dbMigration.down()
+  })
+
+  describe('getUploadAgeMs', () => {
+    it('returns null for an upload that does not exist', async () => {
+      expect(await uploadsRepository.getUploadAgeMs('no-such-upload')).toBeNull()
+    })
+
+    // uploads.uploads.updated_at is `timestamp` with NO time zone, and every
+    // writer stamps it with NOW() — so the stored value is the database session's
+    // local wall clock. node-postgres parses that string in the PROCESS's zone, so
+    // `Date.now() - new Date(row.updated_at).getTime()` is off by the offset
+    // between the two whenever they disagree: an hour too old under Europe/London
+    // in summer (a claim taken seconds ago reads as stale, and abortUpload tears
+    // down a live completion), seven hours too young under America/Los_Angeles
+    // (nothing is ever stale, so a stranded claim can never be aborted).
+    //
+    // Nothing pins TZ in the pool, the compose files or the Dockerfile, so the
+    // guarantee has to come from the query. Postgres subtracts inside one session,
+    // which cancels the zone out: the same 90 minutes, whatever the process thinks
+    // the time is.
+    it('reports the same age whatever the process time zone is', async () => {
+      await uploadsRepository.createUploadEntry(
+        UPLOAD_ID,
+        UploadType.FILE,
+        UploadStatus.COMPLETING,
+        'aged.bin',
+        null,
+        null,
+        UPLOAD_ID,
+        null,
+        'google',
+        'user1',
+        null,
+      )
+      const db = await getDatabase()
+      await db.query(
+        `UPDATE uploads.uploads
+         SET updated_at = NOW() - make_interval(mins => 90)
+         WHERE id = $1`,
+        [UPLOAD_ID],
+      )
+
+      const NINETY_MINUTES_MS = 90 * 60 * 1000
+      const originalTz = process.env.TZ
+      try {
+        for (const tz of ['UTC', 'Europe/London', 'America/Los_Angeles']) {
+          process.env.TZ = tz
+
+          const ageMs = await uploadsRepository.getUploadAgeMs(UPLOAD_ID)
+
+          expect(ageMs).not.toBeNull()
+          // Generous tolerance: this is asserting the absence of a whole-hour
+          // skew, not clock precision.
+          expect(Math.abs(ageMs! - NINETY_MINUTES_MS)).toBeLessThan(60_000)
+        }
+      } finally {
+        process.env.TZ = originalTz
+      }
+    })
+  })
+})

--- a/apps/backend/__tests__/unit/repositories/uploads.spec.ts
+++ b/apps/backend/__tests__/unit/repositories/uploads.spec.ts
@@ -15,6 +15,35 @@ describe('Uploads Repository', () => {
     await dbMigration.down()
   })
 
+  // The migration builds this index with CONCURRENTLY so it does not block writes
+  // to a table holding every in-flight upload's node payloads. That has to happen
+  // outside db-migrate's per-migration transaction, and a CONCURRENTLY build that
+  // fails leaves an INVALID index behind rather than none — an index that enforces
+  // nothing while looking present. So assert the end state, not just that the
+  // migration exited zero.
+  describe('blockstore_root_node_unique_idx', () => {
+    it('is a valid unique index after migrating', async () => {
+      const db = await getDatabase()
+
+      const result = await db.query<{
+        indisvalid: boolean
+        indisunique: boolean
+        indpred: string | null
+      }>(
+        `SELECT i.indisvalid, i.indisunique, pg_get_expr(i.indpred, i.indrelid) AS indpred
+         FROM pg_index i
+         JOIN pg_class c ON c.oid = i.indexrelid
+         WHERE c.relname = 'blockstore_root_node_unique_idx'`,
+      )
+
+      expect(result.rows).toHaveLength(1)
+      expect(result.rows[0].indisvalid).toBe(true)
+      expect(result.rows[0].indisunique).toBe(true)
+      // Partial, so identical chunk rows are still allowed to repeat.
+      expect(result.rows[0].indpred).not.toBeNull()
+    })
+  })
+
   describe('getUploadAgeMs', () => {
     it('returns null for an upload that does not exist', async () => {
       expect(await uploadsRepository.getUploadAgeMs('no-such-upload')).toBeNull()

--- a/apps/backend/__tests__/unit/useCases/uploads.spec.ts
+++ b/apps/backend/__tests__/unit/useCases/uploads.spec.ts
@@ -6,6 +6,7 @@ import {
   uploadsRepository,
   type UploadEntry,
 } from '../../../src/infrastructure/repositories/uploads/uploads.js'
+import { UploadStatus } from '@auto-drive/models'
 
 describe('UploadsUseCases.scheduleNodesPublish', () => {
   beforeEach(() => {
@@ -124,20 +125,27 @@ describe('UploadsUseCases.processMigration', () => {
     const getSpy = jest
       .spyOn(uploadsRepository, 'getUploadEntryById')
       .mockReturnValue(lookupGate)
+    // A missing upload is unrecoverable, so processMigration parks it as failed
+    // and resolves rather than throwing (see UnrecoverableUploadError) — stub the
+    // status write so the guard assertions below don't reach the database.
+    const setStatusSpy = jest
+      .spyOn(uploadsRepository, 'updateUploadStatusByRootUploadId')
+      .mockResolvedValue(undefined)
 
     const first = UploadsUseCases.processMigration('upload-1')
     // Second run for the same upload must short-circuit before touching the repo.
     await UploadsUseCases.processMigration('upload-1')
     expect(getSpy).toHaveBeenCalledTimes(1)
 
-    // Let the first run finish; an unknown upload throws, releasing the guard.
+    // Let the first run finish; an unknown upload is parked, releasing the guard.
     resolveLookup(null)
-    await expect(first).rejects.toThrow('Upload not found')
+    await expect(first).resolves.toBeUndefined()
+    expect(setStatusSpy).toHaveBeenCalledWith('upload-1', UploadStatus.FAILED)
 
     // Guard released — a later run for the same upload proceeds again.
-    await expect(UploadsUseCases.processMigration('upload-1')).rejects.toThrow(
-      'Upload not found',
-    )
+    await expect(
+      UploadsUseCases.processMigration('upload-1'),
+    ).resolves.toBeUndefined()
     expect(getSpy).toHaveBeenCalledTimes(2)
   })
 })

--- a/apps/backend/migrations/20260803000000-blockstore-root-node-unique.js
+++ b/apps/backend/migrations/20260803000000-blockstore-root-node-unique.js
@@ -1,0 +1,51 @@
+'use strict'
+
+var dbm
+var type
+var seed
+var fs = require('fs')
+var path = require('path')
+var Promise
+
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  var filePath = path.join(
+    __dirname,
+    'sqls',
+    '20260803000000-blockstore-root-node-unique-up.sql',
+  )
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      resolve(data)
+    })
+  }).then(function (data) {
+    return db.runSql(data)
+  })
+}
+
+exports.down = function (db) {
+  var filePath = path.join(
+    __dirname,
+    'sqls',
+    '20260803000000-blockstore-root-node-unique-down.sql',
+  )
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      resolve(data)
+    })
+  }).then(function (data) {
+    return db.runSql(data)
+  })
+}
+
+exports._meta = {
+  version: 1,
+}

--- a/apps/backend/migrations/20260803000000-blockstore-root-node-unique.js
+++ b/apps/backend/migrations/20260803000000-blockstore-root-node-unique.js
@@ -14,6 +14,38 @@ exports.setup = function (options, seedLink) {
   Promise = options.Promise
 }
 
+// A plain CREATE UNIQUE INDEX takes a SHARE lock for the whole build, and
+// uploads.blockstore holds the node payloads of every in-flight upload — so it
+// would block uploads for as long as the build takes, on a table whose size is
+// whatever the backlog happens to be. CONCURRENTLY builds it without blocking
+// writes, but it cannot run inside a transaction block and db-migrate wraps every
+// migration in one (its startMigration issues BEGIN, endMigration COMMIT).
+//
+// So: run the deduplication inside that transaction, COMMIT it, build the index in
+// autocommit, then reopen a transaction so db-migrate's own migration-record
+// insert and its closing COMMIT stay balanced. Each statement needs its own
+// runSql call for the same reason — a multi-statement simple query is itself an
+// implicit transaction block, which CONCURRENTLY would reject.
+//
+// Failure is safe in both directions. If the build fails, no migration record is
+// written, so the migration re-runs; the deduplication it already committed is
+// idempotent. A failed CONCURRENTLY build leaves the index INVALID rather than
+// absent, which is why the DROP runs first — without it a re-run would find the
+// name taken and leave an index that enforces nothing. And an absent index only
+// costs the backstop: the ON CONFLICT DO NOTHING on the root-node insert stops
+// firing, which is exactly the behaviour that shipped before this branch, with the
+// app-level completion claim still in place.
+//
+// The one race left is a duplicate root row inserted between the COMMIT and the
+// build, which fails the build; re-running the migration deduplicates again and
+// rebuilds.
+var DROP_INDEX = 'DROP INDEX IF EXISTS uploads.blockstore_root_node_unique_idx'
+
+var CREATE_INDEX_CONCURRENTLY =
+  'CREATE UNIQUE INDEX CONCURRENTLY blockstore_root_node_unique_idx ' +
+  'ON uploads.blockstore (upload_id, cid) ' +
+  "WHERE node_type IN ('File', 'Folder')"
+
 exports.up = function (db) {
   var filePath = path.join(
     __dirname,
@@ -25,9 +57,22 @@ exports.up = function (db) {
       if (err) return reject(err)
       resolve(data)
     })
-  }).then(function (data) {
-    return db.runSql(data)
   })
+    .then(function (data) {
+      return db.runSql(data)
+    })
+    .then(function () {
+      return db.runSql('COMMIT;')
+    })
+    .then(function () {
+      return db.runSql(DROP_INDEX)
+    })
+    .then(function () {
+      return db.runSql(CREATE_INDEX_CONCURRENTLY)
+    })
+    .then(function () {
+      return db.runSql('BEGIN;')
+    })
 }
 
 exports.down = function (db) {

--- a/apps/backend/migrations/sqls/20260803000000-blockstore-root-node-unique-down.sql
+++ b/apps/backend/migrations/sqls/20260803000000-blockstore-root-node-unique-down.sql
@@ -1,0 +1,4 @@
+-- Drops the constraint only. The duplicate root rows the forward migration
+-- removed are not restored: they were byte-identical copies of a row that is
+-- still present, so there is nothing to restore.
+DROP INDEX IF EXISTS uploads.blockstore_root_node_unique_idx;

--- a/apps/backend/migrations/sqls/20260803000000-blockstore-root-node-unique-up.sql
+++ b/apps/backend/migrations/sqls/20260803000000-blockstore-root-node-unique-up.sql
@@ -1,0 +1,40 @@
+-- Make the root blockstore node per upload unique, so a duplicate root node is
+-- unrepresentable rather than merely unlikely.
+--
+-- completeUpload now takes an atomic completion claim, which stops two
+-- overlapping calls from both writing the root node. That guard is app-level
+-- only, and two holes survive it:
+--   * a completion that outlives UPLOAD_COMPLETION_CLAIM_STALE_MS has its claim
+--     taken over, and the second run writes the root node again;
+--   * during a rolling deploy, an old process has no guard at all.
+-- Both leave the duplicate rows that made getFileUploadIdCID — and therefore
+-- every future migration attempt — fail permanently. A constraint closes them.
+--
+-- Scoped to the ROOT node types only. A file containing two identical chunks
+-- legitimately stores two rows with the same CID, and
+-- processBufferToIPLDFormatFromChunks iterates every FileChunk row to build the
+-- DAG links, so deduplicating chunks would silently corrupt such files. Root
+-- rows have no such freedom: exactly one File (or Folder) row exists per
+-- upload_id, since the intermediate nodes of a chunked file are written as
+-- FileInlink, not File (auto-dag-data createFileInlinkIpldNode).
+
+-- Existing duplicates must go first or the index cannot be built. This is
+-- lossless: cid is the content hash of the node, so rows sharing
+-- (upload_id, cid) are byte-identical in data, node_size and node_type, and
+-- keeping the lowest sort_id preserves the row the readers already return
+-- (getByType orders by sort_id ASC). Uploads broken this way are still
+-- MIGRATING with their payload intact, so this deletion repairs them rather
+-- than discarding anything.
+DELETE FROM uploads.blockstore AS b
+WHERE b.node_type IN ('File', 'Folder')
+  AND b.sort_id > (
+    SELECT MIN(inner_b.sort_id)
+    FROM uploads.blockstore AS inner_b
+    WHERE inner_b.upload_id = b.upload_id
+      AND inner_b.cid = b.cid
+      AND inner_b.node_type = b.node_type
+  );
+
+CREATE UNIQUE INDEX blockstore_root_node_unique_idx
+  ON uploads.blockstore (upload_id, cid)
+  WHERE node_type IN ('File', 'Folder');

--- a/apps/backend/migrations/sqls/20260803000000-blockstore-root-node-unique-up.sql
+++ b/apps/backend/migrations/sqls/20260803000000-blockstore-root-node-unique-up.sql
@@ -25,6 +25,9 @@
 -- (getByType orders by sort_id ASC). Uploads broken this way are still
 -- MIGRATING with their payload intact, so this deletion repairs them rather
 -- than discarding anything.
+-- The index itself is built by the migration's JS, not from this file: it needs
+-- CONCURRENTLY, which cannot run inside a transaction block. See the comment
+-- there.
 DELETE FROM uploads.blockstore AS b
 WHERE b.node_type IN ('File', 'Folder')
   AND b.sort_id > (
@@ -34,7 +37,3 @@ WHERE b.node_type IN ('File', 'Folder')
       AND inner_b.cid = b.cid
       AND inner_b.node_type = b.node_type
   );
-
-CREATE UNIQUE INDEX blockstore_root_node_unique_idx
-  ON uploads.blockstore (upload_id, cid)
-  WHERE node_type IN ('File', 'Folder');

--- a/apps/backend/src/app/controllers/s3/s3.ts
+++ b/apps/backend/src/app/controllers/s3/s3.ts
@@ -1,5 +1,6 @@
 import { S3UseCases } from '../../../core/s3/index.js'
 import { handleError, ForbiddenError } from '../../../errors/index.js'
+import { UploadCompletionInProgressError } from '../../../core/uploads/errors.js'
 import { handleS3Auth } from '../../../infrastructure/services/auth/s3.js'
 import {
   getByteRange,
@@ -711,12 +712,36 @@ export const completeMultipartUploadHandler = async (
     throw error
   }
 
-  const result = await S3UseCases.completeMultipartUpload(user, {
-    Bucket: bucket,
-    Key: key,
-    UploadId: req.query.uploadId as string,
-    Parts: parts,
-  })
+  // completeUpload throws (rather than returning an err) when it cannot take the
+  // completion claim, and this handler has no error middleware behind it — an
+  // uncaught throw reaches Express's default handler and answers a non-XML 500,
+  // which an S3 client cannot parse and will not retry. Concurrent completes are
+  // precisely what a client's own timeout retry produces, so answer with the
+  // retryable error S3 clients already understand: 503 SlowDown, which the AWS
+  // SDK retries with backoff until the winning call finishes.
+  let result
+  try {
+    result = await S3UseCases.completeMultipartUpload(user, {
+      Bucket: bucket,
+      Key: key,
+      UploadId: req.query.uploadId as string,
+      Parts: parts,
+    })
+  } catch (error) {
+    if (error instanceof UploadCompletionInProgressError) {
+      logger.info(
+        'Completion already in progress, answering SlowDown (uploadId=%s)',
+        error.uploadId,
+      )
+      sendXML(res.status(503), 'Error', {
+        Code: 'SlowDown',
+        Message:
+          'A completion for this upload is already in progress. Please retry.',
+      })
+      return
+    }
+    throw error
+  }
 
   if (result.isErr()) {
     handleError(result.error, res)

--- a/apps/backend/src/app/controllers/s3/s3.ts
+++ b/apps/backend/src/app/controllers/s3/s3.ts
@@ -1,6 +1,9 @@
 import { S3UseCases } from '../../../core/s3/index.js'
 import { handleError, ForbiddenError } from '../../../errors/index.js'
-import { UploadCompletionInProgressError } from '../../../core/uploads/errors.js'
+import {
+  UploadCompletionInProgressError,
+  UploadPartsChangedError,
+} from '../../../core/uploads/errors.js'
 import { handleS3Auth } from '../../../infrastructure/services/auth/s3.js'
 import {
   getByteRange,
@@ -737,6 +740,22 @@ export const completeMultipartUploadHandler = async (
         Code: 'SlowDown',
         Message:
           'A completion for this upload is already in progress. Please retry.',
+      })
+      return
+    }
+    // The other end of the same problem: this one is terminal, so it must NOT
+    // look retryable. A client that appended a part after a failed completion
+    // has to abort and start again, and it can only learn that from a 4xx it can
+    // parse — the same reason SlowDown is spelled out above rather than left to
+    // Express's default handler.
+    if (error instanceof UploadPartsChangedError) {
+      logger.warn(
+        'Parts changed after the root node was derived, answering InvalidRequest (uploadId=%s)',
+        error.uploadId,
+      )
+      sendXML(res.status(400), 'Error', {
+        Code: 'InvalidRequest',
+        Message: error.message,
       })
       return
     }

--- a/apps/backend/src/config.ts
+++ b/apps/backend/src/config.ts
@@ -127,9 +127,14 @@ export const config = {
     // How long a completion claim (status=completing) is respected before
     // another completeUpload call may take it over. Only reached when a process
     // dies mid-completion, since the claim is released on both success and
-    // failure — so this must comfortably exceed the time it takes to derive the
-    // root IPLD node for the largest expected upload, or a slow completion could
-    // be claimed a second time and duplicate the root blockstore node.
+    // failure — so this should comfortably exceed the time it takes to derive
+    // the root IPLD node for the largest expected upload, or a slow completion
+    // can be claimed a second time while it is still running.
+    //
+    // That second run no longer duplicates the root blockstore node:
+    // blockstore_root_node_unique_idx plus the ON CONFLICT DO NOTHING on the
+    // insert make the write idempotent, so this value is a liveness knob, not
+    // the thing standing between us and a corrupt row.
     completionClaimStaleMs: Number(
       env('UPLOAD_COMPLETION_CLAIM_STALE_MS', '3600000'),
     ), // 1 hour

--- a/apps/backend/src/config.ts
+++ b/apps/backend/src/config.ts
@@ -123,6 +123,17 @@ export const config = {
     // every cycle.
     stalenessMs: Number(env('MIGRATION_RECOVERY_STALENESS_MS', '1800000')), // 30 minutes
   },
+  uploads: {
+    // How long a completion claim (status=completing) is respected before
+    // another completeUpload call may take it over. Only reached when a process
+    // dies mid-completion, since the claim is released on both success and
+    // failure — so this must comfortably exceed the time it takes to derive the
+    // root IPLD node for the largest expected upload, or a slow completion could
+    // be claimed a second time and duplicate the root blockstore node.
+    completionClaimStaleMs: Number(
+      env('UPLOAD_COMPLETION_CLAIM_STALE_MS', '3600000'),
+    ), // 1 hour
+  },
   filesGateway: {
     url: env('FILES_GATEWAY_URL'),
     token: env('FILES_GATEWAY_TOKEN'),

--- a/apps/backend/src/core/objects/nodes.ts
+++ b/apps/backend/src/core/objects/nodes.ts
@@ -214,6 +214,34 @@ const migrateFromBlockstoreToNodesTable = async (
         )
         const uniqueNodes = takeUnseenNodes(nodes)
 
+        // An empty batch is ordinary, not exceptional, and it must not reach
+        // saveNodes. getAllKeys yields one key per blockstore ROW, so a file
+        // holding a long run of identical chunks — a sparse file, a zero-padded
+        // disk image, a padded archive — fills whole batches with CIDs the
+        // filter has already seen; a batch-aligned run of BATCH_SIZE * 2
+        // identical chunks (about 13 MB at DEFAULT_MAX_CHUNK_SIZE) is enough.
+        //
+        // saveNodes([]) is not a no-op: pg-format expands `VALUES %L` over an
+        // empty array to nothing, so Postgres receives `INSERT INTO nodes (...)
+        // VALUES ` and answers `syntax error at end of input`. That is not an
+        // UnrecoverableUploadError, so processMigration rethrows it, the task
+        // burns its three retries, dead-letters to frontend-errors, and leaves
+        // the upload MIGRATING for the recovery sweep to re-drive every
+        // staleness window — the unbounded dead-letter loop this branch exists
+        // to close, reachable from an ordinary upload.
+        //
+        // The per-batch Map that createNodeDeduplicator replaced could never
+        // return zero for a non-empty batch, which is why nothing downstream
+        // was ever built to survive it.
+        if (uniqueNodes.length === 0) {
+          logger.info(
+            'Every node in this batch was already migrated; skipping the insert (uploadId=%s, batchSize=%d)',
+            upload.id,
+            nodes.length,
+          )
+          return
+        }
+
         await nodesRepository.saveNodes(
           uniqueNodes.map((e) => ({
             cid: cidToString(e.cid),

--- a/apps/backend/src/core/objects/nodes.ts
+++ b/apps/backend/src/core/objects/nodes.ts
@@ -140,6 +140,41 @@ const getUploadCID = async (uploadId: string): Promise<CID> => {
   return cid
 }
 
+/**
+ * Returns a filter that keeps only nodes whose CID it has not seen before,
+ * across every call — i.e. across every batch of one upload's migration.
+ *
+ * Deduplicating per batch is not enough. getAllKeys yields in sort_id
+ * (insertion) order, so a duplicate row appended by a later completion pass
+ * lands in a DIFFERENT batch from its original whenever the two are more than
+ * BATCH_SIZE rows apart, and a per-batch Map cannot see it. Verified: a 100-row
+ * blockstore plus one duplicate root row produced 101 nodes rows with the root
+ * present twice. nodes.cid has no unique constraint and getCidsByRootCid has no
+ * DISTINCT, so that fans straight out into duplicate on-chain publish work —
+ * exactly what the removeNodeByRootCid comment warns about.
+ *
+ * Holds one CID string per unique node for the duration of the upload's
+ * migration, the same order of magnitude as the batch data already in flight.
+ */
+export const createNodeDeduplicator = (uploadId: string) => {
+  const seenCids = new Set<string>()
+
+  return <T extends { cid: CID }>(nodes: T[]): T[] =>
+    nodes.filter((node) => {
+      const cid = cidToString(node.cid)
+      if (seenCids.has(cid)) {
+        logger.warn(
+          'Skipping duplicate blockstore node (uploadId=%s, cid=%s)',
+          uploadId,
+          cid,
+        )
+        return false
+      }
+      seenCids.add(cid)
+      return true
+    })
+}
+
 const migrateFromBlockstoreToNodesTable = async (
   uploadId: string,
 ): Promise<void> => {
@@ -168,6 +203,8 @@ const migrateFromBlockstoreToNodesTable = async (
     const headCID = await getUploadCID(upload.id)
     const blockstore = await getUploadBlockstore(upload.id)
 
+    const takeUnseenNodes = createNodeDeduplicator(upload.id)
+
     const BATCH_SIZE = 100
     await asyncIterableForEach(
       blockstore.getAllKeys(),
@@ -175,9 +212,7 @@ const migrateFromBlockstoreToNodesTable = async (
         const nodes = await asyncIterableToPromiseOfArray(
           blockstore.getMany(batch),
         )
-        const uniqueNodes = Array.from(
-          new Map(nodes.map((node) => [cidToString(node.cid), node])).values(),
-        )
+        const uniqueNodes = takeUnseenNodes(nodes)
 
         await nodesRepository.saveNodes(
           uniqueNodes.map((e) => ({

--- a/apps/backend/src/core/objects/nodes.ts
+++ b/apps/backend/src/core/objects/nodes.ts
@@ -17,6 +17,7 @@ import {
   asyncIterableToPromiseOfArray,
 } from '@autonomys/asynchronous'
 import { BlockstoreUseCases } from '../uploads/blockstore.js'
+import { UnrecoverableUploadError } from '../uploads/errors.js'
 import {
   UploadType,
   ObjectMapping,
@@ -181,9 +182,37 @@ const migrateFromBlockstoreToNodesTable = async (
   const uploads = await uploadsRepository.getUploadsByRoot(uploadId)
   const rootCID = await getUploadCID(uploadId)
 
+  // getMetadata returns a neverthrow Result, and a Result object is always truthy,
+  // so the `if (!metadata) return` this replaces could never fire — migration ran
+  // regardless of whether the object had a metadata row.
+  //
+  // Proceeding is the worst of the options. handleFileUploadFinalization and
+  // handleFolderUploadFinalization save the metadata strictly BEFORE the upload
+  // flips to MIGRATING and the migrate task is enqueued, and migrate only ever
+  // runs on a root upload, so a missing row means the completion never got that
+  // far and no retry will change it. Migrating anyway writes the nodes, deletes the
+  // upload artifacts, then hands tag-upload a cid it cannot resolve — tagUpload
+  // returns its error before reaching scheduleNodesPublish, so the object ends up
+  // with nodes in the database, nothing enqueued to publish them, and no upload row
+  // left for the recovery sweep to find.
+  //
+  // Restoring the original intent would only trade that for a silent return, which
+  // leaves the row MIGRATING for the sweep to re-drive every staleness window,
+  // forever. Parking it as FAILED is what this branch already does with the other
+  // permanently-broken shapes: the sweep stops selecting it, the task acks instead
+  // of dead-lettering, and auto_drive_upload_migration_unrecoverable makes it
+  // visible.
   const metadata = await ObjectUseCases.getMetadata(cidToString(rootCID))
-  if (!metadata) {
-    return
+  if (metadata.isErr()) {
+    logger.error(
+      'No metadata for the root of a migrating upload (uploadId=%s, rootCid=%s)',
+      uploadId,
+      cidToString(rootCID),
+    )
+    throw new UnrecoverableUploadError(
+      `No metadata found for the root of upload ${uploadId} (rootCid=${cidToString(rootCID)})`,
+      uploadId,
+    )
   }
 
   // Clear any nodes already written for this root before re-inserting. migrate

--- a/apps/backend/src/core/objects/uploadStatus.ts
+++ b/apps/backend/src/core/objects/uploadStatus.ts
@@ -20,6 +20,7 @@ const getUploadStatus = async (cid: string): Promise<ObjectUploadState> => {
     [
       UploadStatus.MIGRATING,
       UploadStatus.PENDING,
+      UploadStatus.COMPLETING,
       UploadStatus.FAILED,
     ].includes(uploadStatus)
 

--- a/apps/backend/src/core/objects/uploadStatus.ts
+++ b/apps/backend/src/core/objects/uploadStatus.ts
@@ -8,11 +8,22 @@ const logger = createLogger('useCases:objects:uploadStatus')
 const getUploadStatus = async (cid: string): Promise<ObjectUploadState> => {
   logger.debug('Fetching upload status (cid=%s)', cid)
   const uploadStatus = await uploadsRepository.getStatusByCID(cid)
-  const isMigratingOrPending =
+  // FAILED is included deliberately. An upload row still exists for it (only a
+  // successful migration removes the artifacts), so its nodes were never written
+  // and the counting path below would report 0 uploaded of 0 total — which reads
+  // as "fully published" rather than "never published". Returning the same
+  // all-null state as an in-progress upload keeps that from being reported as
+  // success. Surfacing a distinct failed state to the user needs a new
+  // ObjectUploadState field plus frontend work; tracked separately.
+  const hasNoNodesYet =
     uploadStatus &&
-    [UploadStatus.MIGRATING, UploadStatus.PENDING].includes(uploadStatus)
+    [
+      UploadStatus.MIGRATING,
+      UploadStatus.PENDING,
+      UploadStatus.FAILED,
+    ].includes(uploadStatus)
 
-  if (isMigratingOrPending) {
+  if (hasNoNodesYet) {
     logger.trace('Upload is in %s state (cid=%s)', uploadStatus, cid)
     return {
       uploadedNodes: null,

--- a/apps/backend/src/core/objects/uploadStatus.ts
+++ b/apps/backend/src/core/objects/uploadStatus.ts
@@ -8,13 +8,23 @@ const logger = createLogger('useCases:objects:uploadStatus')
 const getUploadStatus = async (cid: string): Promise<ObjectUploadState> => {
   logger.debug('Fetching upload status (cid=%s)', cid)
   const uploadStatus = await uploadsRepository.getStatusByCID(cid)
-  // FAILED is included deliberately. An upload row still exists for it (only a
-  // successful migration removes the artifacts), so its nodes were never written
-  // and the counting path below would report 0 uploaded of 0 total — which reads
-  // as "fully published" rather than "never published". Returning the same
-  // all-null state as an in-progress upload keeps that from being reported as
-  // success. Surfacing a distinct failed state to the user needs a new
-  // ObjectUploadState field plus frontend work; tracked separately.
+  // COMPLETING and FAILED are included deliberately: an upload row still exists
+  // for both (only a successful migration removes the artifacts) and neither has
+  // written any nodes, so the counting path below would report 0 uploaded of 0
+  // total and 0 archived of 0 total. Returning explicit nulls says "no counts
+  // yet" instead of handing callers zeroes that every ratio reads as complete.
+  //
+  // This is about the API being honest, not about a live UI bug: objectStatus()
+  // maps totalNodes === 0 to Processing before it compares archivedNodes to
+  // totalNodes, and the web app's file lists compute uploadState from Hasura
+  // aggregates rather than this endpoint — so neither renders a false "archived"
+  // today. It is REST/SDK consumers doing their own arithmetic that the zeroes
+  // mislead.
+  //
+  // Surfacing a distinct failed state to the user needs a new ObjectUploadState
+  // field plus frontend work; until then a FAILED upload reads as Processing,
+  // and auto_drive_upload_migration_unrecoverable (emitted where the upload is
+  // parked) is what makes it visible to us.
   const hasNoNodesYet =
     uploadStatus &&
     [

--- a/apps/backend/src/core/uploads/blockstore.ts
+++ b/apps/backend/src/core/uploads/blockstore.ts
@@ -28,12 +28,17 @@ const logger = createLogger('useCases:uploads:blockstore')
  *
  * Tolerates DUPLICATE rows that all carry the same CID. Historically a repeated
  * completeUpload call re-ran the completion processing and re-INSERTed the root
- * node (uploads.blockstore has no unique key on (upload_id, cid) — see
- * blockstore_upload_id_cid_index), leaving 2-3 byte-identical rows and making
- * this lookup — and therefore migration — fail permanently for an upload whose
- * data is perfectly intact. completeUpload now refuses to re-run (see
- * UploadsUseCases.completeUpload), but rows written before that guard still
- * exist in production, so the read side must accept them.
+ * node — uploads.blockstore had only the NON-unique
+ * blockstore_upload_id_cid_index on (upload_id, cid) — leaving 2-3 byte-identical
+ * rows and making this lookup, and therefore migration, fail permanently for an
+ * upload whose data is perfectly intact.
+ *
+ * Both ends of that are now closed: completeUpload refuses to re-run, and
+ * blockstore_root_node_unique_idx makes a duplicate root row unrepresentable. So
+ * this tolerance is no longer load-bearing for new writes — it stays because a
+ * replica or a rolled-back deploy may still be reading rows written before the
+ * migration deduplicated them, and because failing an intact upload permanently
+ * is a far worse outcome than picking the single CID they all agree on.
  *
  * Deduplicating on CID rather than row count is safe because it is only used to
  * identify the ROOT node, of which there can be exactly one per upload; the

--- a/apps/backend/src/core/uploads/blockstore.ts
+++ b/apps/backend/src/core/uploads/blockstore.ts
@@ -19,47 +19,80 @@ import { UploadsUseCases } from './uploads.js'
 import { getUploadBlockstore } from '../../infrastructure/services/upload/uploadProcessorCache/index.js'
 import { uploadsRepository } from '../../infrastructure/repositories/uploads/uploads.js'
 import { createLogger } from '../../infrastructure/drivers/logger.js'
+import { UnrecoverableUploadError } from './errors.js'
 
 const logger = createLogger('useCases:uploads:blockstore')
 
-const getFileUploadIdCID = async (uploadId: string): Promise<CID> => {
-  logger.debug('getFileUploadIdCID invoked (uploadId=%s)', uploadId)
+/**
+ * Resolves the single root node CID an upload's blockstore must contain.
+ *
+ * Tolerates DUPLICATE rows that all carry the same CID. Historically a repeated
+ * completeUpload call re-ran the completion processing and re-INSERTed the root
+ * node (uploads.blockstore has no unique key on (upload_id, cid) — see
+ * blockstore_upload_id_cid_index), leaving 2-3 byte-identical rows and making
+ * this lookup — and therefore migration — fail permanently for an upload whose
+ * data is perfectly intact. completeUpload now refuses to re-run (see
+ * UploadsUseCases.completeUpload), but rows written before that guard still
+ * exist in production, so the read side must accept them.
+ *
+ * Deduplicating on CID rather than row count is safe because it is only used to
+ * identify the ROOT node, of which there can be exactly one per upload; the
+ * per-chunk reads (getChunksByNodeType, getFilteredMany) are deliberately left
+ * alone, since a file containing two identical chunks legitimately stores two
+ * rows with the same CID and both links belong in the DAG.
+ *
+ * A count of zero, or genuinely different CIDs, is not a duplicate — it is an
+ * upload that can never produce a root node, so it raises
+ * UnrecoverableUploadError rather than a bare Error.
+ */
+const getRootNodeCID = async (
+  uploadId: string,
+  nodeType: MetadataType.File | MetadataType.Folder,
+): Promise<CID> => {
   const blockstoreEntry = await blockstoreRepository.getByType(
     uploadId,
-    MetadataType.File,
+    nodeType,
   )
-  if (blockstoreEntry.length !== 1) {
+  const distinctCids = new Set(blockstoreEntry.map((e) => e.cid))
+
+  if (distinctCids.size !== 1) {
     logger.warn(
-      'Invalid number of blockstore entries for file upload (uploadId=%s)',
+      'Invalid number of blockstore entries for %s upload (uploadId=%s, rows=%d, distinctCids=%d)',
+      nodeType,
+      uploadId,
+      blockstoreEntry.length,
+      distinctCids.size,
+    )
+    throw new UnrecoverableUploadError(
+      `Invalid number of blockstore entries for ${nodeType} upload with id=${uploadId} (rows=${blockstoreEntry.length}, distinctCids=${distinctCids.size})`,
       uploadId,
     )
-    throw new Error(
-      `Invalid number of blockstore entries for file upload with id=${uploadId}`,
+  }
+
+  if (blockstoreEntry.length > 1) {
+    logger.warn(
+      'Duplicate root blockstore rows for %s upload, all with the same CID; using it (uploadId=%s, rows=%d)',
+      nodeType,
+      uploadId,
+      blockstoreEntry.length,
     )
   }
-  const cid = blockstoreEntry[0].cid
+
+  const [cid] = distinctCids
 
   return stringToCid(cid)
 }
 
+const getFileUploadIdCID = async (uploadId: string): Promise<CID> => {
+  logger.debug('getFileUploadIdCID invoked (uploadId=%s)', uploadId)
+
+  return getRootNodeCID(uploadId, MetadataType.File)
+}
+
 const getFolderUploadIdCID = async (uploadId: string): Promise<CID> => {
   logger.debug('getFolderUploadIdCID invoked (uploadId=%s)', uploadId)
-  const blockstoreEntry = await blockstoreRepository.getByType(
-    uploadId,
-    MetadataType.Folder,
-  )
-  if (blockstoreEntry.length !== 1) {
-    logger.warn(
-      'Invalid number of blockstore entries for folder upload (uploadId=%s)',
-      uploadId,
-    )
-    throw new Error(
-      `Invalid number of blockstore entries for folder upload with id=${uploadId}`,
-    )
-  }
-  const cid = blockstoreEntry[0].cid
 
-  return stringToCid(cid)
+  return getRootNodeCID(uploadId, MetadataType.Folder)
 }
 
 const getUploadCID = async (uploadId: string): Promise<CID> => {
@@ -67,7 +100,9 @@ const getUploadCID = async (uploadId: string): Promise<CID> => {
   const uploadEntry = await uploadsRepository.getUploadEntryById(uploadId)
   if (!uploadEntry) {
     logger.error('Upload not found (uploadId=%s)', uploadId)
-    throw new Error('Upload not found')
+    // Upload rows never come back, so a migrate task for a deleted upload can
+    // only ever fail; do not let it retry into the dead-letter queue.
+    throw new UnrecoverableUploadError('Upload not found', uploadId)
   }
 
   if (uploadEntry.type === UploadType.FILE) {

--- a/apps/backend/src/core/uploads/errors.ts
+++ b/apps/backend/src/core/uploads/errors.ts
@@ -1,4 +1,4 @@
-import { ConflictError } from '../../errors/index.js'
+import { BadRequestError, ConflictError } from '../../errors/index.js'
 
 /**
  * Thrown when an upload can never be migrated, no matter how many times the
@@ -45,5 +45,32 @@ export class UploadCompletionInProgressError extends ConflictError {
   ) {
     super(message)
     this.name = 'UploadCompletionInProgressError'
+  }
+}
+
+/**
+ * Thrown when a completion is retried for an upload whose stored parts no longer
+ * match the root node an earlier attempt already derived.
+ *
+ * completeFileProcessing derives the root at most once and reuses it on re-entry,
+ * which is what makes the "top up your credits and retry" flow resume instead of
+ * restarting. Reuse is only correct while the upload still holds the same bytes
+ * the root was built from, and it can stop being true: uploadChunk has no status
+ * guard, a failed completion releases the row back to PENDING, and S3 permits
+ * UploadPart after a failed CompleteMultipartUpload. Silently returning the old
+ * root would answer 200 with a CID covering a prefix of what the client
+ * uploaded — a truncated object the client then stores and references. This says
+ * so instead.
+ *
+ * 400 rather than a retryable status: no amount of retrying reconciles the two,
+ * the client has to abort the upload and start again.
+ */
+export class UploadPartsChangedError extends BadRequestError {
+  constructor(
+    message: string,
+    readonly uploadId: string,
+  ) {
+    super(message)
+    this.name = 'UploadPartsChangedError'
   }
 }

--- a/apps/backend/src/core/uploads/errors.ts
+++ b/apps/backend/src/core/uploads/errors.ts
@@ -1,3 +1,5 @@
+import { ConflictError } from '../../errors/index.js'
+
 /**
  * Thrown when an upload can never be migrated, no matter how many times the
  * task is retried — the row's data shape itself is wrong (a root blockstore
@@ -19,5 +21,29 @@ export class UnrecoverableUploadError extends Error {
   ) {
     super(message)
     this.name = 'UnrecoverableUploadError'
+  }
+}
+
+/**
+ * Thrown when completeUpload cannot take the completion claim because another
+ * call holds it. Distinct from a generic bad request because it is TRANSIENT and
+ * retryable: the same call will succeed once the winner finishes.
+ *
+ * The type exists so route handlers can say that to the client rather than
+ * guessing from a message string. It matters most on the S3 route, where
+ * CompleteMultipartUpload has no Result-based error path for it — an S3 client's
+ * own timeout retry is exactly the case this guard defends against, and it
+ * deserves a retryable XML error rather than an opaque one.
+ *
+ * 409 rather than 400: the request is well-formed, the resource is simply in the
+ * wrong state for it right now.
+ */
+export class UploadCompletionInProgressError extends ConflictError {
+  constructor(
+    message: string,
+    readonly uploadId: string,
+  ) {
+    super(message)
+    this.name = 'UploadCompletionInProgressError'
   }
 }

--- a/apps/backend/src/core/uploads/errors.ts
+++ b/apps/backend/src/core/uploads/errors.ts
@@ -1,0 +1,23 @@
+/**
+ * Thrown when an upload can never be migrated, no matter how many times the
+ * task is retried — the row's data shape itself is wrong (a root blockstore
+ * node that is missing or ambiguous, or an upload row that no longer exists).
+ *
+ * This exists to separate "try again later" from "this will fail identically
+ * forever". `migrate-upload-nodes` is retried three times and then published to
+ * the unconsumed `frontend-errors` queue, while the migration recovery sweep
+ * re-drives the still-MIGRATING row once per staleness window — so a
+ * permanently broken upload emits a dead-letter message every window, without
+ * bound, for as long as the row exists. processMigration catches this error,
+ * parks the upload in FAILED so the sweep stops selecting it, and acks the task
+ * instead of retrying.
+ */
+export class UnrecoverableUploadError extends Error {
+  constructor(
+    message: string,
+    readonly uploadId: string,
+  ) {
+    super(message)
+    this.name = 'UnrecoverableUploadError'
+  }
+}

--- a/apps/backend/src/core/uploads/uploadProcessing.ts
+++ b/apps/backend/src/core/uploads/uploadProcessing.ts
@@ -38,6 +38,7 @@ import { UploadArtifactsUseCase } from './artifacts.js'
 import { CID } from 'multiformats'
 import { createLogger } from '../../infrastructure/drivers/logger.js'
 import { AccountsUseCases } from '../users/accounts.js'
+import { UploadPartsChangedError } from './errors.js'
 
 const logger = createLogger('useCases:uploads:uploadProcessing')
 
@@ -128,6 +129,42 @@ const completeFileProcessing = async (uploadId: string): Promise<CID> => {
     // Delegates rather than reading [0] so duplicate-but-identical rows are
     // tolerated and genuinely divergent ones still raise UnrecoverableUploadError.
     const existingCid = await BlockstoreUseCases.getFileUploadIdCID(uploadId)
+
+    // Reuse is only correct while the upload still holds the bytes the root was
+    // built from, and that can stop being true between the two calls. uploadChunk
+    // has no status guard, the failed completion above released the row back to
+    // PENDING, and S3 permits UploadPart after a failed CompleteMultipartUpload —
+    // so `part A, failed complete, part B, complete` is legal at every step.
+    // Returning the existing root there answers 200 with a CID covering A alone,
+    // and on the S3 route the composite ETag is computed from the client's part
+    // list, so the mapping would store an ETag that does not describe the stored
+    // object. Loud-and-unrecoverable was the wrong answer to a retry, but
+    // silently truncating an object the client stores and references is a worse
+    // one in a content-addressed store.
+    //
+    // Detected by size because the root node's size IS the uploadedSize it was
+    // derived from, so one aggregate query over the stored parts settles it. The
+    // alternative — refusing uploadChunk once a root exists — costs a query on
+    // the per-part hot path and still cannot see a part that arrives after the
+    // derivation within a single completion, which this comparison does.
+    const derivedSize = BigInt(existingRootNodes[0].node_size).valueOf()
+    const storedSize =
+      (await filePartsRepository.getUploadFilePartsSize(uploadId)) ??
+      BigInt(0).valueOf()
+    if (storedSize !== derivedSize) {
+      logger.error(
+        'Stored parts no longer match the derived root node (uploadId=%s, cid=%s, derivedSize=%s, storedSize=%s)',
+        uploadId,
+        cidToString(existingCid),
+        derivedSize.toString(),
+        storedSize.toString(),
+      )
+      throw new UploadPartsChangedError(
+        `Upload ${uploadId} has ${storedSize} bytes of parts stored but its root node covers ${derivedSize}; parts changed after the root node was derived. Abort the upload and start again.`,
+        uploadId,
+      )
+    }
+
     logger.warn(
       'Reusing the already-derived root node instead of re-deriving (uploadId=%s, cid=%s)',
       uploadId,

--- a/apps/backend/src/core/uploads/uploadProcessing.ts
+++ b/apps/backend/src/core/uploads/uploadProcessing.ts
@@ -6,6 +6,7 @@ import {
 import { getUploadBlockstore } from '../../infrastructure/services/upload/uploadProcessorCache/index.js'
 import {
   cidOfNode,
+  cidToString,
   createFileChunkIpldNode,
   DEFAULT_MAX_CHUNK_SIZE,
   DEFAULT_MAX_LINK_PER_NODE,
@@ -15,6 +16,7 @@ import {
   processChunksToIPLDFormat,
   OffchainMetadata,
 } from '@autonomys/auto-dag-data'
+import { blockstoreRepository } from '../../infrastructure/repositories/uploads/blockstore.js'
 import {
   FolderUpload,
   InteractionType,
@@ -102,6 +104,38 @@ const completeFileProcessing = async (uploadId: string): Promise<CID> => {
     throw new Error('File processing info not found')
   }
 
+  // Derivation runs AT MOST ONCE per upload, and re-entry returns the root node
+  // the first run produced.
+  //
+  // This is not an optimisation, it is a correctness requirement:
+  // processBufferToIPLDFormatFromChunks is DESTRUCTIVE. For a single-chunk file it
+  // does get -> delete -> put(root) (auto-dag-data chunker.ts), so the chunk it
+  // folded in is gone afterwards. Re-deriving therefore does not reproduce the
+  // first result — it builds a root over whatever chunks remain and yields a
+  // DIFFERENT CID, which is the unrecoverable shape: getRootNodeCID refuses two
+  // distinct root CIDs, so every later retry 500s and appends another root row.
+  //
+  // Re-entry is entirely reachable: completeUpload releases its claim back to
+  // PENDING when completion fails, and the documented failure — `Not enough
+  // upload credits`, thrown by handleFileUploadFinalization — happens strictly
+  // AFTER this derivation. The advertised "top up and retry" flow is exactly this
+  // path, so it has to resume rather than restart.
+  const existingRootNodes = await blockstoreRepository.getByType(
+    uploadId,
+    MetadataType.File,
+  )
+  if (existingRootNodes.length > 0) {
+    // Delegates rather than reading [0] so duplicate-but-identical rows are
+    // tolerated and genuinely divergent ones still raise UnrecoverableUploadError.
+    const existingCid = await BlockstoreUseCases.getFileUploadIdCID(uploadId)
+    logger.warn(
+      'Reusing the already-derived root node instead of re-deriving (uploadId=%s, cid=%s)',
+      uploadId,
+      cidToString(existingCid),
+    )
+    return existingCid
+  }
+
   const blockstore = await getUploadBlockstore(uploadId)
   const latestPartLeftOver =
     await getUnprocessedChunkFromLatestFilePart(fileProcessingInfo)
@@ -109,6 +143,19 @@ const completeFileProcessing = async (uploadId: string): Promise<CID> => {
   if (latestPartLeftOver.byteLength > 0) {
     const fileChunk = createFileChunkIpldNode(latestPartLeftOver)
     await blockstore.put(cidOfNode(fileChunk), encode(fileChunk))
+    // Consume the tail. The guard above covers re-entry after the root node
+    // exists; this covers the narrower window where the first run flushed the
+    // tail and then failed BEFORE deriving a root. Without clearing it, the
+    // retry would re-put the same tail chunk, the DAG would gain a duplicate
+    // link, and the derived CID would differ from the one a clean run produces.
+    //
+    // Ordered after the put deliberately: if the clear fails, the tail bytes are
+    // already durable and behaviour degrades to what it was before this change,
+    // rather than losing the tail.
+    await fileProcessingInfoRepository.updateFileProcessingInfo({
+      ...fileProcessingInfo,
+      pending_bytes: null,
+    })
   }
 
   const uploadedSize =

--- a/apps/backend/src/core/uploads/uploads.ts
+++ b/apps/backend/src/core/uploads/uploads.ts
@@ -341,32 +341,52 @@ const completeUpload = async (
   // The status read above is not a guard on its own — two overlapping calls
   // would both see PENDING and both fall through. Take the claim atomically so
   // exactly one caller runs the processing, across every API process.
-  const claimed = await uploadsRepository.claimUploadForCompletion(
+  let claimed = await uploadsRepository.claimUploadForCompletion(
     uploadId,
     config.uploads.completionClaimStaleMs,
   )
   if (!claimed) {
-    // Losing the claim does not necessarily mean a completion is still running:
-    // the winner may have finished the whole thing between the status read above
-    // and this compare-and-swap, which for a small upload is an easy window to
-    // hit. Re-read before erroring so a retry of an already-successful
-    // completion still gets its CID instead of a spurious failure.
+    // Losing the claim does not by itself mean a completion is still running, so
+    // re-read before erroring — the row's state says which of three things
+    // happened while this call was between its status read and the CAS.
     const current = await uploadsRepository.getUploadEntryById(uploadId)
     if (!current) {
       logger.warn('Upload not found (uploadId=%s)', uploadId)
       throw new Error('Upload not found')
     }
     if (current.status === UploadStatus.MIGRATING) {
+      // The winner finished the whole completion — an easy window to hit for a
+      // small upload. This call is then just a retry of a completed upload.
       return resolveAlreadyCompletedUpload(current, uploadId)
     }
-    logger.warn(
-      'completeUpload could not claim the upload (uploadId=%s, status=%s)',
-      uploadId,
-      current.status,
-    )
-    throw new BadRequestError(
-      `Upload ${uploadId} is already being completed; retry once it finishes`,
-    )
+    if (current.status === UploadStatus.PENDING) {
+      // The winner failed and released the claim (e.g. insufficient credits, or
+      // a gap in the stored parts). Nothing holds the claim now, so this call is
+      // free to take it rather than telling the client to retry something that
+      // is not in progress. Exactly one re-attempt: a repeatedly failing sibling
+      // must not turn this into a loop.
+      logger.warn(
+        'Completion claim was released before this call could take it; retrying the claim once (uploadId=%s)',
+        uploadId,
+      )
+      claimed = await uploadsRepository.claimUploadForCompletion(
+        uploadId,
+        config.uploads.completionClaimStaleMs,
+      )
+    }
+    if (!claimed) {
+      logger.warn(
+        'completeUpload could not claim the upload (uploadId=%s, status=%s)',
+        uploadId,
+        current.status,
+      )
+      throw new BadRequestError(
+        current.status === UploadStatus.PENDING ||
+        current.status === UploadStatus.COMPLETING
+          ? `Upload ${uploadId} is already being completed; retry once it finishes`
+          : `Upload ${uploadId} is ${current.status}`,
+      )
+    }
   }
 
   try {

--- a/apps/backend/src/core/uploads/uploads.ts
+++ b/apps/backend/src/core/uploads/uploads.ts
@@ -32,7 +32,10 @@ import {
   ObjectNotFoundError,
 } from '../../errors/index.js'
 import { err, ok, Result } from 'neverthrow'
-import { UnrecoverableUploadError } from './errors.js'
+import {
+  UnrecoverableUploadError,
+  UploadCompletionInProgressError,
+} from './errors.js'
 
 const logger = createLogger('useCases:uploads:uploads')
 
@@ -397,12 +400,15 @@ const completeUpload = async (
         uploadId,
         current.status,
       )
-      throw new BadRequestError(
-        current.status === UploadStatus.PENDING ||
-        current.status === UploadStatus.COMPLETING
-          ? `Upload ${uploadId} is already being completed; retry once it finishes`
-          : `Upload ${uploadId} is ${current.status}`,
-      )
+      // Transient vs terminal, as separate types: the first is worth retrying,
+      // the second never is, and the S3 route needs to tell a client which.
+      throw current.status === UploadStatus.PENDING ||
+      current.status === UploadStatus.COMPLETING
+        ? new UploadCompletionInProgressError(
+            `Upload ${uploadId} is already being completed; retry once it finishes`,
+            uploadId,
+          )
+        : new BadRequestError(`Upload ${uploadId} is ${current.status}`)
     }
   }
 
@@ -472,10 +478,14 @@ const completeUpload = async (
 // one was lost, so the retry heals the upload instead of corrupting it. It is
 // off for the claim-lost path, where the winner has only just enqueued its own
 // task and a re-drive would be a guaranteed duplicate; the recovery sweep
-// (migrationRecovery) is the backstop there. Where it is on, the enqueue rate is
-// bounded by how often the client retries, and duplicates are harmless — migrate
-// clears the root's nodes before re-inserting and processMigration skips a
-// concurrent run for the same upload.
+// (migrationRecovery) is the backstop there.
+//
+// Where it is on it is rate-limited by the same staleness window the recovery
+// sweep uses, because a re-drive is NOT cheap: each migrate run does a
+// removeNodeByRootCid followed by a full re-insert of every node in the object.
+// Unthrottled, a client retrying complete in a loop would multiply that against
+// a large object. Reusing the sweep's window means a repeat complete can only
+// ever pull a re-drive forward that the sweep was about to do anyway.
 const resolveAlreadyCompletedUpload = async (
   upload: UploadEntry,
   uploadId: string,
@@ -483,11 +493,14 @@ const resolveAlreadyCompletedUpload = async (
 ): Promise<string> => {
   const cid = cidToString(await BlockstoreUseCases.getUploadCID(uploadId))
   const isRootUpload = upload.root_upload_id === uploadId
-  const willRedrive = redriveMigration && isRootUpload
+  const migratingForMs = Date.now() - new Date(upload.updated_at).getTime()
+  const isStale = migratingForMs >= config.migrationRecovery.stalenessMs
+  const willRedrive = redriveMigration && isRootUpload && isStale
   logger.warn(
-    'completeUpload called on an already-completed upload (uploadId=%s, cid=%s, redrivingMigration=%s)',
+    'completeUpload called on an already-completed upload (uploadId=%s, cid=%s, migratingForMs=%d, redrivingMigration=%s)',
     uploadId,
     cid,
+    migratingForMs,
     willRedrive,
   )
   if (willRedrive) {
@@ -706,10 +719,27 @@ const abortUpload = async (
     )
   }
 
-  // Only a still-in-progress (PENDING) upload may be aborted. A MIGRATING (or
-  // otherwise terminal) upload has already been completed; its artifacts must
-  // not be torn down mid-migration.
-  if (upload.status !== UploadStatus.PENDING) {
+  // Only a still-in-progress upload may be aborted. A MIGRATING (or otherwise
+  // terminal) upload has already been completed; its artifacts must not be torn
+  // down mid-migration.
+  //
+  // COMPLETING counts as in-progress only once its claim has gone stale. Without
+  // that exception, introducing COMPLETING would have made a stranded claim
+  // un-abortable for the full UPLOAD_COMPLETION_CLAIM_STALE_MS window — S3
+  // AbortMultipartUpload answering NoSuchUpload for an hour — where the
+  // equivalent stranded PENDING row can be aborted immediately. A stale claim
+  // means the completion that held it is gone, which is exactly when tearing the
+  // upload down is safe and is the same judgement claimUploadForCompletion makes
+  // when it lets the claim be re-taken.
+  //
+  // A LIVE completion stays non-abortable on purpose: it is not stranded, it is
+  // working, and racing removeUploadArtifacts against it would pull rows out from
+  // under a running DAG build.
+  const isStaleClaim =
+    upload.status === UploadStatus.COMPLETING &&
+    Date.now() - new Date(upload.updated_at).getTime() >=
+      config.uploads.completionClaimStaleMs
+  if (upload.status !== UploadStatus.PENDING && !isStaleClaim) {
     return err(new ObjectNotFoundError('Upload not found'))
   }
 

--- a/apps/backend/src/core/uploads/uploads.ts
+++ b/apps/backend/src/core/uploads/uploads.ts
@@ -30,6 +30,7 @@ import {
   ObjectNotFoundError,
 } from '../../errors/index.js'
 import { err, ok, Result } from 'neverthrow'
+import { UnrecoverableUploadError } from './errors.js'
 
 const logger = createLogger('useCases:uploads:uploads')
 
@@ -307,6 +308,41 @@ const completeUpload = async (
   }
   await checkPermissions(upload, user)
 
+  // completeUpload is NOT idempotent, so it must run at most once per upload.
+  // completeUploadProcessing re-derives the root IPLD node and writes it to
+  // uploads.blockstore on every call (blockstore.put -> plain INSERT, no unique
+  // key on (upload_id, cid)), and handleFileUploadFinalization re-runs
+  // registerInteraction. A second call therefore leaves a duplicate root node —
+  // which used to make getFileUploadIdCID, and so every future migration
+  // attempt, fail permanently — and double-charges upload credits. A client
+  // retry after a timeout, a double submit, or a proxy retry is enough to
+  // trigger it; only `abortUpload` guarded its status before this.
+  //
+  // A repeat call on an already-completed upload is treated as a no-op that
+  // returns the existing CID, and re-drives migration in case the original
+  // one-shot migrate task was lost — the retry heals the upload instead of
+  // corrupting it.
+  if (upload.status === UploadStatus.MIGRATING) {
+    const cid = cidToString(await BlockstoreUseCases.getUploadCID(uploadId))
+    logger.warn(
+      'completeUpload called on an already-completed upload; re-driving migration (uploadId=%s, cid=%s)',
+      uploadId,
+      cid,
+    )
+    if (upload.root_upload_id === uploadId) {
+      await scheduleNodeMigration(uploadId)
+    }
+    return cid
+  }
+  if (upload.status !== UploadStatus.PENDING) {
+    logger.warn(
+      'completeUpload called on a %s upload (uploadId=%s)',
+      upload.status,
+      uploadId,
+    )
+    throw new Error(`Upload ${uploadId} is ${upload.status}`)
+  }
+
   // FILE uploads: drain any not-yet-processed chunks and reject on a gap before
   // finalising. Folder uploads have no file_processing_info row and finalise
   // via processFolderUpload instead. Both steps share one lock; the lockless
@@ -581,7 +617,7 @@ const processMigration = async (uploadId: string): Promise<void> => {
     const upload = await uploadsRepository.getUploadEntryById(uploadId)
     if (!upload) {
       logger.error('Upload not found (uploadId=%s)', uploadId)
-      throw new Error('Upload not found')
+      throw new UnrecoverableUploadError('Upload not found', uploadId)
     }
 
     const cid = await BlockstoreUseCases.getUploadCID(uploadId)
@@ -590,6 +626,37 @@ const processMigration = async (uploadId: string): Promise<void> => {
     await removeUploadArtifacts(uploadId)
     await scheduleUploadTagging(cidToString(cid))
     await scheduleCachePopulation(cidToString(cid))
+  } catch (error) {
+    // A permanently broken upload must not be retried. Left to the normal retry
+    // path it would burn its three retries, publish one message to the
+    // consumer-less frontend-errors queue, stay MIGRATING, and then be re-driven
+    // by the migration recovery sweep on the next staleness window — forever, so
+    // the dead-letter queue grows without bound (this is exactly what filled it
+    // with 300+ messages). Parking the upload in FAILED takes it out of
+    // getStuckRootMigrations, so the sweep stops selecting it, and swallowing the
+    // error acks the task instead of dead-lettering it. Mirrors the
+    // `unrecoverable` bucket that publishing recovery already logs.
+    if (error instanceof UnrecoverableUploadError) {
+      logger.error(
+        error,
+        'Migration is unrecoverable, parking upload as failed (uploadId=%s)',
+        uploadId,
+      )
+      await uploadsRepository
+        .updateUploadStatusByRootUploadId(uploadId, UploadStatus.FAILED)
+        .catch((updateError) =>
+          // Best-effort: if the status write fails the task still acks and the
+          // sweep may re-drive it once more, which is strictly better than
+          // rethrowing into an unbounded dead-letter loop.
+          logger.error(
+            updateError as Error,
+            'Failed to park unrecoverable upload as failed (uploadId=%s)',
+            uploadId,
+          ),
+        )
+      return
+    }
+    throw error
   } finally {
     migrationsInFlight.delete(uploadId)
   }

--- a/apps/backend/src/core/uploads/uploads.ts
+++ b/apps/backend/src/core/uploads/uploads.ts
@@ -18,6 +18,7 @@ import { fileProcessingInfoRepository } from '../../infrastructure/repositories/
 import { NodesUseCases } from '../objects/nodes.js'
 import { ObjectUseCases } from '../objects/object.js'
 import { cidToString, FileUploadOptions } from '@autonomys/auto-dag-data'
+import { CID } from 'multiformats'
 import { EventRouter } from '../../infrastructure/eventRouter/index.js'
 import { createTask, Task } from '../../infrastructure/eventRouter/tasks.js'
 import { config } from '../../config.js'
@@ -334,7 +335,10 @@ const completeUpload = async (
     }
     return cid
   }
-  if (upload.status !== UploadStatus.PENDING) {
+  if (
+    upload.status !== UploadStatus.PENDING &&
+    upload.status !== UploadStatus.COMPLETING
+  ) {
     logger.warn(
       'completeUpload called on a %s upload (uploadId=%s)',
       upload.status,
@@ -343,32 +347,75 @@ const completeUpload = async (
     throw new Error(`Upload ${uploadId} is ${upload.status}`)
   }
 
-  // FILE uploads: drain any not-yet-processed chunks and reject on a gap before
-  // finalising. Folder uploads have no file_processing_info row and finalise
-  // via processFolderUpload instead. Both steps share one lock; the lockless
-  // helpers are used because the lock-acquiring path would deadlock here
-  // (withDrainLock is not reentrant).
-  if (upload.type === UploadType.FILE) {
-    await withDrainLock(uploadId, async () => {
-      await drainLoop(uploadId)
-      await assertNoUnprocessedParts(uploadId)
-    })
-  }
-
-  const cid = await UploadFileProcessingUseCase.completeUploadProcessing(upload)
-
-  if (upload.type === UploadType.FILE) {
-    await UploadFileProcessingUseCase.handleFileUploadFinalization(
-      user,
+  // The status read above is not a guard on its own — two overlapping calls
+  // would both see PENDING and both fall through. Take the claim atomically so
+  // exactly one caller runs the processing, across every API process.
+  const claimed = await uploadsRepository.claimUploadForCompletion(
+    uploadId,
+    config.uploads.completionClaimStaleMs,
+  )
+  if (!claimed) {
+    logger.warn(
+      'completeUpload is already in progress for this upload (uploadId=%s)',
       uploadId,
     )
-  } else if (upload.type === UploadType.FOLDER) {
-    await UploadFileProcessingUseCase.handleFolderUploadFinalization(
-      user,
-      uploadId,
+    throw new BadRequestError(
+      `Upload ${uploadId} is already being completed; retry once it finishes`,
     )
   }
 
+  try {
+    // FILE uploads: drain any not-yet-processed chunks and reject on a gap before
+    // finalising. Folder uploads have no file_processing_info row and finalise
+    // via processFolderUpload instead. Both steps share one lock; the lockless
+    // helpers are used because the lock-acquiring path would deadlock here
+    // (withDrainLock is not reentrant).
+    if (upload.type === UploadType.FILE) {
+      await withDrainLock(uploadId, async () => {
+        await drainLoop(uploadId)
+        await assertNoUnprocessedParts(uploadId)
+      })
+    }
+
+    const cid =
+      await UploadFileProcessingUseCase.completeUploadProcessing(upload)
+
+    if (upload.type === UploadType.FILE) {
+      await UploadFileProcessingUseCase.handleFileUploadFinalization(
+        user,
+        uploadId,
+      )
+    } else if (upload.type === UploadType.FOLDER) {
+      await UploadFileProcessingUseCase.handleFolderUploadFinalization(
+        user,
+        uploadId,
+      )
+    }
+
+    return await finalizeCompletedUpload(upload, uploadId, cid)
+  } catch (error) {
+    // Hand the upload back so the client can retry — a failed completion (e.g.
+    // insufficient credits, or a gap in the stored parts) must not leave the row
+    // parked in COMPLETING, which nothing sweeps. Only rolls back rows still in
+    // COMPLETING, so a failure after the flip to MIGRATING cannot undo it.
+    await uploadsRepository
+      .releaseUploadCompletionClaim(uploadId)
+      .catch((releaseError) =>
+        logger.error(
+          releaseError as Error,
+          'Failed to release completion claim (uploadId=%s)',
+          uploadId,
+        ),
+      )
+    throw error
+  }
+}
+
+const finalizeCompletedUpload = async (
+  upload: UploadEntry,
+  uploadId: string,
+  cid: CID,
+): Promise<string> => {
   const updatedUpload = {
     ...upload,
     status: UploadStatus.MIGRATING,

--- a/apps/backend/src/core/uploads/uploads.ts
+++ b/apps/backend/src/core/uploads/uploads.ts
@@ -25,6 +25,7 @@ import { config } from '../../config.js'
 import { blockstoreRepository } from '../../infrastructure/repositories/uploads/blockstore.js'
 import { BlockstoreUseCases } from './blockstore.js'
 import { createLogger } from '../../infrastructure/drivers/logger.js'
+import { sendMetricToVictoria } from '../../infrastructure/drivers/vmetrics.js'
 import {
   BadRequestError,
   ForbiddenError,
@@ -311,20 +312,29 @@ const completeUpload = async (
 
   // completeUpload is NOT idempotent, so it must run at most once per upload.
   // completeUploadProcessing re-derives the root IPLD node and writes it to
-  // uploads.blockstore on every call (blockstore.put -> plain INSERT, no unique
-  // key on (upload_id, cid)), and handleFileUploadFinalization re-runs
-  // registerInteraction. A second call therefore leaves a duplicate root node —
-  // which used to make getFileUploadIdCID, and so every future migration
-  // attempt, fail permanently — and double-charges upload credits. A client
-  // retry after a timeout, a double submit, or a proxy retry is enough to
-  // trigger it; only `abortUpload` guarded its status before this.
+  // uploads.blockstore on every call, and handleFileUploadFinalization re-runs
+  // registerInteraction. A second call therefore used to leave a duplicate root
+  // node — which made getFileUploadIdCID, and so every future migration attempt,
+  // fail permanently — and it still double-charges upload credits. A client retry
+  // after a timeout, a double submit, or a proxy retry is enough to trigger it;
+  // only `abortUpload` guarded its status before this.
+  //
+  // The duplicate root node is now also prevented one layer down
+  // (blockstore_root_node_unique_idx + ON CONFLICT DO NOTHING), which covers the
+  // holes this claim cannot: a claim that goes stale under a still-running
+  // completion, and old processes during a rolling deploy. The credit charge has
+  // no such backstop, so this guard is still the load-bearing one.
   //
   // A repeat call on an already-completed upload is treated as a no-op that
   // returns the existing CID, and re-drives migration in case the original
   // one-shot migrate task was lost — the retry heals the upload instead of
   // corrupting it.
   if (upload.status === UploadStatus.MIGRATING) {
-    return resolveAlreadyCompletedUpload(upload, uploadId)
+    // Already MIGRATING before this call, so the one-shot migrate task may have
+    // been enqueued long ago and lost; re-drive it.
+    return resolveAlreadyCompletedUpload(upload, uploadId, {
+      redriveMigration: true,
+    })
   }
   if (
     upload.status !== UploadStatus.PENDING &&
@@ -335,7 +345,7 @@ const completeUpload = async (
       upload.status,
       uploadId,
     )
-    throw new Error(`Upload ${uploadId} is ${upload.status}`)
+    throw new BadRequestError(`Upload ${uploadId} is ${upload.status}`)
   }
 
   // The status read above is not a guard on its own — two overlapping calls
@@ -357,7 +367,14 @@ const completeUpload = async (
     if (current.status === UploadStatus.MIGRATING) {
       // The winner finished the whole completion — an easy window to hit for a
       // small upload. This call is then just a retry of a completed upload.
-      return resolveAlreadyCompletedUpload(current, uploadId)
+      //
+      // No re-drive here: the winner reached MIGRATING while this call was in
+      // flight, so it has just enqueued the migrate task itself. Re-driving
+      // would be a guaranteed-duplicate enqueue on every concurrent retry, and
+      // the task is too fresh to be a lost one.
+      return resolveAlreadyCompletedUpload(current, uploadId, {
+        redriveMigration: false,
+      })
     }
     if (current.status === UploadStatus.PENDING) {
       // The winner failed and released the claim (e.g. insufficient credits, or
@@ -389,13 +406,23 @@ const completeUpload = async (
     }
   }
 
+  // Re-read now that the claim is held. The snapshot taken before the CAS can be
+  // stale — a sibling call may have run and released a failed completion in
+  // between — and finalizeCompletedUpload writes the whole row back through
+  // updateUploadEntry (file_tree, mime_type, upload_options), so a stale
+  // snapshot would revert any of those a concurrent writer had changed. Nothing
+  // in the completion path edits them today, which makes this a latent hazard
+  // rather than a live bug; one query removes it.
+  const claimedUpload =
+    (await uploadsRepository.getUploadEntryById(uploadId)) ?? upload
+
   try {
     // FILE uploads: drain any not-yet-processed chunks and reject on a gap before
     // finalising. Folder uploads have no file_processing_info row and finalise
     // via processFolderUpload instead. Both steps share one lock; the lockless
     // helpers are used because the lock-acquiring path would deadlock here
     // (withDrainLock is not reentrant).
-    if (upload.type === UploadType.FILE) {
+    if (claimedUpload.type === UploadType.FILE) {
       await withDrainLock(uploadId, async () => {
         await drainLoop(uploadId)
         await assertNoUnprocessedParts(uploadId)
@@ -403,21 +430,21 @@ const completeUpload = async (
     }
 
     const cid =
-      await UploadFileProcessingUseCase.completeUploadProcessing(upload)
+      await UploadFileProcessingUseCase.completeUploadProcessing(claimedUpload)
 
-    if (upload.type === UploadType.FILE) {
+    if (claimedUpload.type === UploadType.FILE) {
       await UploadFileProcessingUseCase.handleFileUploadFinalization(
         user,
         uploadId,
       )
-    } else if (upload.type === UploadType.FOLDER) {
+    } else if (claimedUpload.type === UploadType.FOLDER) {
       await UploadFileProcessingUseCase.handleFolderUploadFinalization(
         user,
         uploadId,
       )
     }
 
-    return await finalizeCompletedUpload(upload, uploadId, cid)
+    return await finalizeCompletedUpload(claimedUpload, uploadId, cid)
   } catch (error) {
     // Hand the upload back so the client can retry — a failed completion (e.g.
     // insufficient credits, or a gap in the stored parts) must not leave the row
@@ -437,21 +464,33 @@ const completeUpload = async (
 }
 
 // A repeat completeUpload call for an upload that already finished is a no-op
-// that returns the existing CID, and re-drives migration in case the original
-// one-shot migrate task was lost — so the retry heals the upload instead of
-// corrupting it. Reached both when the status read sees MIGRATING and when the
-// completion claim is lost to a winner that has already finished.
+// that returns the existing CID. Reached both when the status read sees
+// MIGRATING and when the completion claim is lost to a winner that has already
+// finished.
+//
+// redriveMigration re-enqueues the migrate task in case the original one-shot
+// one was lost, so the retry heals the upload instead of corrupting it. It is
+// off for the claim-lost path, where the winner has only just enqueued its own
+// task and a re-drive would be a guaranteed duplicate; the recovery sweep
+// (migrationRecovery) is the backstop there. Where it is on, the enqueue rate is
+// bounded by how often the client retries, and duplicates are harmless — migrate
+// clears the root's nodes before re-inserting and processMigration skips a
+// concurrent run for the same upload.
 const resolveAlreadyCompletedUpload = async (
   upload: UploadEntry,
   uploadId: string,
+  { redriveMigration }: { redriveMigration: boolean },
 ): Promise<string> => {
   const cid = cidToString(await BlockstoreUseCases.getUploadCID(uploadId))
+  const isRootUpload = upload.root_upload_id === uploadId
+  const willRedrive = redriveMigration && isRootUpload
   logger.warn(
-    'completeUpload called on an already-completed upload; re-driving migration (uploadId=%s, cid=%s)',
+    'completeUpload called on an already-completed upload (uploadId=%s, cid=%s, redrivingMigration=%s)',
     uploadId,
     cid,
+    willRedrive,
   )
-  if (upload.root_upload_id === uploadId) {
+  if (willRedrive) {
     await scheduleNodeMigration(uploadId)
   }
   return cid
@@ -735,6 +774,25 @@ const processMigration = async (uploadId: string): Promise<void> => {
         'Migration is unrecoverable, parking upload as failed (uploadId=%s)',
         uploadId,
       )
+      // Parking silences the dead-letter loop, which means it also silences the
+      // only signal that anything is wrong: a FAILED upload keeps its rows, is
+      // no longer swept, and reports the same in-progress-looking state to the
+      // client as a healthy one. Unbounded-but-visible was how this incident got
+      // noticed at all; emit a counter so unbounded-and-invisible does not
+      // replace it. Fire-and-forget, like every other metric call — a monitoring
+      // failure must not turn an acked park back into a throw.
+      sendMetricToVictoria({
+        measurement: 'auto_drive_upload_migration_unrecoverable',
+        tags: {
+          chain: config.monitoring.metricEnvironmentTag,
+        },
+        // uploadId is a field, not a tag, deliberately: it is unbounded
+        // cardinality and would blow up the series count if indexed.
+        fields: {
+          count: 1,
+          uploadId,
+        },
+      })
       await uploadsRepository
         .updateUploadStatusByRootUploadId(uploadId, UploadStatus.FAILED)
         .catch((updateError) =>

--- a/apps/backend/src/core/uploads/uploads.ts
+++ b/apps/backend/src/core/uploads/uploads.ts
@@ -324,16 +324,7 @@ const completeUpload = async (
   // one-shot migrate task was lost — the retry heals the upload instead of
   // corrupting it.
   if (upload.status === UploadStatus.MIGRATING) {
-    const cid = cidToString(await BlockstoreUseCases.getUploadCID(uploadId))
-    logger.warn(
-      'completeUpload called on an already-completed upload; re-driving migration (uploadId=%s, cid=%s)',
-      uploadId,
-      cid,
-    )
-    if (upload.root_upload_id === uploadId) {
-      await scheduleNodeMigration(uploadId)
-    }
-    return cid
+    return resolveAlreadyCompletedUpload(upload, uploadId)
   }
   if (
     upload.status !== UploadStatus.PENDING &&
@@ -355,9 +346,23 @@ const completeUpload = async (
     config.uploads.completionClaimStaleMs,
   )
   if (!claimed) {
+    // Losing the claim does not necessarily mean a completion is still running:
+    // the winner may have finished the whole thing between the status read above
+    // and this compare-and-swap, which for a small upload is an easy window to
+    // hit. Re-read before erroring so a retry of an already-successful
+    // completion still gets its CID instead of a spurious failure.
+    const current = await uploadsRepository.getUploadEntryById(uploadId)
+    if (!current) {
+      logger.warn('Upload not found (uploadId=%s)', uploadId)
+      throw new Error('Upload not found')
+    }
+    if (current.status === UploadStatus.MIGRATING) {
+      return resolveAlreadyCompletedUpload(current, uploadId)
+    }
     logger.warn(
-      'completeUpload is already in progress for this upload (uploadId=%s)',
+      'completeUpload could not claim the upload (uploadId=%s, status=%s)',
       uploadId,
+      current.status,
     )
     throw new BadRequestError(
       `Upload ${uploadId} is already being completed; retry once it finishes`,
@@ -409,6 +414,27 @@ const completeUpload = async (
       )
     throw error
   }
+}
+
+// A repeat completeUpload call for an upload that already finished is a no-op
+// that returns the existing CID, and re-drives migration in case the original
+// one-shot migrate task was lost — so the retry heals the upload instead of
+// corrupting it. Reached both when the status read sees MIGRATING and when the
+// completion claim is lost to a winner that has already finished.
+const resolveAlreadyCompletedUpload = async (
+  upload: UploadEntry,
+  uploadId: string,
+): Promise<string> => {
+  const cid = cidToString(await BlockstoreUseCases.getUploadCID(uploadId))
+  logger.warn(
+    'completeUpload called on an already-completed upload; re-driving migration (uploadId=%s, cid=%s)',
+    uploadId,
+    cid,
+  )
+  if (upload.root_upload_id === uploadId) {
+    await scheduleNodeMigration(uploadId)
+  }
+  return cid
 }
 
 const finalizeCompletedUpload = async (

--- a/apps/backend/src/core/uploads/uploads.ts
+++ b/apps/backend/src/core/uploads/uploads.ts
@@ -493,11 +493,20 @@ const resolveAlreadyCompletedUpload = async (
 ): Promise<string> => {
   const cid = cidToString(await BlockstoreUseCases.getUploadCID(uploadId))
   const isRootUpload = upload.root_upload_id === uploadId
-  const migratingForMs = Date.now() - new Date(upload.updated_at).getTime()
-  const isStale = migratingForMs >= config.migrationRecovery.stalenessMs
-  const willRedrive = redriveMigration && isRootUpload && isStale
+  // Age comes from Postgres, not from Date.now() against the parsed row: see
+  // getUploadAgeMs. Looked up only when a re-drive is otherwise on the table, so
+  // the claim-lost path — the one a client retry storm hammers, and the one that
+  // never re-drives — costs no extra query. A null age (the row vanished under
+  // us, or we never asked) is not a reason to re-drive anything.
+  const migratingForMs =
+    redriveMigration && isRootUpload
+      ? await uploadsRepository.getUploadAgeMs(uploadId)
+      : null
+  const willRedrive =
+    migratingForMs !== null &&
+    migratingForMs >= config.migrationRecovery.stalenessMs
   logger.warn(
-    'completeUpload called on an already-completed upload (uploadId=%s, cid=%s, migratingForMs=%d, redrivingMigration=%s)',
+    'completeUpload called on an already-completed upload (uploadId=%s, cid=%s, migratingForMs=%s, redrivingMigration=%s)',
     uploadId,
     cid,
     migratingForMs,
@@ -735,10 +744,18 @@ const abortUpload = async (
   // A LIVE completion stays non-abortable on purpose: it is not stranded, it is
   // working, and racing removeUploadArtifacts against it would pull rows out from
   // under a running DAG build.
+  //
+  // The age is computed by Postgres (see getUploadAgeMs) because getting it wrong
+  // in the positive direction breaks exactly the promise the paragraph above
+  // makes: a claim taken seconds ago would read as stale and this would tear down
+  // a live completion. Queried only for a COMPLETING row, so the common abort of a
+  // PENDING upload costs nothing extra.
+  const claimAgeMs =
+    upload.status === UploadStatus.COMPLETING
+      ? await uploadsRepository.getUploadAgeMs(uploadId)
+      : null
   const isStaleClaim =
-    upload.status === UploadStatus.COMPLETING &&
-    Date.now() - new Date(upload.updated_at).getTime() >=
-      config.uploads.completionClaimStaleMs
+    claimAgeMs !== null && claimAgeMs >= config.uploads.completionClaimStaleMs
   if (upload.status !== UploadStatus.PENDING && !isStaleClaim) {
     return err(new ObjectNotFoundError('Upload not found'))
   }

--- a/apps/backend/src/infrastructure/repositories/objects/nodes.ts
+++ b/apps/backend/src/infrastructure/repositories/objects/nodes.ts
@@ -38,6 +38,16 @@ const saveNode = async (node: Node) => {
 }
 
 const saveNodes = async (nodes: Node[]) => {
+  // Writing nothing has to mean nothing. pg-format expands `VALUES %L` over an
+  // empty array to the empty string, so the statement below would go to
+  // Postgres as `INSERT INTO nodes (...) VALUES ` and raise `syntax error at
+  // end of input` — an empty list is the one input that turns a no-op into a
+  // hard failure. Callers reach this legitimately (a migration batch whose every
+  // node was already written by an earlier batch), so absorb it here as well as
+  // at the call site: nothing else in this file has an arity-dependent SQL
+  // shape, and this is the layer that owns the shape.
+  if (nodes.length === 0) return
+
   const db = await getDatabase()
 
   return db.query({

--- a/apps/backend/src/infrastructure/repositories/uploads/blockstore.ts
+++ b/apps/backend/src/infrastructure/repositories/uploads/blockstore.ts
@@ -25,8 +25,20 @@ const addBlockstoreEntry = async (
 ) => {
   const db = await getDatabase()
 
+  // ON CONFLICT DO NOTHING makes writing a root node idempotent, which
+  // blockstore_root_node_unique_idx alone would not: with only the constraint, a
+  // completion that died after writing the root node but before flipping the
+  // upload to MIGRATING could never be retried — every retry would raise a
+  // unique violation and the upload would be stuck for good. Re-writing the same
+  // (upload_id, cid) is a no-op instead, so a retry proceeds and derives the same
+  // CID.
+  //
+  // The bare form (no conflict target) takes no action on a violation of *any*
+  // arbiter index, so it is scoped by the partial index: chunk rows are not
+  // covered by it and still insert unconditionally, which they must — a file with
+  // two identical chunks legitimately stores two rows with the same CID.
   await db.query(
-    'INSERT INTO uploads.blockstore (upload_id, cid, node_type, node_size, data) VALUES ($1, $2, $3, $4, $5)',
+    'INSERT INTO uploads.blockstore (upload_id, cid, node_type, node_size, data) VALUES ($1, $2, $3, $4, $5) ON CONFLICT DO NOTHING',
     [uploadId, cid, nodeType, nodeSize, data],
   )
 }

--- a/apps/backend/src/infrastructure/repositories/uploads/uploads.ts
+++ b/apps/backend/src/infrastructure/repositories/uploads/uploads.ts
@@ -92,6 +92,57 @@ export const updateUploadEntry = async (
   return result.rows[0]
 }
 
+/**
+ * Atomically claims a PENDING upload for completion, returning false if someone
+ * else holds the claim.
+ *
+ * A plain read-then-act guard in completeUpload is not enough: two overlapping
+ * calls for the same upload (a client timeout retry while the first is still in
+ * flight) would both read PENDING and both run the completion processing, each
+ * re-INSERTing the root blockstore node and re-charging credits. A single
+ * conditional UPDATE makes the transition a compare-and-swap, so exactly one
+ * caller can win regardless of how many API processes are running.
+ *
+ * A claim older than staleClaimMs is re-claimable so a process that died
+ * mid-completion does not strand the upload: COMPLETING is not selected by
+ * getStuckRootMigrations (correctly — there is no root node to migrate yet), so
+ * without this the row would never become completable again.
+ */
+export const claimUploadForCompletion = async (
+  id: string,
+  staleClaimMs: number,
+): Promise<boolean> => {
+  const db = await getDatabase()
+
+  const result = await db.query(
+    `UPDATE uploads.uploads
+     SET status = $2, updated_at = NOW()
+     WHERE id = $1
+       AND (
+         status = $3
+         OR (status = $2 AND updated_at < NOW() - ($4::bigint * INTERVAL '1 millisecond'))
+       )
+     RETURNING id`,
+    [id, UploadStatus.COMPLETING, UploadStatus.PENDING, staleClaimMs],
+  )
+
+  return result.rowCount === 1
+}
+
+// Releases a completion claim so the client can retry. Only ever moves a row we
+// still hold (COMPLETING) back to PENDING — never touches an upload that has
+// already reached MIGRATING or a terminal state.
+export const releaseUploadCompletionClaim = async (
+  id: string,
+): Promise<void> => {
+  const db = await getDatabase()
+
+  await db.query(
+    'UPDATE uploads.uploads SET status = $2, updated_at = NOW() WHERE id = $1 AND status = $3',
+    [id, UploadStatus.PENDING, UploadStatus.COMPLETING],
+  )
+}
+
 export const updateUploadStatusByRootUploadId = async (
   root_upload_id: string,
   status: UploadStatus,
@@ -232,6 +283,8 @@ export const uploadsRepository = {
   getUploadEntriesByRelativeId,
   getUploadsByStatus,
   getStatusByCID,
+  claimUploadForCompletion,
+  releaseUploadCompletionClaim,
   updateUploadStatusByRootUploadId,
   deleteEntriesByRootUploadId,
   getStuckRootMigrations,

--- a/apps/backend/src/infrastructure/repositories/uploads/uploads.ts
+++ b/apps/backend/src/infrastructure/repositories/uploads/uploads.ts
@@ -98,10 +98,11 @@ export const updateUploadEntry = async (
  *
  * A plain read-then-act guard in completeUpload is not enough: two overlapping
  * calls for the same upload (a client timeout retry while the first is still in
- * flight) would both read PENDING and both run the completion processing, each
- * re-INSERTing the root blockstore node and re-charging credits. A single
- * conditional UPDATE makes the transition a compare-and-swap, so exactly one
- * caller can win regardless of how many API processes are running.
+ * flight) would both read PENDING and both run the completion processing, which
+ * re-charges upload credits (and, before blockstore_root_node_unique_idx, also
+ * duplicated the root blockstore node). A single conditional UPDATE makes the
+ * transition a compare-and-swap, so exactly one caller can win regardless of how
+ * many API processes are running.
  *
  * A claim older than staleClaimMs is re-claimable so a process that died
  * mid-completion does not strand the upload: COMPLETING is not selected by

--- a/apps/backend/src/infrastructure/repositories/uploads/uploads.ts
+++ b/apps/backend/src/infrastructure/repositories/uploads/uploads.ts
@@ -14,6 +14,15 @@ export type UploadEntry = {
   oauth_provider: string
   oauth_user_id: string
   upload_options: FileUploadOptions | null
+  // Always selected (every read is SELECT *) but previously untyped. Typed now
+  // because callers need to reason about claim and migration age. Every status
+  // transition that anything waits on sets it explicitly — updateUploadEntry,
+  // claimUploadForCompletion, releaseUploadCompletionClaim,
+  // markMigrationRecoveryAttempt — since the set_timestamp trigger is AFTER
+  // UPDATE and therefore a no-op. The one exception is
+  // updateUploadStatusByRootUploadId (parking as FAILED), which leaves it stale;
+  // that is harmless because nothing selects FAILED rows by age.
+  updated_at: Date
 }
 
 export const createUploadEntry = async (

--- a/apps/backend/src/infrastructure/repositories/uploads/uploads.ts
+++ b/apps/backend/src/infrastructure/repositories/uploads/uploads.ts
@@ -14,14 +14,18 @@ export type UploadEntry = {
   oauth_provider: string
   oauth_user_id: string
   upload_options: FileUploadOptions | null
-  // Always selected (every read is SELECT *) but previously untyped. Typed now
-  // because callers need to reason about claim and migration age. Every status
+  // Always selected (every read is SELECT *) but previously untyped. Every status
   // transition that anything waits on sets it explicitly — updateUploadEntry,
   // claimUploadForCompletion, releaseUploadCompletionClaim,
   // markMigrationRecoveryAttempt — since the set_timestamp trigger is AFTER
   // UPDATE and therefore a no-op. The one exception is
   // updateUploadStatusByRootUploadId (parking as FAILED), which leaves it stale;
   // that is harmless because nothing selects FAILED rows by age.
+  //
+  // Do NOT compute an age from this in JS. The column is `timestamp` with no time
+  // zone, so node-postgres parses it in the process's zone while Postgres wrote
+  // it in the session's — see getUploadAgeMs, which is what every age comparison
+  // goes through.
   updated_at: Date
 }
 
@@ -137,6 +141,42 @@ export const claimUploadForCompletion = async (
   )
 
   return result.rowCount === 1
+}
+
+/**
+ * How long ago an upload's updated_at was stamped, in milliseconds, computed by
+ * Postgres.
+ *
+ * The subtraction has to happen in SQL. uploads.uploads.updated_at is `timestamp`
+ * with no time zone and every writer sets it with NOW(), so the stored value is
+ * the DB session's local wall clock; node-postgres then parses that string in the
+ * *process's* zone. `Date.now() - new Date(upload.updated_at).getTime()` is
+ * therefore only right while the two zones agree, and nothing pins TZ in the
+ * pool, the compose files or the Dockerfile — one DB string parses to 12:00:00Z,
+ * 11:00:00Z or 19:00:00Z under UTC, Europe/London and America/Los_Angeles.
+ *
+ * The consequences are not symmetric but both are bad. Under a positive offset
+ * every age reads too old, so a claim taken seconds ago looks stale and
+ * abortUpload would tear down a LIVE completion — precisely what it promises not
+ * to do. Under a negative offset nothing is ever stale, so a stranded COMPLETING
+ * row stays un-abortable and a migration re-drive never fires.
+ *
+ * Subtracting inside a single session cancels the zone out, which is what
+ * getStuckRootMigrations and claimUploadForCompletion already get for free by
+ * comparing in SQL. Returns null when the row does not exist.
+ */
+export const getUploadAgeMs = async (id: string): Promise<number | null> => {
+  const db = await getDatabase()
+
+  const result = await db.query<{ age_ms: string }>(
+    `SELECT EXTRACT(EPOCH FROM (NOW() - updated_at)) * 1000 AS age_ms
+     FROM uploads.uploads
+     WHERE id = $1`,
+    [id],
+  )
+
+  const ageMs = result.rows.at(0)?.age_ms
+  return ageMs === undefined ? null : Number(ageMs)
 }
 
 // Releases a completion claim so the client can retry. Only ever moves a row we
@@ -295,6 +335,7 @@ export const uploadsRepository = {
   getStatusByCID,
   claimUploadForCompletion,
   releaseUploadCompletionClaim,
+  getUploadAgeMs,
   updateUploadStatusByRootUploadId,
   deleteEntriesByRootUploadId,
   getStuckRootMigrations,

--- a/packages/models/src/uploads/upload.ts
+++ b/packages/models/src/uploads/upload.ts
@@ -15,6 +15,14 @@ export enum UploadType {
 
 export enum UploadStatus {
   PENDING = "pending",
+  // Completion is running: the root IPLD node is being derived and written.
+  // Claimed atomically so two concurrent completes cannot both process the same
+  // upload (which would duplicate the root blockstore node and double-charge
+  // credits). Deliberately distinct from MIGRATING, which the migration recovery
+  // sweep selects on — a still-completing upload has no root node yet and must
+  // not be re-driven. Rolled back to PENDING if completion fails, so a client
+  // can retry.
+  COMPLETING = "completing",
   MIGRATING = "migrating",
   CANCELLED = "cancelled",
   FAILED = "failed",


### PR DESCRIPTION
## Summary

The `frontend-errors` RabbitMQ queue crossed its 100-message alert threshold in production (332 → 350 while we were investigating), growing by exactly 6 messages every 30 minutes. This PR fixes the cause: **`completeUpload` is not idempotent**, so a retried complete call leaves an upload permanently unmigratable, and the migration recovery sweep then re-drives that broken upload forever, emitting one dead-letter message per upload per staleness window.

No data was lost — the affected payloads are intact in `uploads.blockstore`. This PR makes them migrate on the next sweep tick.

## How we got here

The alert:

```
[FIRING:1] RabbitMQ Queue Exceeds 100 Messages
Broker = auto-drive-rabbitmq-broker-primary
Queue  = frontend-errors      Value: B=332
```

### 1. `frontend-errors` is a terminal sink with no consumer

`Rabbit.subscribe` is typed to `'task-manager' | 'download-manager' | 'publish-manager'`, and `frontend-errors` is not one of them. `publish()` takes a plain `string`, so the code can write to that queue but is type-prevented from ever reading it. Anything landing there stays forever, so the depth is monotonic and the alert re-fires until someone drains it.

Messages arrive via `createHandlerWithRetries`: a failing task is re-published with `retriesLeft - 1`, and at zero it is published to the error queue with `retriesLeft` reset to `errorRetries` (3). Two consequences when reading the queue: the reset means you cannot tell how many attempts a message burned, and the error object is never included in the message — only the task. Only `logger.error(error, 'Task failed')` has the exception.

### 2. What was actually in the queue

Sampled on the production broker with `reject_requeue_true` (messages left in place):

```
324  migrate-upload-nodes   <- 6 uploadIds × 54 copies each
 14  publish-nodes          <- 7 node batches, older, not growing
  4  tag-upload
  1  recover-publishing
  1  reconcile-archival
```

94% is one bug repeated. The 14 `publish-nodes` messages are residue from before #794 moved on-chain publishing to `publish-manager`/`publish-errors`; they are not growing and are unrelated to this fix.

All six uploads are the same user's attempts at a 13-byte `test2.txt`, uploaded 2025-12-01 between 21:03 and 21:33 — six attempts in thirty minutes, i.e. someone retrying an upload that would not finish. All six were still `status = migrating` eight months later. No user was actively affected at the time of the alert; the growth was entirely a background sweep chewing on eight-month-old rows.

### 3. The failure

Each of those six uploads has **three duplicate `uploads.blockstore` rows** — same `cid`, same `node_type = 'File'`, same 13-byte payload. `getFileUploadIdCID` demanded exactly one:

```ts
if (blockstoreEntry.length !== 1) {
  throw new Error(`Invalid number of blockstore entries for file upload with id=${uploadId}`)
}
```

So `processMigration` → `getUploadCID` threw immediately, every time — a permanent data-shape problem where retrying can never help. Every root upload in `migrating` (6 of them; the other 65 `migrating` rows are non-root children) was broken this same way, all with `file_nodes = 3`.

### 4. Why the queue grew forever

1. `migrationRecoveryJob` (added in #797, deployed ~28h before the alert) enqueues `recover-migrations` every 5 minutes.
2. The sweep selects root uploads sitting in `migrating` past the 30-minute staleness window — all 6 qualify, every window.
3. Each `migrate-upload-nodes` fails, retries 3×, then dead-letters to `frontend-errors`.
4. The sweep stamps `updated_at = NOW()` on all six, so they go quiet for exactly one window and then requalify.

This was confirmed live rather than inferred: `updated_at` on all six read `18:46:40.509678`, then `19:16:40.516742` — 30 minutes apart to the millisecond, identical across all six rows — and the queue went 344 → 350 on that tick. 54 copies per upload ≈ 54 windows ≈ 27 hours, matching the #797 deploy.

#797 did not *create* the broken rows; it converted a silent stuck-row backlog into an unbounded visible dead-letter stream. Its docstring assumed "a successful migration deletes its upload rows, so recovered uploads drop out of the sweep automatically" — which never happens for an upload that can't migrate, and the sweep had no give-up counter or unrecoverable-state detection (unlike `publishingRecovery`, which already logs an `unrecoverable` bucket).

### 5. Root cause: `completeUpload` had no status precondition

`completeUpload` fetched the upload, checked permissions, and went straight into `completeUploadProcessing` — **with no check that the upload was still `PENDING`**, unlike `abortUpload` twenty lines above it. `completeFileProcessing` → `processBufferToIPLDFormatFromChunks` writes the root File node via `blockstore.put` → a bare `INSERT` with no `ON CONFLICT`, and `uploads.blockstore` has its primary key on the surrogate `sort_id` with only a **non-unique** btree `blockstore_upload_id_cid_index` on `(upload_id, cid)`.

So calling complete three times on one uploadId wrote the root File node three times. A client timeout retry, a double submit, or a proxy retry is enough — and it matches the evidence precisely (only the `File`-type root row is triplicated, not the chunk rows).

The same missing guard means a repeated complete also re-ran `handleFileUploadFinalization` → `AccountsUseCases.registerInteraction`, i.e. **it double-charged upload credits**. Worth checking `interactions` for duplicate rows on those six CIDs; trivial money at 13 bytes, but the path is general.

## What this PR changes

**1. `completeUpload` claims the upload atomically — the cause fix** (`core/uploads/uploads.ts`, `repositories/uploads/uploads.ts`, `packages/models`)

A repeat call on an already-`MIGRATING` upload is now a no-op that returns the existing CID and re-drives migration, so a client retry *heals* a stuck upload instead of corrupting it. This preserves S3 semantics: `CompleteMultipartUpload` is expected to succeed on retry, and both S3 call sites (`completeMultipartUpload`, `putObject`) get the right behavior. Any other terminal status is rejected. This also removes the duplicate credit debit.

A status *read* is not sufficient on its own, though — **thanks to Bugbot for catching this**: two overlapping calls (a client timeout retry while the first is still in flight) would both observe `PENDING` and both fall through into the processing, recreating the very shape this PR removes. Completion is therefore claimed with a conditional `UPDATE` (compare-and-swap) in `claimUploadForCompletion`, so exactly one caller proceeds no matter how many API processes are running.

Losing the claim is not proof that a completion is still running, though — **thanks to Cursor Bot for catching both of these**. The row is re-read on claim loss, and its state says which of four things happened while this call sat between its status read and the CAS:

| Re-read shows | Meaning | Outcome |
| --- | --- | --- |
| `MIGRATING` | winner finished the whole completion (an easy window to hit for a small upload) | return the existing CID and re-drive migration — same path as the fast path |
| row gone | a successful migration already removed the artifacts | not-found, exactly as the check at the top of the function |
| `PENDING` | winner failed and released the claim (insufficient credits, a gap in the stored parts) | nothing holds the claim, so re-attempt it **once** and do the work |
| `COMPLETING` / terminal | a completion really is in flight, or the upload is finished/cancelled | error, with the message reflecting the observed status |

The `PENDING` re-attempt is deliberately capped at one, so a sibling that keeps failing and releasing cannot turn this into a loop. Both already-completed entry points share `resolveAlreadyCompletedUpload`, so they cannot drift.

The claim uses a new `UploadStatus.COMPLETING` rather than flipping straight to `MIGRATING`, for two reasons:

- The migration recovery sweep selects on `MIGRATING`. A still-completing upload has no root node yet, so if the claim used `MIGRATING` the sweep could enqueue `migrate-upload-nodes` mid-completion — and with change (3) below that would park a perfectly healthy upload as `FAILED`. Any upload whose completion processing outlasts the 30-minute staleness window would hit this.
- `updated_at` must keep marking *`MIGRATING`-entry* for that staleness anchor (the invariant #797 relies on), which it does because the flip to `MIGRATING` still happens exactly where it did before, after finalization.

The claim is released back to `PENDING` when completion fails, so today's retry-after-failure behavior (e.g. `Not enough upload credits`) is unchanged, and a claim older than `UPLOAD_COMPLETION_CLAIM_STALE_MS` (default 1h) is re-claimable so a process dying mid-completion cannot strand the upload — nothing sweeps `COMPLETING`. `uploads.uploads.status` is plain `text`, so the new value needs **no DB migration**.

**2. Root-node CID lookup tolerates same-CID duplicates — recovers the six uploads** (`core/uploads/blockstore.ts`)

`getFileUploadIdCID`/`getFolderUploadIdCID` now resolve through a shared `getRootNodeCID` that keys on **distinct** CIDs rather than row count, logging a warning when duplicates are present. Zero rows, or genuinely different CIDs, still fail.

This is safe because migration already dedupes downstream — `migrateFromBlockstoreToNodesTable` builds `uniqueNodes` keyed by CID before `saveNodes`, so no duplicate `nodes` rows result. Deploying this lets all six production uploads migrate on the next sweep tick, with no manual row deletion and no data mutation.

**Deliberately not done: a unique index on `(upload_id, cid)`.** A file containing two identical chunks legitimately stores two rows with the same CID, and `processBufferToIPLDFormatFromChunks` iterates `getFilteredMany(FileChunk)` to build the DAG links — deduping there would silently corrupt such files (cf. `handleRepeatedNodes`). Tolerating duplicates at the root-node read site is the safe layer; the write path is fixed by (1). Per-chunk reads are untouched.

**3. Permanent failures are parked, not retried forever** (`core/uploads/errors.ts`, `core/uploads/uploads.ts`)

New `UnrecoverableUploadError` marks shapes that can never succeed (missing/ambiguous root node, deleted upload row). `processMigration` catches it, sets the upload tree to `FAILED` so `getStuckRootMigrations` stops selecting it, and acks the task instead of dead-lettering. Transient errors still throw and retry as before. `UploadStatus.FAILED` already exists in `@auto-drive/models`, so this needs no DB migration. Without this, the next differently-broken row reopens this incident.

**4. `FAILED` is not reported as success** (`core/objects/uploadStatus.ts`)

A `FAILED` upload still has its rows (only a successful migration removes artifacts) and no `nodes`, so the counting path would report 0 uploaded of 0 total — which reads as "fully published". `getUploadStatus` now returns the same all-null state it returns for in-progress uploads. Surfacing a genuine failed state to the user needs a new `ObjectUploadState` field plus frontend work; that is out of scope here.

## Tests

New `__tests__/unit/core/uploadCompletionIdempotency.spec.ts` (14 tests): complete-on-MIGRATING skips processing / returns the CID / re-drives migration; complete on a terminal status is rejected; a caller that loses the claim to a still-running winner never reaches the processing; a caller that loses the claim to an *already-finished* winner gets the CID and re-drives migration; a claim lost with the row gone reports not-found; a claim released back to `PENDING` is re-taken and processed; the re-attempt is capped at one; the winner claims *before* processing and only reaches `MIGRATING` after the root node exists; a failed completion releases the claim and never flips the status; duplicate same-CID root rows are accepted; ambiguous and missing root rows raise `UnrecoverableUploadError`; `processMigration` parks-and-acks an unrecoverable failure and still rethrows a transient one.

`__tests__/unit/useCases/uploads.spec.ts` — the existing concurrent-migration guard test asserted that a missing upload *rejects*; updated to the new park-and-resolve contract while still exercising the in-flight guard.

Verified locally: `yarn backend lint` clean, `tsc --noEmit` clean, and 30/37 unit suites pass (421 tests). The 7 failing suites are all DB-backed (`repositories/*`, `OnchainPublisher`, `objectModeration`) and fail identically on a clean tree in this sandbox — Docker/TestContainers is unavailable, so those and the e2e suites need CI.

## Rolling deploy note

An old process that sees `status = 'completing'` during a rolling deploy behaves exactly as it does today: `abortUpload` rejects it (it requires `PENDING`), and old `completeUpload` — which had no guard at all — would re-run processing on it, i.e. the pre-PR behavior for the duration of the rollout. `getUploadStatus` on old code reports a `COMPLETING` upload as 0-of-0 for that window. Nothing is corrupted that isn't already corruptible today, and the window closes when the rollout finishes.

## Deploy / follow-up

- After deploy, the six uploads migrate on the next sweep tick (≤30 min) and the queue stops growing. Only then is it safe to drain the 350 existing messages — purging first would refill within 30 minutes.
- **Ops, not code:** `frontend-errors` / `download-errors` / `publish-errors` are unbounded sinks with no consumer. They want `x-message-ttl` and `x-max-length`. Queue arguments are immutable in RabbitMQ, so on Amazon MQ this means delete-and-recreate after draining.
- Consider whether the alert should fire on queue *growth* rather than absolute depth, since a terminal sink's depth only ever rises.
- Known wart, pre-existing and left alone deliberately: on the REST route, `handleInternalError` flattens every thrown error into `InternalError`, so the new "already being completed" rejection surfaces as a 500 rather than a 4xx (the same is already true of the `BadRequestError` that `assertNoUnprocessedParts` throws). There is no Express error middleware, so on the S3 route it reaches the default handler. Worth fixing by preserving `HttpError` instances in `handleInternalError`, but that changes status codes across every route that uses it and does not belong in this fix.
- Nothing sweeps a stranded `COMPLETING` row before its 1h re-claim window; the equivalent today is a stranded `PENDING` row, which is equally unswept. A recovery pass for both is a reasonable follow-up.
- One correction for anyone debugging on the boxes: `/home/ubuntu/deploy/auto-drive` on the mainnet host is a stale checkout (`e0c47592`, 2026-06-23), which is why the deployed image looks "newer than git HEAD" and appears to contain code that isn't in the repo. `migrationRecovery.js`, `migrationRecoveryJob.js`, `recover-migrations`, and `publishWorker` are all on `main` (#794, #797). There is no unversioned code in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
