### PR TITLE
feat(intents): quote and lock a USDC purchase at creation

### DIFF
--- a/apps/backend/__tests__/unit/PaymentManager.spec.ts
+++ b/apps/backend/__tests__/unit/PaymentManager.spec.ts
@@ -94,12 +94,14 @@ describe('PaymentManager', () => {
       await paymentManager.watchTransaction(txHash)
 
       // The function should process the logs and attempt to mark intents,
-      // passing fromAddress captured from receipt.from.
+      // passing fromAddress captured from receipt.from and the tx hash, which is
+      // what a refused payment is recorded against for admin review.
       expect(markIntentSpy).toHaveBeenCalledTimes(1)
       expect(markIntentSpy).toHaveBeenCalledWith({
         intentId,
         paymentAmount,
         fromAddress,
+        txHash,
       })
     })
 

--- a/apps/backend/__tests__/unit/PaymentManager.spec.ts
+++ b/apps/backend/__tests__/unit/PaymentManager.spec.ts
@@ -482,6 +482,38 @@ describe('PaymentManager', () => {
 
       expect(onConfirmedSpy).toHaveBeenCalledTimes(3)
     })
+
+    // The case the two tests above do not cover: they return errors, and a
+    // returned error was always handled. A THROWN one used to escape the loop
+    // and abandon every intent behind it — users who paid correctly, skipped,
+    // every tick, for as long as the poison row sat in the batch.
+    it('should keep processing the batch when one intent throws', async () => {
+      const intents = [
+        { id: '0xbefore', userPublicId: 'user1', status: 'CONFIRMED' },
+        { id: '0xpoison', userPublicId: 'user2', status: 'CONFIRMED' },
+        { id: '0xafter', userPublicId: 'user3', status: 'CONFIRMED' },
+      ] as any[]
+
+      jest
+        .spyOn(IntentsUseCases, 'getConfirmedIntents')
+        .mockResolvedValue(intents)
+
+      const onConfirmedSpy = jest
+        .spyOn(IntentsUseCases, 'onConfirmedIntent')
+        .mockResolvedValueOnce(ok(undefined))
+        // What a zero shannonsPerByte produces: BigInt division by zero throws
+        // a RangeError rather than returning an err().
+        .mockRejectedValueOnce(new RangeError('Division by zero'))
+        .mockResolvedValueOnce(ok(undefined))
+
+      await expect(
+        paymentManager._checkConfirmedIntents(),
+      ).resolves.not.toThrow()
+
+      // All three attempted, and specifically the one AFTER the thrower.
+      expect(onConfirmedSpy).toHaveBeenCalledTimes(3)
+      expect(onConfirmedSpy).toHaveBeenCalledWith('0xafter')
+    })
   })
 
   describe('start', () => {

--- a/apps/backend/__tests__/unit/repositories/intentMispayments.spec.ts
+++ b/apps/backend/__tests__/unit/repositories/intentMispayments.spec.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeAll, afterAll } from '@jest/globals'
+import { intentMispaymentsRepository } from '../../../src/infrastructure/repositories/users/intentMispayments.js'
+import { IntentMispaymentReason, PaymentMethod } from '@auto-drive/models'
+import { dbMigration } from '../../utils/dbMigrate.js'
+
+// Exercises the table added by 20260812000000-intent-mispayments against the
+// migrated TestContainers Postgres (requires Docker), like the other repository
+// specs.
+describe('Intent Mispayments Repository', () => {
+  beforeAll(async () => {
+    await dbMigration.up()
+  })
+
+  afterAll(async () => {
+    await dbMigration.down()
+  })
+
+  it('round-trips an asset mismatch, keeping amounts as bigints', async () => {
+    const recorded = await intentMispaymentsRepository.record({
+      intentId: '0xusdc-intent',
+      reason: IntentMispaymentReason.ASSET_MISMATCH,
+      expectedPaymentMethod: PaymentMethod.USDC_ETH,
+      // An AI3 amount against a USDC intent — wide enough to prove
+      // numeric(78,0) carries it without going through a float.
+      paymentAmount: 5_000_000_000_000_000_000n,
+      fromAddress: '0xpayer',
+      txHash: '0xdeadbeef',
+    })
+
+    expect(recorded).not.toBeNull()
+    expect(recorded!.reason).toBe(IntentMispaymentReason.ASSET_MISMATCH)
+    expect(recorded!.expectedPaymentMethod).toBe(PaymentMethod.USDC_ETH)
+    expect(recorded!.paymentAmount).toBe(5_000_000_000_000_000_000n)
+    expect(typeof recorded!.paymentAmount).toBe('bigint')
+    // Exactly one amount is set, and which one is the evidence of what happened.
+    expect(recorded!.tokenAmount).toBeUndefined()
+    expect(recorded!.createdAt).toBeInstanceOf(Date)
+  })
+
+  it('records an unknown intent id, which has no expected asset', async () => {
+    const recorded = await intentMispaymentsRepository.record({
+      intentId: '0xnosuchintent',
+      reason: IntentMispaymentReason.UNKNOWN_INTENT,
+      tokenAmount: 3_045_000n,
+      txHash: '0xfeedface',
+    })
+
+    expect(recorded!.reason).toBe(IntentMispaymentReason.UNKNOWN_INTENT)
+    // No intent row exists, so there is no asset it was supposed to be.
+    expect(recorded!.expectedPaymentMethod).toBeUndefined()
+    expect(recorded!.tokenAmount).toBe(3_045_000n)
+  })
+
+  it('does not duplicate a mispayment the watcher re-delivers', async () => {
+    // Reorgs re-emit events and the startup sweep replays every PENDING intent
+    // with a tx_hash. A second sighting of one transfer must not become a second
+    // row — an admin queue that grows on every restart is one nobody reads.
+    const first = await intentMispaymentsRepository.record({
+      intentId: '0xreplayed',
+      reason: IntentMispaymentReason.ASSET_MISMATCH,
+      expectedPaymentMethod: PaymentMethod.USDC_ETH,
+      paymentAmount: 1n,
+      txHash: '0xsamehash',
+    })
+    const second = await intentMispaymentsRepository.record({
+      intentId: '0xreplayed',
+      reason: IntentMispaymentReason.ASSET_MISMATCH,
+      expectedPaymentMethod: PaymentMethod.USDC_ETH,
+      paymentAmount: 1n,
+      txHash: '0xsamehash',
+    })
+
+    expect(first).not.toBeNull()
+    // Null is the ON CONFLICT path: already on file.
+    expect(second).toBeNull()
+
+    const listed = await intentMispaymentsRepository.list()
+    expect(listed.filter((m) => m.intentId === '0xreplayed')).toHaveLength(1)
+  })
+
+  it('keeps one transaction paying two different intents apart', async () => {
+    // The constraint is per (transaction, intent), not per transaction: one tx
+    // can carry payments for more than one intent id.
+    await intentMispaymentsRepository.record({
+      intentId: '0xintent-a',
+      reason: IntentMispaymentReason.UNKNOWN_INTENT,
+      paymentAmount: 1n,
+      txHash: '0xmultipay',
+    })
+    await intentMispaymentsRepository.record({
+      intentId: '0xintent-b',
+      reason: IntentMispaymentReason.UNKNOWN_INTENT,
+      paymentAmount: 2n,
+      txHash: '0xmultipay',
+    })
+
+    const listed = await intentMispaymentsRepository.list()
+    expect(listed.filter((m) => m.txHash === '0xmultipay')).toHaveLength(2)
+  })
+
+  it('lists newest first', async () => {
+    const listed = await intentMispaymentsRepository.list()
+    expect(listed.length).toBeGreaterThan(1)
+    for (let i = 1; i < listed.length; i++) {
+      expect(listed[i - 1].createdAt.getTime()).toBeGreaterThanOrEqual(
+        listed[i].createdAt.getTime(),
+      )
+    }
+  })
+})

--- a/apps/backend/__tests__/unit/repositories/intents.spec.ts
+++ b/apps/backend/__tests__/unit/repositories/intents.spec.ts
@@ -28,11 +28,13 @@ describe('Intents Repository — payment fields', () => {
     expect(created.paymentMethod).toBe(PaymentMethod.AI3_NATIVE)
     expect(created.tokenAmount).toBeUndefined()
     expect(created.quotedTokenAmount).toBeUndefined()
+    expect(created.quotedAi3Shannons).toBeUndefined()
     expect(created.usdRateAtCreation).toBeUndefined()
 
     const fetched = await intentsRepository.getById('ai3-1')
     expect(fetched?.paymentMethod).toBe(PaymentMethod.AI3_NATIVE)
     expect(fetched?.tokenAmount).toBeUndefined()
+    expect(fetched?.quotedAi3Shannons).toBeUndefined()
   })
 
   it('round-trips a USDC intent with token amounts and locked rate as bigints', async () => {
@@ -41,6 +43,9 @@ describe('Intents Repository — payment fields', () => {
       paymentMethod: PaymentMethod.USDC_ETH,
       tokenAmount: 5_000_000n, // 5 USDC (6 decimals)
       quotedTokenAmount: 5_000_000n,
+      // The AI3 the quote was priced for. Wide enough to prove numeric(78,0)
+      // carries it without going through a float.
+      quotedAi3Shannons: 45_312_499_999_999_996_723_200n,
       usdRateAtCreation: 6_400_000_000_000_000n, // 0.0064 USD/AI3 * 1e18
     }
     await intentsRepository.createIntent(usdcIntent)
@@ -49,6 +54,8 @@ describe('Intents Repository — payment fields', () => {
     expect(fetched?.paymentMethod).toBe(PaymentMethod.USDC_ETH)
     expect(fetched?.tokenAmount).toBe(5_000_000n)
     expect(fetched?.quotedTokenAmount).toBe(5_000_000n)
+    expect(fetched?.quotedAi3Shannons).toBe(45_312_499_999_999_996_723_200n)
+    expect(typeof fetched?.quotedAi3Shannons).toBe('bigint')
     expect(fetched?.usdRateAtCreation).toBe(6_400_000_000_000_000n)
     expect(typeof fetched?.usdRateAtCreation).toBe('bigint')
   })
@@ -59,6 +66,7 @@ describe('Intents Repository — payment fields', () => {
       paymentMethod: PaymentMethod.USDC_ETH,
       tokenAmount: 1_000_000n,
       quotedTokenAmount: 1_000_000n,
+      quotedAi3Shannons: 3_000_000_000_000n,
       usdRateAtCreation: 6_400_000_000_000_000n,
     }
     await intentsRepository.createIntent(usdcIntent)
@@ -68,6 +76,12 @@ describe('Intents Repository — payment fields', () => {
 
     // Mirrors how the use cases update intents: spread the loaded row, override
     // only the changed field. The token/method fields must survive untouched.
+    //
+    // This is the test that catches the trap in updateIntent: the statement
+    // rewrites the full column list, so a column added to the table but missed
+    // there is silently nulled on the first status transition — invisible until
+    // credits come out wrong, because the intent still looks complete at
+    // creation.
     await intentsRepository.updateIntent({
       ...(loaded as Intent),
       status: IntentStatus.CONFIRMED,
@@ -79,7 +93,40 @@ describe('Intents Repository — payment fields', () => {
     expect(updated?.paymentMethod).toBe(PaymentMethod.USDC_ETH)
     expect(updated?.tokenAmount).toBe(1_000_000n)
     expect(updated?.quotedTokenAmount).toBe(1_000_000n)
+    expect(updated?.quotedAi3Shannons).toBe(3_000_000_000_000n)
     expect(updated?.usdRateAtCreation).toBe(6_400_000_000_000_000n)
   })
 
+  it('keeps the quote pair exact across a full create/update/read cycle', async () => {
+    // Not a duplicate of the round-trip above: this asserts the two numbers still
+    // reproduce the requested size after a database round trip, which is the
+    // property the credit conversion depends on. numeric(78,0) mapped through a
+    // float anywhere in that path would break it while both columns still looked
+    // populated.
+    const requestedBytes = 1_073_741_824n
+    const shannonsPerByte = 422_005_541_622n
+    const quotedAi3Shannons = requestedBytes * shannonsPerByte
+
+    await intentsRepository.createIntent({
+      ...baseIntent('usdc-3'),
+      shannonsPerByte,
+      paymentMethod: PaymentMethod.USDC_ETH,
+      quotedTokenAmount: 3_045_000_000n,
+      quotedAi3Shannons,
+      usdRateAtCreation: 6_400_000_000_000_000n,
+    })
+
+    const loaded = await intentsRepository.getById('usdc-3')
+    await intentsRepository.updateIntent({
+      ...(loaded as Intent),
+      status: IntentStatus.CONFIRMED,
+      tokenAmount: 3_045_000_000n, // paid exactly what was quoted
+    })
+
+    const confirmed = (await intentsRepository.getById('usdc-3')) as Intent
+    const shannons =
+      (confirmed.tokenAmount! * confirmed.quotedAi3Shannons!) /
+      confirmed.quotedTokenAmount!
+    expect(shannons / confirmed.shannonsPerByte).toBe(requestedBytes)
+  })
 })

--- a/apps/backend/__tests__/unit/useCases/intents.spec.ts
+++ b/apps/backend/__tests__/unit/useCases/intents.spec.ts
@@ -11,10 +11,15 @@ import {
   CreditCapExceededError,
   ForbiddenError,
   GoneError,
+  ObjectNotFoundError,
   QuoteErrorCode,
   QuoteFailedError,
+  ServiceUnavailableError,
+  UsdcPaymentsDisabledError,
 } from '../../../src/errors/index.js'
+import { intentMispaymentsRepository } from '../../../src/infrastructure/repositories/users/intentMispayments.js'
 import {
+  IntentMispaymentReason,
   IntentStatus,
   PaymentMethod,
   UserRole,
@@ -69,13 +74,21 @@ describe('IntentsUseCases', () => {
       } as PurchasedCreditSummary)
   }
 
+  // Paying in USDC is gated (featureFlags.payWithUsdc). Almost every test below
+  // is about what a quote contains rather than about who may ask for one, so the
+  // flag is opened here and the gate itself is tested separately.
+  const usdcFlag = config.featureFlags.flags.payWithUsdc
+  const usdcFlagDefault = usdcFlag.active
+
   beforeEach(() => {
     jest.clearAllMocks()
     jest.spyOn(IntentsUseCases, 'getPrice').mockResolvedValue({ price: 1, pricePerGB: 1073741824 })
+    usdcFlag.active = true
   })
 
   afterEach(() => {
     jest.restoreAllMocks()
+    usdcFlag.active = usdcFlagDefault
   })
 
   // ────────────────────────────────────────────────────────────────────────────
@@ -277,6 +290,108 @@ describe('IntentsUseCases', () => {
       config.credits.usdQuoteMarginPercent,
     )
 
+  // ────────────────────────────────────────────────────────────────────────────
+  // The payWithUsdc gate
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('createIntent refuses USDC when the flag is off', async () => {
+    usdcFlag.active = false
+    const accountSpy = jest.spyOn(AccountsUseCases, 'getOrCreateAccount')
+    const priceSpy = jest.spyOn(IntentsUseCases, 'getPrice')
+    const rateSpy = jest.spyOn(priceOracle, 'getPrice')
+    const createSpy = jest.spyOn(intentsRepository, 'createIntent')
+
+    const result = await IntentsUseCases.createIntent(orgUser, {
+      requestedBytes: 1000n,
+      paymentMethod: PaymentMethod.USDC_ETH,
+    })
+
+    expect(result.isErr()).toBe(true)
+    const error = result._unsafeUnwrapErr()
+    expect(error).toBeInstanceOf(UsdcPaymentsDisabledError)
+    expect((error as UsdcPaymentsDisabledError).statusCode).toBe(403)
+    // Refused before anything is read, priced or written: a caller who cannot
+    // use the asset costs nothing to turn away.
+    expect(accountSpy).not.toHaveBeenCalled()
+    expect(priceSpy).not.toHaveBeenCalled()
+    expect(rateSpy).not.toHaveBeenCalled()
+    expect(createSpy).not.toHaveBeenCalled()
+  })
+
+  it('createIntent lets an admin pay in USDC while the flag is off', async () => {
+    // The point of the exemption: the path stays exercisable against production
+    // while it is shut to everyone else.
+    usdcFlag.active = false
+    mockPurchasedBalance(0n)
+    mockPrice()
+    const createSpy = jest
+      .spyOn(intentsRepository, 'createIntent')
+      .mockImplementation(async (intent) => intent)
+
+    const admin = {
+      ...orgUser,
+      role: UserRole.Admin,
+    } as unknown as UserWithOrganization
+
+    const result = await IntentsUseCases.createIntent(admin, {
+      requestedBytes: 1000n,
+      paymentMethod: PaymentMethod.USDC_ETH,
+    })
+
+    expect(result.isOk()).toBe(true)
+    expect(createSpy.mock.calls[0][0].quotedTokenAmount).toBe(
+      expectedCharge(1000n),
+    )
+  })
+
+  it('createIntent is unaffected by the USDC flag on the AI3 path', async () => {
+    usdcFlag.active = false
+    const createSpy = jest
+      .spyOn(intentsRepository, 'createIntent')
+      .mockImplementation(async (intent) => intent)
+
+    const result = await IntentsUseCases.createIntent(orgUser)
+
+    expect(result.isOk()).toBe(true)
+    expect(createSpy.mock.calls[0][0].paymentMethod).toBe(
+      PaymentMethod.AI3_NATIVE,
+    )
+  })
+
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('createIntent refuses to create an intent at a zero per-byte price', async () => {
+    // CREDITS_PRICE_MULTIPLIER=0, or a chain reporting a zero byte fee. Every
+    // payment against such an intent converts to 0 credits and lands in FAILED
+    // with the money kept, and on the USDC path the quote itself would be 0.
+    jest
+      .spyOn(IntentsUseCases, 'getPrice')
+      .mockResolvedValue({ price: 0, pricePerGB: 0 })
+    mockPurchasedBalance(0n)
+    const rateSpy = jest.spyOn(priceOracle, 'getPrice')
+    const createSpy = jest.spyOn(intentsRepository, 'createIntent')
+
+    for (const paymentMethod of [
+      PaymentMethod.AI3_NATIVE,
+      PaymentMethod.USDC_ETH,
+    ]) {
+      const result = await IntentsUseCases.createIntent(orgUser, {
+        requestedBytes: 1000n,
+        paymentMethod,
+      })
+
+      expect(result.isErr()).toBe(true)
+      const error = result._unsafeUnwrapErr()
+      // The request was fine; the deployment is not. 503, not 4xx.
+      expect(error).toBeInstanceOf(ServiceUnavailableError)
+      expect((error as ServiceUnavailableError).statusCode).toBe(503)
+    }
+
+    // No unpriceable intent is written, and no rate is fetched to price one.
+    expect(rateSpy).not.toHaveBeenCalled()
+    expect(createSpy).not.toHaveBeenCalled()
+  })
+
   it('createIntent requires requestedBytes when paying with USDC', async () => {
     const rateSpy = jest.spyOn(priceOracle, 'getPrice')
     const priceSpy = jest.spyOn(IntentsUseCases, 'getPrice')
@@ -435,10 +550,20 @@ describe('IntentsUseCases', () => {
   )
 
   it('createIntent treats an unrecognised quote failure as retryable, not as bad input', async () => {
+    // A reason added to OracleUnavailableReason after the mapping was written —
+    // the union has grown twice already. It must not fall through to a 4xx that
+    // tells the user to change a request that was fine.
     mockPurchasedBalance(0n)
     jest
       .spyOn(priceOracle, 'getPrice')
-      .mockResolvedValue(err(new Error('something new') as never))
+      .mockResolvedValue(
+        err(
+          new OracleUnavailableError(
+            'something new',
+            'a-guard-invented-later' as never,
+          ),
+        ),
+      )
 
     const result = await IntentsUseCases.createIntent(orgUser, {
       requestedBytes: 1000n,
@@ -712,6 +837,131 @@ describe('IntentsUseCases', () => {
     // Refused before the row is even read — confirming with nothing received
     // would surface later as a 0-credit FAILED row to diagnose backwards.
     expect(getByIdSpy).not.toHaveBeenCalled()
+  })
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Refused payments have to leave a durable record
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('markIntentAsConfirmed files a mispayment when the asset does not match', async () => {
+    const intent: Intent = {
+      id: '0xusdc-mispaid-recorded',
+      userPublicId: user.publicId,
+      status: IntentStatus.PENDING,
+      shannonsPerByte: 1n,
+      paymentMethod: PaymentMethod.USDC_ETH,
+      quotedTokenAmount: 1_050_000n,
+      quotedAi3Shannons: 1000n,
+    }
+    jest.spyOn(intentsRepository, 'getById').mockResolvedValue(intent)
+    const recordSpy = jest
+      .spyOn(intentMispaymentsRepository, 'record')
+      .mockResolvedValue(null)
+
+    const res = await IntentsUseCases.markIntentAsConfirmed({
+      intentId: intent.id,
+      paymentAmount: 5n * 10n ** 18n,
+      fromAddress: '0xpayer',
+      txHash: '0xdeadbeef',
+    })
+
+    expect(res.isErr()).toBe(true)
+    // Refusing is correct but resolves nothing on chain — the transfer happened.
+    // Everything needed to find it again has to be written down.
+    expect(recordSpy).toHaveBeenCalledWith({
+      intentId: intent.id,
+      reason: IntentMispaymentReason.ASSET_MISMATCH,
+      expectedPaymentMethod: PaymentMethod.USDC_ETH,
+      paymentAmount: 5n * 10n ** 18n,
+      tokenAmount: undefined,
+      fromAddress: '0xpayer',
+      txHash: '0xdeadbeef',
+    })
+  })
+
+  it('markIntentAsConfirmed files a mispayment for an unknown intent id', async () => {
+    // The case with the least other evidence: no intent row exists, so nothing
+    // anywhere else records that money arrived.
+    jest.spyOn(intentsRepository, 'getById').mockResolvedValue(null)
+    const recordSpy = jest
+      .spyOn(intentMispaymentsRepository, 'record')
+      .mockResolvedValue(null)
+
+    const res = await IntentsUseCases.markIntentAsConfirmed({
+      intentId: '0xnosuchintent',
+      paymentAmount: 5n * 10n ** 18n,
+      fromAddress: '0xpayer',
+      txHash: '0xfeedface',
+    })
+
+    expect(res.isErr()).toBe(true)
+    expect(res._unsafeUnwrapErr()).toBeInstanceOf(ObjectNotFoundError)
+    expect(recordSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        intentId: '0xnosuchintent',
+        reason: IntentMispaymentReason.UNKNOWN_INTENT,
+        txHash: '0xfeedface',
+      }),
+    )
+  })
+
+  it('markIntentAsConfirmed still refuses when the mispayment record cannot be written', async () => {
+    // Filing the paperwork must not change which error actually happened: the
+    // watcher would log the wrong cause, and on the startup-sweep path a throw
+    // here would abort the recovery of unrelated transactions.
+    jest.spyOn(intentsRepository, 'getById').mockResolvedValue(null)
+    jest
+      .spyOn(intentMispaymentsRepository, 'record')
+      .mockRejectedValue(new Error('db down'))
+
+    const res = await IntentsUseCases.markIntentAsConfirmed({
+      intentId: '0xnosuchintent',
+      paymentAmount: 1n,
+    })
+
+    expect(res.isErr()).toBe(true)
+    expect(res._unsafeUnwrapErr()).toBeInstanceOf(ObjectNotFoundError)
+  })
+
+  it('markIntentAsConfirmed files nothing when the payment is accepted', async () => {
+    const intent: Intent = {
+      id: '0xai3-fine',
+      userPublicId: user.publicId,
+      status: IntentStatus.PENDING,
+      shannonsPerByte: 1n,
+      paymentMethod: PaymentMethod.AI3_NATIVE,
+    }
+    jest.spyOn(intentsRepository, 'getById').mockResolvedValue(intent)
+    jest
+      .spyOn(intentsRepository, 'updateIntent')
+      .mockImplementation(async (i) => i)
+    const recordSpy = jest.spyOn(intentMispaymentsRepository, 'record')
+
+    const res = await IntentsUseCases.markIntentAsConfirmed({
+      intentId: intent.id,
+      paymentAmount: 5n * 10n ** 18n,
+    })
+
+    expect(res.isOk()).toBe(true)
+    expect(recordSpy).not.toHaveBeenCalled()
+  })
+
+  it('getMispayments is admin-only', async () => {
+    const listSpy = jest
+      .spyOn(intentMispaymentsRepository, 'list')
+      .mockResolvedValue([])
+
+    const denied = await IntentsUseCases.getMispayments(user)
+    expect(denied.isErr()).toBe(true)
+    expect(denied._unsafeUnwrapErr()).toBeInstanceOf(ForbiddenError)
+    expect(listSpy).not.toHaveBeenCalled()
+
+    const allowed = await IntentsUseCases.getMispayments({
+      ...user,
+      role: UserRole.Admin,
+    } as User)
+    expect(allowed.isOk()).toBe(true)
+    expect(listSpy).toHaveBeenCalled()
   })
 
   // ────────────────────────────────────────────────────────────────────────────

--- a/apps/backend/__tests__/unit/useCases/intents.spec.ts
+++ b/apps/backend/__tests__/unit/useCases/intents.spec.ts
@@ -627,6 +627,79 @@ describe('IntentsUseCases', () => {
     expect(updated.quotedAi3Shannons).toBe(1000n)
   })
 
+  it('markIntentAsConfirmed refuses an AI3 payment against a USDC intent', async () => {
+    // The live watcher reports every payIntent event as paymentAmount, and
+    // payIntent(bytes32) accepts ANY intent id — so this arrives as a well-formed
+    // call and nothing upstream rejects it.
+    const intent: Intent = {
+      id: '0xusdc-mispaid',
+      userPublicId: user.publicId,
+      status: IntentStatus.PENDING,
+      shannonsPerByte: 1n,
+      paymentMethod: PaymentMethod.USDC_ETH,
+      quotedTokenAmount: 1_050_000n,
+      quotedAi3Shannons: 1000n,
+    }
+    jest.spyOn(intentsRepository, 'getById').mockResolvedValue(intent)
+    const updateSpy = jest.spyOn(intentsRepository, 'updateIntent')
+
+    const res = await IntentsUseCases.markIntentAsConfirmed({
+      intentId: intent.id,
+      paymentAmount: 5n * 10n ** 18n,
+    })
+
+    expect(res.isErr()).toBe(true)
+    expect(res._unsafeUnwrapErr()).toBeInstanceOf(BadRequestError)
+    // Must not go CONFIRMED. Doing so would strand the row in the polling loop
+    // AND make the idempotency guard discard the user's real USDC payment.
+    expect(updateSpy).not.toHaveBeenCalled()
+  })
+
+  it('markIntentAsConfirmed refuses a token payment against an AI3 intent', async () => {
+    const intent: Intent = {
+      id: '0xai3-mispaid',
+      userPublicId: user.publicId,
+      status: IntentStatus.PENDING,
+      shannonsPerByte: 1n,
+      paymentMethod: PaymentMethod.AI3_NATIVE,
+    }
+    jest.spyOn(intentsRepository, 'getById').mockResolvedValue(intent)
+    const updateSpy = jest.spyOn(intentsRepository, 'updateIntent')
+
+    const res = await IntentsUseCases.markIntentAsConfirmed({
+      intentId: intent.id,
+      tokenAmount: 1_050_000n,
+    })
+
+    expect(res.isErr()).toBe(true)
+    expect(updateSpy).not.toHaveBeenCalled()
+  })
+
+  it('markIntentAsConfirmed still treats a duplicate event on a settled intent as a no-op', async () => {
+    // The asset check must not turn re-delivery into an error, or the watcher
+    // would retry a genuinely settled intent indefinitely.
+    const intent: Intent = {
+      id: '0xusdc-dup',
+      userPublicId: user.publicId,
+      status: IntentStatus.COMPLETED,
+      shannonsPerByte: 1n,
+      paymentMethod: PaymentMethod.USDC_ETH,
+      tokenAmount: 1_050_000n,
+      quotedTokenAmount: 1_050_000n,
+      quotedAi3Shannons: 1000n,
+    }
+    jest.spyOn(intentsRepository, 'getById').mockResolvedValue(intent)
+    const updateSpy = jest.spyOn(intentsRepository, 'updateIntent')
+
+    const res = await IntentsUseCases.markIntentAsConfirmed({
+      intentId: intent.id,
+      paymentAmount: 5n * 10n ** 18n,
+    })
+
+    expect(res.isOk()).toBe(true)
+    expect(updateSpy).not.toHaveBeenCalled()
+  })
+
   it('markIntentAsConfirmed refuses a confirmation carrying no amount at all', async () => {
     const getByIdSpy = jest.spyOn(intentsRepository, 'getById')
 
@@ -1085,7 +1158,7 @@ describe('IntentsUseCases', () => {
     expect(res.isErr()).toBe(true)
   })
 
-  it('onConfirmedIntent should error when payment amount is missing', async () => {
+  it('onConfirmedIntent marks a confirmed intent with no deposit FAILED instead of retrying it forever', async () => {
     const intent: Intent = {
       id: '0x10',
       userPublicId: user.publicId,
@@ -1094,10 +1167,44 @@ describe('IntentsUseCases', () => {
       shannonsPerByte: 1n,
     }
     jest.spyOn(intentsRepository, 'getById').mockResolvedValue(intent)
+    const updateSpy = jest
+      .spyOn(intentsRepository, 'updateIntent')
+      .mockResolvedValue({ ...intent, status: IntentStatus.FAILED })
 
     const res = await IntentsUseCases.onConfirmedIntent(intent.id)
 
-    expect(res.isErr()).toBe(true)
+    // Nothing writes the received-amount column after confirmation, so this can
+    // never resolve itself. Returning an error left the row CONFIRMED and
+    // _checkConfirmedIntents re-ran it every 30 seconds forever — payment kept,
+    // no credits, nothing in the admin queue.
+    expect(res.isOk()).toBe(true)
+    expect(updateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ id: intent.id, status: IntentStatus.FAILED }),
+    )
+  })
+
+  it('getIntentCredits returns 0 rather than throwing when shannonsPerByte is 0', () => {
+    // BigInt division by zero throws, and that exception would escape
+    // onConfirmedIntent and abort the whole polling tick rather than just this
+    // intent. Reachable via CREDITS_PRICE_MULTIPLIER=0.
+    for (const paymentMethod of [
+      PaymentMethod.AI3_NATIVE,
+      PaymentMethod.USDC_ETH,
+    ]) {
+      expect(
+        IntentsUseCases.getIntentCredits({
+          id: '0xzero',
+          userPublicId: user.publicId,
+          status: IntentStatus.CONFIRMED,
+          shannonsPerByte: 0n,
+          paymentMethod,
+          paymentAmount: 1_000n,
+          tokenAmount: 1_000n,
+          quotedTokenAmount: 1_000n,
+          quotedAi3Shannons: 1_000n,
+        }),
+      ).toBe(0n)
+    }
   })
 
   it('onConfirmedIntent should mark OVER_CAP (not retry) when cap is exceeded', async () => {

--- a/apps/backend/__tests__/unit/useCases/intents.spec.ts
+++ b/apps/backend/__tests__/unit/useCases/intents.spec.ts
@@ -11,6 +11,8 @@ import {
   CreditCapExceededError,
   ForbiddenError,
   GoneError,
+  QuoteErrorCode,
+  QuoteFailedError,
 } from '../../../src/errors/index.js'
 import {
   IntentStatus,
@@ -23,6 +25,15 @@ import {
   type UserWithOrganization,
 } from '@auto-drive/models'
 import { ok, err } from 'neverthrow'
+import { priceOracle } from '../../../src/infrastructure/services/priceOracle/index.js'
+import {
+  OracleUnavailableError,
+  type OraclePrice,
+} from '../../../src/infrastructure/services/priceOracle/types.js'
+import {
+  ai3ShannonsToUsdcBaseUnits,
+  applyMarginPercent,
+} from '../../../src/shared/utils/index.js'
 
 describe('IntentsUseCases', () => {
   const now = new Date()
@@ -137,14 +148,22 @@ describe('IntentsUseCases', () => {
       .spyOn(intentsRepository, 'createIntent')
       .mockImplementation(async (intent) => intent)
 
-    const result = await IntentsUseCases.createIntent(orgUser, 1_073_741_824n)
+    const result = await IntentsUseCases.createIntent(orgUser, {
+      requestedBytes: 1_073_741_824n,
+    })
 
     expect(result.isOk()).toBe(true)
-    // The size gates creation and is then discarded. Persisting it would store a
-    // number that reads like a balance and never agrees with one, since credits
-    // come from paymentAmount / shannonsPerByte.
+    // On the AI3 path the size gates creation and is then discarded. Persisting
+    // it would store a number that reads like a balance and never agrees with
+    // one, since credits come from paymentAmount / shannonsPerByte.
+    //
+    // The USDC path is different and deliberately so: it persists
+    // quotedAi3Shannons, which is the size times the locked price and therefore
+    // half of the rate the payment converts at. See the USDC group below.
     const created = createSpy.mock.calls[0][0]
     expect(Object.keys(created)).not.toContain('quotedBytes')
+    expect(created.quotedAi3Shannons).toBeUndefined()
+    expect(created.quotedTokenAmount).toBeUndefined()
   })
 
   it.each<[string, bigint]>([
@@ -160,7 +179,9 @@ describe('IntentsUseCases', () => {
       )
       const createSpy = jest.spyOn(intentsRepository, 'createIntent')
 
-      const result = await IntentsUseCases.createIntent(orgUser, requestedBytes)
+      const result = await IntentsUseCases.createIntent(orgUser, {
+        requestedBytes,
+      })
 
       expect(result.isErr()).toBe(true)
       expect(result._unsafeUnwrapErr()).toBeInstanceOf(BadRequestError)
@@ -177,7 +198,9 @@ describe('IntentsUseCases', () => {
       'getRemainingCredits',
     )
 
-    const result = await IntentsUseCases.createIntent(orgUser, cap + 1n)
+    const result = await IntentsUseCases.createIntent(orgUser, {
+      requestedBytes: cap + 1n,
+    })
 
     expect(result.isErr()).toBe(true)
     // A size that can never fit is malformed, not a headroom problem — and it
@@ -193,7 +216,9 @@ describe('IntentsUseCases', () => {
     const priceSpy = jest.spyOn(IntentsUseCases, 'getPrice')
     const createSpy = jest.spyOn(intentsRepository, 'createIntent')
 
-    const result = await IntentsUseCases.createIntent(orgUser, 101n)
+    const result = await IntentsUseCases.createIntent(orgUser, {
+      requestedBytes: 101n,
+    })
 
     expect(result.isErr()).toBe(true)
     const error = result._unsafeUnwrapErr()
@@ -213,7 +238,9 @@ describe('IntentsUseCases', () => {
       .spyOn(intentsRepository, 'createIntent')
       .mockImplementation(async (intent) => intent)
 
-    const result = await IntentsUseCases.createIntent(orgUser, 100n)
+    const result = await IntentsUseCases.createIntent(orgUser, {
+      requestedBytes: 100n,
+    })
 
     // Boundary must match the authoritative check in
     // createPurchasedCreditWithCapCheck, which uses `>`. A stricter pre-check
@@ -222,28 +249,48 @@ describe('IntentsUseCases', () => {
   })
 
   // ────────────────────────────────────────────────────────────────────────────
-  // createIntent — the size is required on the USDC path
-  //
-  // The asymmetry is the whole gate: optional on AI3 so the documented API-key
-  // flow keeps working, mandatory on USDC because that path cannot name an
-  // amount to charge without it. These pin both halves.
+  // createIntent — USDC quoting
   // ────────────────────────────────────────────────────────────────────────────
 
-  it('createIntent refuses a USDC intent with no requestedBytes', async () => {
+  const RATE = 6_400_000_000_000_000n // $0.0064/AI3, scaled 1e18
+
+  // What the oracle reports: one size-independent rate. There is no per-size
+  // quote to stub any more — the charge is this rate times the purchase, so
+  // these tests assert the arithmetic rather than a mocked pool answer.
+  const stubPrice = (overrides: Partial<OraclePrice> = {}): OraclePrice => ({
+    usdPerAi3: RATE,
+    asOf: new Date(),
+    fromCache: false,
+    stale: false,
+    ...overrides,
+  })
+
+  const mockPrice = (overrides: Partial<OraclePrice> = {}) =>
+    jest
+      .spyOn(priceOracle, 'getPrice')
+      .mockResolvedValue(ok(stubPrice(overrides)))
+
+  // The charge the code should arrive at, derived the same way production does.
+  const expectedCharge = (ai3Shannons: bigint, rate = RATE) =>
+    applyMarginPercent(
+      ai3ShannonsToUsdcBaseUnits(ai3Shannons, rate),
+      config.credits.usdQuoteMarginPercent,
+    )
+
+  it('createIntent requires requestedBytes when paying with USDC', async () => {
+    const rateSpy = jest.spyOn(priceOracle, 'getPrice')
     const priceSpy = jest.spyOn(IntentsUseCases, 'getPrice')
     const createSpy = jest.spyOn(intentsRepository, 'createIntent')
 
-    const result = await IntentsUseCases.createIntent(
-      orgUser,
-      undefined,
-      PaymentMethod.USDC_ETH,
-    )
+    const result = await IntentsUseCases.createIntent(orgUser, {
+      paymentMethod: PaymentMethod.USDC_ETH,
+    })
 
     expect(result.isErr()).toBe(true)
     expect(result._unsafeUnwrapErr()).toBeInstanceOf(BadRequestError)
-    // Refused before pricing and before any row exists — a USDC intent without
-    // a size is unquotable, not merely incomplete.
+    // Nothing may be priced, quoted or written without a size to quote for.
     expect(priceSpy).not.toHaveBeenCalled()
+    expect(rateSpy).not.toHaveBeenCalled()
     expect(createSpy).not.toHaveBeenCalled()
   })
 
@@ -252,32 +299,13 @@ describe('IntentsUseCases', () => {
       .spyOn(intentsRepository, 'createIntent')
       .mockImplementation(async (intent) => intent)
 
-    // The explicit default, spelled out: making the size mandatory on USDC must
-    // not make it mandatory on the path third-party API keys already call.
-    const result = await IntentsUseCases.createIntent(
-      orgUser,
-      undefined,
-      PaymentMethod.AI3_NATIVE,
-    )
+    // Making the size mandatory on USDC must not make it mandatory on the path
+    // third-party API keys already call.
+    const result = await IntentsUseCases.createIntent(orgUser, {
+      paymentMethod: PaymentMethod.AI3_NATIVE,
+    })
 
     expect(result.isOk()).toBe(true)
-  })
-
-  it('createIntent creates a USDC intent when a size is supplied', async () => {
-    mockPurchasedBalance(0n)
-    const createSpy = jest
-      .spyOn(intentsRepository, 'createIntent')
-      .mockImplementation(async (intent) => intent)
-
-    const result = await IntentsUseCases.createIntent(
-      orgUser,
-      1_073_741_824n,
-      PaymentMethod.USDC_ETH,
-    )
-
-    expect(result.isOk()).toBe(true)
-    // The method has to reach the row: it is what the payment manager routes on.
-    expect(createSpy.mock.calls[0][0].paymentMethod).toBe(PaymentMethod.USDC_ETH)
   })
 
   it('createIntent defaults an unspecified payment method to AI3', async () => {
@@ -291,6 +319,363 @@ describe('IntentsUseCases', () => {
     expect(createSpy.mock.calls[0][0].paymentMethod).toBe(
       PaymentMethod.AI3_NATIVE,
     )
+  })
+
+  it('createIntent charges for the AI3 value of the purchase, not the byte count', async () => {
+    mockPurchasedBalance(0n)
+    mockPrice()
+    const createSpy = jest
+      .spyOn(intentsRepository, 'createIntent')
+      .mockImplementation(async (intent) => intent)
+    // shannonsPerByte = 3 here, so the AI3 the purchase is worth — and what the
+    // rate gets applied to — is 1000 bytes * 3 = 3000 shannons.
+    jest
+      .spyOn(IntentsUseCases, 'getPrice')
+      .mockResolvedValue({ price: 3, pricePerGB: 1 })
+
+    const result = await IntentsUseCases.createIntent(orgUser, {
+      requestedBytes: 1000n,
+      paymentMethod: PaymentMethod.USDC_ETH,
+    })
+
+    expect(result.isOk()).toBe(true)
+    const created = createSpy.mock.calls[0][0]
+    expect(created.quotedAi3Shannons).toBe(3000n)
+    expect(created.quotedTokenAmount).toBe(expectedCharge(3000n))
+  })
+
+  it('createIntent persists the charge, what it was charged for, and the raw rate', async () => {
+    mockPurchasedBalance(0n)
+    mockPrice()
+    const createSpy = jest
+      .spyOn(intentsRepository, 'createIntent')
+      .mockImplementation(async (intent) => intent)
+
+    const result = await IntentsUseCases.createIntent(orgUser, {
+      requestedBytes: 1000n,
+      paymentMethod: PaymentMethod.USDC_ETH,
+    })
+
+    expect(result.isOk()).toBe(true)
+    const created = createSpy.mock.calls[0][0]
+    // The method has to reach the row: it is what the payment manager routes on.
+    expect(created.paymentMethod).toBe(PaymentMethod.USDC_ETH)
+    // shannonsPerByte is 1 from the default getPrice mock.
+    expect(created.quotedAi3Shannons).toBe(1000n)
+    // The rate applied to the purchase, then the margin on top.
+    expect(created.quotedTokenAmount).toBe(expectedCharge(1000n))
+    // The stored rate stays the raw oracle rate — display and reconciliation
+    // data, never the conversion rate.
+    expect(created.usdRateAtCreation).toBe(RATE)
+  })
+
+  it('createIntent does not read a rate until the cap pre-check has passed', async () => {
+    mockPurchasedBalance(cap - 100n)
+    const rateSpy = jest.spyOn(priceOracle, 'getPrice')
+    const createSpy = jest.spyOn(intentsRepository, 'createIntent')
+
+    const result = await IntentsUseCases.createIntent(orgUser, {
+      requestedBytes: 101n,
+      paymentMethod: PaymentMethod.USDC_ETH,
+    })
+
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(CreditCapExceededError)
+    // A subgraph round-trip is not spent on a purchase that cannot be granted.
+    expect(rateSpy).not.toHaveBeenCalled()
+    expect(createSpy).not.toHaveBeenCalled()
+  })
+
+  // Every refusal is a 503. None of them is about the size, because the rate is
+  // size-independent — asking for less can never turn one into a quote, and a
+  // 4xx would tell the user otherwise.
+  it.each<[string, Error, QuoteErrorCode]>([
+    [
+      'an unreadable source',
+      new OracleUnavailableError('gateway did not respond', 'gateway'),
+      QuoteErrorCode.ORACLE_UNAVAILABLE,
+    ],
+    [
+      'too few swaps to average',
+      new OracleUnavailableError('3 usable swaps', 'insufficient-samples'),
+      QuoteErrorCode.ORACLE_UNAVAILABLE,
+    ],
+    [
+      'a pool too thin to price from',
+      new OracleUnavailableError('180 USDC of depth', 'thin-liquidity'),
+      QuoteErrorCode.ORACLE_UNAVAILABLE,
+    ],
+    [
+      'a market that has re-priced past the window',
+      new OracleUnavailableError('newest fill is an outlier', 'market-moved'),
+      QuoteErrorCode.PRICE_UNSTABLE,
+    ],
+  ])(
+    'createIntent maps %s to a 503 with the right code',
+    async (_label, oracleError, expectedCode) => {
+      mockPurchasedBalance(0n)
+      jest
+        .spyOn(priceOracle, 'getPrice')
+        .mockResolvedValue(err(oracleError as OracleUnavailableError))
+      const createSpy = jest.spyOn(intentsRepository, 'createIntent')
+
+      const result = await IntentsUseCases.createIntent(orgUser, {
+        requestedBytes: 1000n,
+        paymentMethod: PaymentMethod.USDC_ETH,
+      })
+
+      expect(result.isErr()).toBe(true)
+      const error = result._unsafeUnwrapErr()
+      expect(error).toBeInstanceOf(QuoteFailedError)
+      expect((error as QuoteFailedError).statusCode).toBe(503)
+      expect((error as QuoteFailedError).code).toBe(expectedCode)
+      // A failed quote must not leave a PENDING intent with no price behind.
+      expect(createSpy).not.toHaveBeenCalled()
+    },
+  )
+
+  it('createIntent treats an unrecognised quote failure as retryable, not as bad input', async () => {
+    mockPurchasedBalance(0n)
+    jest
+      .spyOn(priceOracle, 'getPrice')
+      .mockResolvedValue(err(new Error('something new') as never))
+
+    const result = await IntentsUseCases.createIntent(orgUser, {
+      requestedBytes: 1000n,
+      paymentMethod: PaymentMethod.USDC_ETH,
+    })
+
+    const error = result._unsafeUnwrapErr() as QuoteFailedError
+    // Defaulting to 4xx would tell a user to change a request that was fine.
+    expect(error.statusCode).toBe(503)
+    expect(error.code).toBe(QuoteErrorCode.ORACLE_UNAVAILABLE)
+  })
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // The invariant this whole design exists to protect
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('paying exactly the quoted USDC amount grants exactly the requested bytes', async () => {
+    const requestedBytes = 1_073_741_824n // 1 GiB
+    const shannonsPerByte = 422_005_541_622n // realistic, from a $290/100GiB pool
+    mockPurchasedBalance(0n)
+    jest
+      .spyOn(IntentsUseCases, 'getPrice')
+      .mockResolvedValue({ price: Number(shannonsPerByte), pricePerGB: 1 })
+    mockPrice()
+    const createSpy = jest
+      .spyOn(intentsRepository, 'createIntent')
+      .mockImplementation(async (intent) => intent)
+
+    const created = await IntentsUseCases.createIntent(orgUser, {
+      requestedBytes,
+      paymentMethod: PaymentMethod.USDC_ETH,
+    })
+    expect(created.isOk()).toBe(true)
+    const intent = createSpy.mock.calls[0][0]
+
+    // The user pays precisely what they were quoted.
+    const credits = IntentsUseCases.getIntentCredits({
+      ...intent,
+      tokenAmount: intent.quotedTokenAmount,
+    })
+
+    // Exactly — not "close to". Any rounding here is money.
+    expect(credits).toBe(requestedBytes)
+  })
+
+  it('converting at the raw rate would over-credit by the margin — the regression this guards', () => {
+    const requestedBytes = 1_073_741_824n
+    const shannonsPerByte = 422_005_541_622n
+    const quotedAi3Shannons = requestedBytes * shannonsPerByte
+    const usdPerAi3 = RATE
+    // The charge is the raw rate plus the margin, and nothing else. Under the
+    // retired Quoter the gap also carried the swap fee and this size's own price
+    // impact; since #807 both live inside the rate, so the margin is the entire
+    // wedge — which makes it exactly what leaks if the raw rate is used to
+    // convert.
+    const quotedTokenAmount = applyMarginPercent(
+      ai3ShannonsToUsdcBaseUnits(quotedAi3Shannons, usdPerAi3),
+      config.credits.usdQuoteMarginPercent,
+    )
+
+    const intent: Intent = {
+      id: '0xusdc-drift',
+      userPublicId: user.publicId,
+      status: IntentStatus.CONFIRMED,
+      shannonsPerByte,
+      paymentMethod: PaymentMethod.USDC_ETH,
+      quotedTokenAmount,
+      quotedAi3Shannons,
+      usdRateAtCreation: usdPerAi3,
+      tokenAmount: quotedTokenAmount,
+    }
+
+    // Correct: the rate the user was actually charged at.
+    expect(IntentsUseCases.getIntentCredits(intent)).toBe(requestedBytes)
+
+    // Wrong: converting the same payment at the raw rate. The error is the whole
+    // margin, exactly — a rate is a scalar, so it scales with the amount rather
+    // than washing out on large purchases.
+    const viaRawRate =
+      (quotedTokenAmount * 10n ** 30n) / usdPerAi3 / shannonsPerByte
+    expect(viaRawRate).toBeGreaterThan(requestedBytes)
+    const overCreditBps =
+      ((viaRawRate - requestedBytes) * 10_000n) / requestedBytes
+    // USD_QUOTE_MARGIN is 5% by default; assert against the configured value so
+    // this keeps meaning "the margin" if it is ever retuned.
+    expect(overCreditBps).toBeGreaterThan(
+      BigInt(Math.floor(config.credits.usdQuoteMarginPercent * 100)) - 10n,
+    )
+  })
+
+  it('getIntentCredits returns 0 for a USDC intent missing any conversion input', () => {
+    const base: Intent = {
+      id: '0xusdc-partial',
+      userPublicId: user.publicId,
+      status: IntentStatus.CONFIRMED,
+      shannonsPerByte: 1n,
+      paymentMethod: PaymentMethod.USDC_ETH,
+      tokenAmount: 1_050_000n,
+      quotedTokenAmount: 1_050_000n,
+      quotedAi3Shannons: 1000n,
+    }
+
+    // Guessing at a rate would grant the wrong amount silently; 0 routes the
+    // intent to FAILED for admin review instead.
+    expect(
+      IntentsUseCases.getIntentCredits({ ...base, tokenAmount: undefined }),
+    ).toBe(0n)
+    expect(
+      IntentsUseCases.getIntentCredits({
+        ...base,
+        quotedTokenAmount: undefined,
+      }),
+    ).toBe(0n)
+    expect(
+      IntentsUseCases.getIntentCredits({
+        ...base,
+        quotedAi3Shannons: undefined,
+      }),
+    ).toBe(0n)
+  })
+
+  it('onConfirmedIntent grants credits for a USDC intent from tokenAmount', async () => {
+    const intent: Intent = {
+      id: '0xusdc-confirm',
+      userPublicId: user.publicId,
+      status: IntentStatus.CONFIRMED,
+      shannonsPerByte: 2n,
+      paymentMethod: PaymentMethod.USDC_ETH,
+      // 1000 shannons quoted for 1_050_000 base units; paying that exactly
+      // yields 1000 shannons, and at 2 shannons/byte that is 500 bytes.
+      quotedTokenAmount: 1_050_000n,
+      quotedAi3Shannons: 1000n,
+      tokenAmount: 1_050_000n,
+      // No paymentAmount at all — the AI3 column stays NULL on this path.
+      paymentAmount: undefined,
+    }
+    jest.spyOn(intentsRepository, 'getById').mockResolvedValue(intent)
+    const addCreditsSpy = jest
+      .spyOn(AccountsUseCases, 'addCreditsToAccount')
+      .mockResolvedValue(ok())
+    const updateSpy = jest
+      .spyOn(intentsRepository, 'updateIntent')
+      .mockResolvedValue({ ...intent, status: IntentStatus.COMPLETED })
+
+    const res = await IntentsUseCases.onConfirmedIntent(intent.id)
+
+    expect(res.isOk()).toBe(true)
+    // The old guard read paymentAmount unconditionally and would have refused
+    // this intent as having no deposit.
+    expect(addCreditsSpy).toHaveBeenCalledWith(user.publicId, 500n, intent.id)
+    expect(updateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ status: IntentStatus.COMPLETED }),
+    )
+  })
+
+  it('markIntentAsConfirmed records a USDC payment on tokenAmount, not paymentAmount', async () => {
+    const intent: Intent = {
+      id: '0xusdc-mark',
+      userPublicId: user.publicId,
+      status: IntentStatus.PENDING,
+      shannonsPerByte: 1n,
+      paymentMethod: PaymentMethod.USDC_ETH,
+      quotedTokenAmount: 1_050_000n,
+      quotedAi3Shannons: 1000n,
+    }
+    jest.spyOn(intentsRepository, 'getById').mockResolvedValue(intent)
+    const updateSpy = jest
+      .spyOn(intentsRepository, 'updateIntent')
+      .mockImplementation(async (i) => i)
+
+    const res = await IntentsUseCases.markIntentAsConfirmed({
+      intentId: intent.id,
+      tokenAmount: 1_050_000n,
+      fromAddress: '0xpayer',
+    })
+
+    expect(res.isOk()).toBe(true)
+    const updated = updateSpy.mock.calls[0][0]
+    expect(updated.tokenAmount).toBe(1_050_000n)
+    // paymentAmount is denominated in shannons; writing USDC into it would make
+    // every AI3-shaped read of the row wrong.
+    expect(updated.paymentAmount).toBeUndefined()
+    // The quote must survive the status transition — updateIntent rewrites the
+    // whole column list, so a column missing from it is silently nulled here.
+    expect(updated.quotedTokenAmount).toBe(1_050_000n)
+    expect(updated.quotedAi3Shannons).toBe(1000n)
+  })
+
+  it('markIntentAsConfirmed refuses a confirmation carrying no amount at all', async () => {
+    const getByIdSpy = jest.spyOn(intentsRepository, 'getById')
+
+    const res = await IntentsUseCases.markIntentAsConfirmed({
+      intentId: '0xnothing',
+    })
+
+    expect(res.isErr()).toBe(true)
+    expect(res._unsafeUnwrapErr()).toBeInstanceOf(BadRequestError)
+    // Refused before the row is even read — confirming with nothing received
+    // would surface later as a 0-credit FAILED row to diagnose backwards.
+    expect(getByIdSpy).not.toHaveBeenCalled()
+  })
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // parsePaymentMethod
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it.each<[string, unknown]>([
+    ['undefined', undefined],
+    ['null', null],
+  ])('parsePaymentMethod defaults %s to AI3 (body-less requests)', (_l, raw) => {
+    const result = IntentsUseCases.parsePaymentMethod(raw)
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap()).toBe(PaymentMethod.AI3_NATIVE)
+  })
+
+  it.each<[PaymentMethod]>([
+    [PaymentMethod.AI3_NATIVE],
+    [PaymentMethod.USDC_ETH],
+  ])('parsePaymentMethod accepts %s', (method) => {
+    const result = IntentsUseCases.parsePaymentMethod(method)
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap()).toBe(method)
+  })
+
+  it.each<[string, unknown]>([
+    ['a near-miss casing', 'USDC_ETH'],
+    ['a shorthand', 'usdc'],
+    ['an unknown asset', 'eth_native'],
+    ['an empty string', ''],
+    ['a number', 1],
+    ['an object', { paymentMethod: 'usdc_eth' }],
+  ])('parsePaymentMethod rejects %s rather than defaulting to AI3', (_l, raw) => {
+    // Defaulting would quote in AI3 a purchase the caller intended to pay in
+    // USDC, and they would only find out at payment time.
+    const result = IntentsUseCases.parsePaymentMethod(raw)
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(BadRequestError)
   })
 
   // ────────────────────────────────────────────────────────────────────────────

--- a/apps/backend/migrations/20260806000000-intent-quoted-ai3-shannons.js
+++ b/apps/backend/migrations/20260806000000-intent-quoted-ai3-shannons.js
@@ -1,0 +1,53 @@
+'use strict'
+
+var dbm
+var type
+var seed
+var fs = require('fs')
+var path = require('path')
+var Promise
+
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  var filePath = path.join(
+    __dirname,
+    'sqls',
+    '20260806000000-intent-quoted-ai3-shannons-up.sql',
+  )
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+      resolve(data)
+    })
+  }).then(function (data) {
+    return db.runSql(data)
+  })
+}
+
+exports.down = function (db) {
+  var filePath = path.join(
+    __dirname,
+    'sqls',
+    '20260806000000-intent-quoted-ai3-shannons-down.sql',
+  )
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+      resolve(data)
+    })
+  }).then(function (data) {
+    return db.runSql(data)
+  })
+}
+
+exports._meta = {
+  version: 1,
+}

--- a/apps/backend/migrations/20260812000000-intent-mispayments.js
+++ b/apps/backend/migrations/20260812000000-intent-mispayments.js
@@ -1,0 +1,53 @@
+'use strict'
+
+var dbm
+var type
+var seed
+var fs = require('fs')
+var path = require('path')
+var Promise
+
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
+
+exports.up = function (db) {
+  var filePath = path.join(
+    __dirname,
+    'sqls',
+    '20260812000000-intent-mispayments-up.sql',
+  )
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+      resolve(data)
+    })
+  }).then(function (data) {
+    return db.runSql(data)
+  })
+}
+
+exports.down = function (db) {
+  var filePath = path.join(
+    __dirname,
+    'sqls',
+    '20260812000000-intent-mispayments-down.sql',
+  )
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
+      resolve(data)
+    })
+  }).then(function (data) {
+    return db.runSql(data)
+  })
+}
+
+exports._meta = {
+  version: 1,
+}

--- a/apps/backend/migrations/sqls/20260806000000-intent-quoted-ai3-shannons-down.sql
+++ b/apps/backend/migrations/sqls/20260806000000-intent-quoted-ai3-shannons-down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE intents
+  DROP COLUMN IF EXISTS quoted_ai3_shannons;

--- a/apps/backend/migrations/sqls/20260806000000-intent-quoted-ai3-shannons-up.sql
+++ b/apps/backend/migrations/sqls/20260806000000-intent-quoted-ai3-shannons-up.sql
@@ -1,0 +1,37 @@
+-- Record the AI3 amount a USDC quote was priced for.
+--
+-- A USDC intent needs to convert the payment it receives back into storage
+-- bytes, and the only rate that makes "pay the quote, receive the quote" true is
+-- the rate the user was actually quoted at. Neither existing column carries it:
+--
+--   usd_rate_at_creation is the pool's MARGINAL price. The user pays the
+--   executable quote, which is that price plus the pool swap fee, plus the
+--   price impact of their own size, plus the quote margin. Converting a received
+--   payment at the marginal rate hands all three back as free storage — 5-8% on
+--   a realistic purchase — and grants more bytes than the pre-payment cap check
+--   was run against.
+--
+--   quoted_token_amount is one half of the rate: what was charged. This column
+--   is the other half: what it was charged FOR.
+--
+-- Together the pair IS the effective rate, held exactly as two integers rather
+-- than as a rounded ratio. That matters because USDC has 6 decimals against
+-- byte counts of ~1e11, so a usdc-per-byte or usdc-per-shannon rate is deeply
+-- sub-unit (~0.0027 base units per byte at 100 GiB) and cannot be stored as an
+-- integer without scaling — and once scaled it is a rounded ratio that no longer
+-- round-trips the quote exactly. Storing the two quantities keeps the
+-- confirmation-path conversion exact:
+--
+--   bytes = token_amount * quoted_ai3_shannons
+--             / quoted_token_amount / shannons_per_byte
+--
+-- With token_amount = quoted_token_amount the ratio cancels and the result is
+-- the requested size exactly, with no rounding in either direction.
+--
+-- numeric(78,0) to match the bigint base-unit convention already used by
+-- payment_amount / shannons_per_byte / quoted_token_amount. NULL for AI3_NATIVE
+-- intents and for rows created before USDC support, both of which derive credits
+-- from payment_amount / shannons_per_byte and never read this.
+
+ALTER TABLE intents
+  ADD COLUMN IF NOT EXISTS quoted_ai3_shannons numeric(78,0);

--- a/apps/backend/migrations/sqls/20260806000000-intent-quoted-ai3-shannons-up.sql
+++ b/apps/backend/migrations/sqls/20260806000000-intent-quoted-ai3-shannons-up.sql
@@ -30,8 +30,16 @@
 --
 -- numeric(78,0) to match the bigint base-unit convention already used by
 -- payment_amount / shannons_per_byte / quoted_token_amount. NULL for AI3_NATIVE
--- intents and for rows created before USDC support, both of which derive credits
--- from payment_amount / shannons_per_byte and never read this.
+-- intents, which derive credits from payment_amount / shannons_per_byte and never
+-- read this.
+--
+-- No existing row needs a backfill: nothing could create a usdc_eth intent before
+-- this column existed. Note that credit derivation routes purely on
+-- payment_method and does NOT fall back to the AI3 formula, so a usdc_eth row
+-- without this column yields 0 credits and is marked FAILED for admin review.
+-- That is the intended outcome for a corrupt row, but it is also why the
+-- down-migration is destructive in a way a column drop usually is not: running it
+-- while paid USDC intents are in flight strands them. Drain or settle them first.
 
 ALTER TABLE intents
   ADD COLUMN IF NOT EXISTS quoted_ai3_shannons numeric(78,0);

--- a/apps/backend/migrations/sqls/20260806000000-intent-quoted-ai3-shannons-up.sql
+++ b/apps/backend/migrations/sqls/20260806000000-intent-quoted-ai3-shannons-up.sql
@@ -4,12 +4,11 @@
 -- bytes, and the only rate that makes "pay the quote, receive the quote" true is
 -- the rate the user was actually quoted at. Neither existing column carries it:
 --
---   usd_rate_at_creation is the pool's MARGINAL price. The user pays the
---   executable quote, which is that price plus the pool swap fee, plus the
---   price impact of their own size, plus the quote margin. Converting a received
---   payment at the marginal rate hands all three back as free storage — 5-8% on
---   a realistic purchase — and grants more bytes than the pre-payment cap check
---   was run against.
+--   usd_rate_at_creation is the RAW rate the oracle reported. The user pays that
+--   rate plus USD_QUOTE_MARGIN, so converting a received payment at the raw rate
+--   hands the margin back as free storage on every purchase — the whole margin,
+--   exactly, since a rate is a scalar and the error scales with the amount — and
+--   grants more bytes than the pre-payment cap check was run against.
 --
 --   quoted_token_amount is one half of the rate: what was charged. This column
 --   is the other half: what it was charged FOR.

--- a/apps/backend/migrations/sqls/20260812000000-intent-mispayments-down.sql
+++ b/apps/backend/migrations/sqls/20260812000000-intent-mispayments-down.sql
@@ -1,0 +1,3 @@
+-- Destructive: these rows are the only durable record of a refused on-chain
+-- payment. Export them before running this if any are unresolved.
+DROP TABLE IF EXISTS intent_mispayments;

--- a/apps/backend/migrations/sqls/20260812000000-intent-mispayments-up.sql
+++ b/apps/backend/migrations/sqls/20260812000000-intent-mispayments-up.sql
@@ -1,0 +1,49 @@
+-- Record on-chain payments that were refused, so an irreversible transfer is
+-- never left with only a log line pointing at it.
+--
+-- Both receivers accept any intent id from anyone — payIntent(bytes32) on Auto
+-- EVM, payIntentWithToken(bytes32, uint256) on Ethereum — so a payment can name
+-- an intent that does not exist, or one denominated in the other asset.
+-- markIntentAsConfirmed refuses both, which is correct: confirming a mispayment
+-- strands the intent in the polling loop AND makes the idempotency guard discard
+-- the user's real payment when it arrives. But refusing resolves nothing on
+-- chain. The money has moved; the only open question is whose it is, and that
+-- question needs a row.
+--
+-- No foreign key to intents on purpose. The unknown-intent case has no row to
+-- point at, and it is exactly the case with the least other evidence attached.
+
+CREATE TABLE IF NOT EXISTS intent_mispayments (
+  id bigserial PRIMARY KEY,
+  -- The id named by the on-chain event, which may match no intent.
+  intent_id text NOT NULL,
+  -- IntentMispaymentReason: 'unknown_intent' | 'asset_mismatch'. Text rather
+  -- than an enum type so a new reason is a code change, not a migration.
+  reason text NOT NULL,
+  -- What the named intent was denominated in; NULL when there is no such intent.
+  expected_payment_method text,
+  -- Whichever the watcher reported. Exactly one is set, and which one is itself
+  -- the evidence: an AI3 amount against a USDC intent is the asset mismatch.
+  -- numeric(78,0) to match the bigint base-unit convention used across intents.
+  payment_amount numeric(78,0),
+  token_amount numeric(78,0),
+  from_address text,
+  tx_hash text,
+  created_at timestamptz NOT NULL DEFAULT NOW()
+);
+
+-- The watcher re-runs: chain reorgs re-emit events, and the startup sweep
+-- replays every PENDING intent that has a tx_hash. Recording is therefore
+-- idempotent per (transaction, intent) rather than append-only, or one restart
+-- loop would turn a single mispayment into a page of them.
+--
+-- Partial because a NULL tx_hash cannot participate in the constraint anyway
+-- (NULLs are distinct in a unique index) — stating that in the predicate keeps
+-- the index honest about what it enforces, and small.
+CREATE UNIQUE INDEX IF NOT EXISTS intent_mispayments_tx_intent_uniq
+  ON intent_mispayments (tx_hash, intent_id)
+  WHERE tx_hash IS NOT NULL;
+
+-- The admin listing reads newest-first and nothing else reads this table.
+CREATE INDEX IF NOT EXISTS intent_mispayments_created_at_idx
+  ON intent_mispayments (created_at DESC);

--- a/apps/backend/src/app/controllers/intents.ts
+++ b/apps/backend/src/app/controllers/intents.ts
@@ -15,14 +15,15 @@ export const intentsController = Router()
 // each response site: the fields are spread wholesale, so a field added to
 // Intent and forgotten here does not fail at compile time — it throws at
 // runtime, on the first request for a row that happens to have it set. The
-// token_* fields are currently always unset, which is the only reason listing
-// them per-endpoint has not broken yet.
+// token_* fields are set for the first time by the USDC creation path, so this
+// is now load-bearing rather than latent.
 const serializeIntent = (intent: Intent) => ({
   ...intent,
   shannonsPerByte: intent.shannonsPerByte.toString(),
   paymentAmount: intent.paymentAmount?.toString(),
   tokenAmount: intent.tokenAmount?.toString(),
   quotedTokenAmount: intent.quotedTokenAmount?.toString(),
+  quotedAi3Shannons: intent.quotedAi3Shannons?.toString(),
   usdRateAtCreation: intent.usdRateAtCreation?.toString(),
 })
 
@@ -69,13 +70,28 @@ intentsController.post(
       return
     }
 
+    // Absent means AI3, so a body-less request keeps its current meaning. An
+    // unrecognised value is rejected rather than defaulted — see
+    // parsePaymentMethod.
+    const paymentMethod = IntentsUseCases.parsePaymentMethod(
+      req.body?.paymentMethod,
+    )
+    if (paymentMethod.isErr()) {
+      handleError(paymentMethod.error, res)
+      return
+    }
+
     const result = await handleInternalErrorResult(
-      IntentsUseCases.createIntent(user, requestedBytes.value),
+      IntentsUseCases.createIntent(user, {
+        requestedBytes: requestedBytes.value,
+        paymentMethod: paymentMethod.value,
+      }),
       'Failed to create intent',
     )
     if (result.isErr()) {
-      // CreditCapExceededError carries its own { error: 'CREDIT_CAP_EXCEEDED',
-      // message } response shape, so the generic path emits it correctly.
+      // CreditCapExceededError and QuoteFailedError each carry their own
+      // { error: <CODE>, message } response shape, so the generic path emits
+      // them — and their 403 / 503 / 409 / 400 statuses — correctly.
       handleError(result.error, res)
       return
     }

--- a/apps/backend/src/app/controllers/intents.ts
+++ b/apps/backend/src/app/controllers/intents.ts
@@ -6,7 +6,7 @@ import { handleInternalErrorResult } from '../../shared/utils/neverthrow.js'
 import { handleError } from '../../errors/index.js'
 import { config } from '../../config.js'
 import { hasGoogleAuth } from '../../core/featureFlags/index.js'
-import { Intent } from '@auto-drive/models'
+import { Intent, IntentMispayment } from '@auto-drive/models'
 
 export const intentsController = Router()
 
@@ -25,6 +25,13 @@ const serializeIntent = (intent: Intent) => ({
   quotedTokenAmount: intent.quotedTokenAmount?.toString(),
   quotedAi3Shannons: intent.quotedAi3Shannons?.toString(),
   usdRateAtCreation: intent.usdRateAtCreation?.toString(),
+})
+
+// Same reason as serializeIntent: res.json() throws on a raw BigInt.
+const serializeMispayment = (mispayment: IntentMispayment) => ({
+  ...mispayment,
+  paymentAmount: mispayment.paymentAmount?.toString(),
+  tokenAmount: mispayment.tokenAmount?.toString(),
 })
 
 // ---------------------------------------------------------------------------
@@ -89,9 +96,10 @@ intentsController.post(
       'Failed to create intent',
     )
     if (result.isErr()) {
-      // CreditCapExceededError and QuoteFailedError each carry their own
-      // { error: <CODE>, message } response shape, so the generic path emits
-      // them — and their 403 / 503 / 409 / 400 statuses — correctly.
+      // CreditCapExceededError, UsdcPaymentsDisabledError and QuoteFailedError
+      // each carry their own { error: <CODE>, message } response shape, so the
+      // generic path emits them — and their 400 / 403 / 503 statuses —
+      // correctly.
       handleError(result.error, res)
       return
     }
@@ -129,6 +137,37 @@ intentsController.get(
     }
 
     res.status(200).json(result.value.map(serializeIntent))
+  }),
+)
+
+// ---------------------------------------------------------------------------
+// GET /intents/mispayments  (admin only)
+// Lists on-chain payments that were refused rather than attached to an intent:
+// the intent id was unknown, or the payment was denominated in the other asset.
+// The intent itself is untouched in both cases, so nothing about its row records
+// that money arrived — this is the only place it does.
+//
+// NOTE: like /over-cap, this static route must be registered BEFORE GET /:id.
+// ---------------------------------------------------------------------------
+
+intentsController.get(
+  '/mispayments',
+  asyncSafeHandler(async (req, res) => {
+    const user = await handleAuth(req, res)
+    if (!user) {
+      return
+    }
+
+    const result = await handleInternalErrorResult(
+      IntentsUseCases.getMispayments(user),
+      'Failed to get mispayments',
+    )
+    if (result.isErr()) {
+      handleError(result.error, res)
+      return
+    }
+
+    res.status(200).json(result.value.map(serializeMispayment))
   }),
 )
 

--- a/apps/backend/src/config.ts
+++ b/apps/backend/src/config.ts
@@ -373,6 +373,18 @@ export const config = {
         active: optionalBoolEnvironmentVariable('BUY_CREDITS_ACTIVE'),
         staffOnly: optionalBoolEnvironmentVariable('BUY_CREDITS_STAFF_ONLY'),
       } as FeatureFlag,
+      // Pay-with-USDC. Gates the USDC branch of intent creation only; the AI3
+      // path is unaffected and `buyCredits` still gates the endpoint itself.
+      //
+      // Off by default, and deliberately so for longer than the quote code
+      // takes to land: creating a USDC intent hands the user a binding amount
+      // to transfer, and nothing observes an IntentTokenPaymentReceived event
+      // yet, so a quote issued today is one the backend cannot settle.
+      //
+      // Admins are exempt whatever this says — see featureFlags/isActive.
+      payWithUsdc: {
+        active: optionalBoolEnvironmentVariable('PAY_WITH_USDC_ACTIVE'),
+      } as FeatureFlag,
     },
     allowlistedUsernames: env('STAFF_USERNAME_ALLOWLIST', '<none>')
       .split(',')

--- a/apps/backend/src/core/featureFlags/index.ts
+++ b/apps/backend/src/core/featureFlags/index.ts
@@ -1,4 +1,4 @@
-import { User } from '@auto-drive/models'
+import { User, UserRole } from '@auto-drive/models'
 import { config } from '../../config.js'
 import { createLogger } from '../../infrastructure/drivers/logger.js'
 
@@ -9,12 +9,23 @@ export interface FeatureFlag {
   staffOnly?: boolean
 }
 
+export type FeatureFlagKey = keyof typeof config.featureFlags.flags
+
 const get = (user: User | null) => {
   const entries = Object.entries(config.featureFlags.flags)
 
   return Object.fromEntries(
     entries.map(([key, value]) => [key, isActive(key, value, user)]),
   )
+}
+
+// One flag's state for one user, without materialising the whole map.
+//
+// Exists so a use case can gate on the same rules the client is told about via
+// `get`. Two evaluations of the same flag that could disagree is the failure
+// this avoids: the UI would offer a path the backend then refuses.
+const isFlagActive = (key: FeatureFlagKey, user: User | null): boolean => {
+  return isActive(key, config.featureFlags.flags[key], user)
 }
 
 // Returns true if the user's account was registered via Google OAuth.
@@ -29,10 +40,29 @@ export const hasGoogleAuth = (user: User | null): boolean => {
   return Boolean(user && user.oauthProvider === 'google')
 }
 
+// An account with the Admin role. Distinct from `isStaff`, which is a
+// configured allowlist of domains and usernames: staff is who we recognise,
+// admin is who we have granted authority to.
+export const isAdmin = (user: User | null): boolean => {
+  return Boolean(user && user.role === UserRole.Admin)
+}
+
 const isActive = (key: string, value: FeatureFlag, user: User | null) => {
   // buyCredits requires Google auth when publicly active.
   if (key === 'buyCredits' && value.active) {
     return hasGoogleAuth(user)
+  }
+
+  // payWithUsdc stays open to admins whatever the flag says. The USDC path has
+  // to be driven end to end against production — a real quote, a real transfer,
+  // a real settlement — before it can be opened to users with any confidence,
+  // and a switch that also locks out the people verifying it cannot be turned on
+  // on the strength of anything but hope.
+  //
+  // Placed before the `value.active` short-circuit so it reads as one rule
+  // ("admins always") rather than as a special case of the flag being off.
+  if (key === 'payWithUsdc' && isAdmin(user)) {
+    return true
   }
 
   if (value.active) {
@@ -73,6 +103,8 @@ const isStaff = (user: User | null) => {
 
 export const FeatureFlagsUseCases = {
   get,
+  isFlagActive,
   isStaff,
+  isAdmin,
   hasGoogleAuth,
 }

--- a/apps/backend/src/core/users/intents.ts
+++ b/apps/backend/src/core/users/intents.ts
@@ -1,5 +1,6 @@
 import {
   Intent,
+  IntentMispaymentReason,
   IntentStatus,
   PaymentMethod,
   User,
@@ -7,6 +8,7 @@ import {
   UserWithOrganization,
 } from '@auto-drive/models'
 import { intentsRepository } from '../../infrastructure/repositories/users/intents.js'
+import { intentMispaymentsRepository } from '../../infrastructure/repositories/users/intentMispayments.js'
 import { purchasedCreditsRepository } from '../../infrastructure/repositories/users/purchasedCredits.js'
 import { EventRouter } from '../../infrastructure/eventRouter/index.js'
 import { MAX_RETRIES } from '../../infrastructure/eventRouter/tasks.js'
@@ -20,12 +22,14 @@ import {
   QuoteErrorCode,
   QuoteFailedError,
   ServiceUnavailableError,
+  UsdcPaymentsDisabledError,
 } from '../../errors/index.js'
 import { err, ok, Result } from 'neverthrow'
 import { config } from '../../config.js'
 import { randomBytes } from 'crypto'
 import { createLogger } from '../../infrastructure/drivers/logger.js'
 import { AccountsUseCases } from './accounts.js'
+import { FeatureFlagsUseCases } from '../featureFlags/index.js'
 import { transactionByteFee } from '@autonomys/auto-consensus'
 import { ApiPromise, WsProvider } from '@polkadot/api'
 import { priceOracle } from '../../infrastructure/services/priceOracle/index.js'
@@ -247,38 +251,35 @@ const checkCapHeadroom = async (
   return ok(undefined)
 }
 
-// Map a price-oracle failure onto an HTTP status and a client-facing code.
+// Map a price-oracle failure onto a client-facing code.
 //
-// Every one of them is a 503. That is a narrowing: this mapping used to send two
-// of four causes back as 4xx — 409 "the pool cannot fill it, ask for less" and
-// 400 "the amount is out of the quoter's range". Both told the user to change
-// the size, and since #807 no oracle failure is about the size. The rate is one
-// size-independent average of realized fills; it is refused for the market or
-// for the source, never for how much was asked for. A 4xx here would blame a
-// request that was fine.
+// Every one of them is a 503, carried by QuoteFailedError itself. That is a
+// narrowing: this mapping used to send two of four causes back as 4xx — 409 "the
+// pool cannot fill it, ask for less" and 400 "the amount is out of the quoter's
+// range". Both told the user to change the size, and since #807 no oracle
+// failure is about the size. The rate is one size-independent average of
+// realized fills; it is refused for the market or for the source, never for how
+// much was asked for. A 4xx here would blame a request that was fine.
 //
 // Still two codes rather than one, because the oracle draws the distinction
 // deliberately and flattening it misdirects whoever reads the response: a market
 // that has re-priced past its own window is a different fact from a source we
 // could not read, even though both mean "not right now".
-const quoteErrorToHttpError = (error: Error): QuoteFailedError => {
-  if (
-    error instanceof OracleUnavailableError &&
-    error.reason === 'market-moved'
-  ) {
-    return new QuoteFailedError(
-      ServiceUnavailableError.statusCode,
-      QuoteErrorCode.PRICE_UNSTABLE,
-      error.message,
-    )
+//
+// Takes OracleUnavailableError rather than Error because that is what
+// priceOracle.getPrice() can fail with — the Result type says so. The default
+// branch is not defence against some other error class arriving; it is the
+// mapping's answer for reasons added to OracleUnavailableReason after this was
+// written, which is a union that has grown twice already.
+const quoteErrorToHttpError = (
+  error: OracleUnavailableError,
+): QuoteFailedError => {
+  if (error.reason === 'market-moved') {
+    return new QuoteFailedError(QuoteErrorCode.PRICE_UNSTABLE, error.message)
   }
   // Every other reason, and anything the oracle grows later: an unrecognised
   // failure is our problem and retryable, which is the safe default.
-  return new QuoteFailedError(
-    ServiceUnavailableError.statusCode,
-    QuoteErrorCode.ORACLE_UNAVAILABLE,
-    error.message,
-  )
+  return new QuoteFailedError(QuoteErrorCode.ORACLE_UNAVAILABLE, error.message)
 }
 
 type CreateIntentOptions = {
@@ -302,8 +303,44 @@ const createIntent = async (
     paymentMethod = PaymentMethod.AI3_NATIVE,
   }: CreateIntentOptions = {},
 ): Promise<
-  Result<Intent, BadRequestError | CreditCapExceededError | QuoteFailedError>
+  Result<
+    Intent,
+    | BadRequestError
+    | CreditCapExceededError
+    | QuoteFailedError
+    | ServiceUnavailableError
+    | UsdcPaymentsDisabledError
+  >
 > => {
+  // Is this caller allowed to pay in USDC at all?
+  //
+  // First, before the request is even validated: a caller who cannot use the
+  // asset should be told that, not walked through a critique of a body that was
+  // never going to be quoted. It also keeps the closed path cheap — no account
+  // read, no balance read, no chain round-trip.
+  //
+  // Checked in the use case rather than in the controller, for the same reason
+  // the requestedBytes rule is: `POST /intents` is not the only door, and a
+  // caller reaching this function directly must be held to the same rule.
+  //
+  // Admins are exempt by construction (see featureFlags/isActive), which is what
+  // makes the flag safe to leave off — the path stays exercisable in production
+  // while it is shut to everyone else.
+  if (
+    paymentMethod === PaymentMethod.USDC_ETH &&
+    !FeatureFlagsUseCases.isFlagActive('payWithUsdc', executor)
+  ) {
+    logger.info('Rejecting USDC intent creation — feature not open to caller', {
+      userPublicId: executor.publicId,
+    })
+    return err(
+      new UsdcPaymentsDisabledError(
+        'Paying in USDC is not available on this account. Pay in AI3 instead, ' +
+          'or omit paymentMethod to default to it.',
+      ),
+    )
+  }
+
   // The USDC path cannot price a purchase without knowing its size, so the size
   // is required there and optional on AI3.
   //
@@ -365,6 +402,35 @@ const createIntent = async (
   const { price } = await IntentsUseCases.getPrice()
   const shannonsPerByte = BigInt(price)
 
+  // An intent priced at zero per byte is a trap, not a bargain. Every payment
+  // made against it converts to zero credits — getIntentCredits divides by this
+  // number and returns 0 rather than throwing — so the intent lands in FAILED
+  // with the payment kept and nothing bought. On the USDC path it is worse
+  // still: the quote itself computes to 0, and the user is shown a binding
+  // amount of "nothing" for a purchase that will never be granted.
+  //
+  // Reachable from CREDITS_PRICE_MULTIPLIER=0 or a chain reporting a zero byte
+  // fee — a misconfiguration rather than a market condition, which is why it is
+  // a 503 and not a 4xx: the request was fine, the deployment is not.
+  //
+  // Guarded on both paths, though only the USDC one produces a misleading quote:
+  // the downstream failure is identical, and an intent nobody can settle should
+  // not be created whichever asset it names. The zero check in getIntentCredits
+  // stays as defence for rows written before this existed.
+  if (shannonsPerByte === 0n) {
+    logger.error('Refusing to create an intent at a zero per-byte price', {
+      userPublicId: executor.publicId,
+      paymentMethod,
+      priceMultiplier: config.paymentManager.priceMultiplier,
+    })
+    return err(
+      new ServiceUnavailableError(
+        'Storage is not priceable right now: the per-byte rate resolved to ' +
+          'zero. This is a server-side condition — retry shortly.',
+      ),
+    )
+  }
+
   const expiresAt = new Date(
     Date.now() + config.credits.intentExpiryMinutes * 60 * 1000,
   )
@@ -394,6 +460,16 @@ const createIntent = async (
   // the same intent is what makes the charge reproducible.
   const quotedAi3Shannons = requestedBytes! * shannonsPerByte
 
+  // A last-good rate prices the quote exactly as a fresh one does, and that is a
+  // decision rather than an oversight. The oracle's number is a volume-weighted
+  // average over days of realized fills, so the ORACLE_MAX_STALE_MS window (10
+  // minutes) cannot move it the way it would move a spot price — while refusing
+  // to quote through every subgraph blip would shut the purchase path far more
+  // often than the drift justifies. `stale` and `asOf` are recorded on every
+  // quote below, so a charge can still be explained after the fact.
+  //
+  // The guard that DOES fire on a moved market is `market-moved`, which the
+  // oracle raises against the window itself rather than against its age.
   const rate = await priceOracle.getPrice()
   if (rate.isErr()) {
     logger.info(
@@ -518,11 +594,51 @@ const triggerWatchIntent = async ({
   return ok()
 }
 
+/**
+ * Write down a payment we refused to attach to an intent.
+ *
+ * Never throws. The caller is already on its way to returning a refusal, and a
+ * failure to file the paperwork must not become a different error than the one
+ * that actually happened — the watcher would log the wrong cause, and on the
+ * startup-sweep path it would abort the recovery of unrelated transactions.
+ * A failed write degrades to the log line we had before, which is the floor
+ * rather than the goal.
+ */
+const recordMispayment = async (
+  mispayment: Parameters<typeof intentMispaymentsRepository.record>[0],
+): Promise<void> => {
+  try {
+    const recorded = await intentMispaymentsRepository.record(mispayment)
+    if (recorded) {
+      logger.warn('Recorded a mispayment for admin review', {
+        mispaymentId: recorded.id,
+        intentId: recorded.intentId,
+        reason: recorded.reason,
+        txHash: recorded.txHash,
+      })
+    }
+    // A null return is the ON CONFLICT path: this (transaction, intent) is
+    // already on file, which is the expected outcome of a reorg or the startup
+    // sweep replaying it. Not worth a line.
+  } catch (error) {
+    logger.error('Failed to record a mispayment — it survives only in logs', {
+      intentId: mispayment.intentId,
+      reason: mispayment.reason,
+      txHash: mispayment.txHash,
+      paymentAmount: mispayment.paymentAmount?.toString(),
+      tokenAmount: mispayment.tokenAmount?.toString(),
+      fromAddress: mispayment.fromAddress,
+      error,
+    })
+  }
+}
+
 const markIntentAsConfirmed = async ({
   intentId,
   paymentAmount,
   tokenAmount,
   fromAddress,
+  txHash,
 }: {
   intentId: string
   // AI3 path: shannons received on Auto EVM.
@@ -533,6 +649,10 @@ const markIntentAsConfirmed = async ({
   // silently wrong, starting with the dust guard in onConfirmedIntent.
   tokenAmount?: bigint
   fromAddress?: string
+  // The transaction the payment arrived in. Carried purely so a refusal can be
+  // recorded against something an admin can look up on a block explorer — an
+  // amount and a sender describe a payment, but only the hash finds it.
+  txHash?: string
 }) => {
   // Exactly one of the two is expected, but neither is the failure worth
   // catching: it would confirm an intent with nothing received, which later
@@ -549,6 +669,21 @@ const markIntentAsConfirmed = async ({
 
   const intent = await intentsRepository.getById(intentId)
   if (!intent) {
+    // A payment naming an intent that does not exist. Nothing can be done with
+    // it in code, which is exactly why it is written down: this is the case with
+    // the least evidence attached, and a log line is not evidence anyone finds.
+    logger.warn('markIntentAsConfirmed: payment for an unknown intent', {
+      intentId,
+      txHash,
+    })
+    await recordMispayment({
+      intentId,
+      reason: IntentMispaymentReason.UNKNOWN_INTENT,
+      paymentAmount,
+      tokenAmount,
+      fromAddress,
+      txHash,
+    })
     return err(new ObjectNotFoundError('Intent not found'))
   }
 
@@ -590,8 +725,9 @@ const markIntentAsConfirmed = async ({
   // discarded when it arrived.
   //
   // Refusing leaves the intent PENDING so it expires on its own schedule. The
-  // mispaid amount still needs manual resolution, which is the same position a
-  // payment to an unknown intent id is already in.
+  // mispaid amount still needs manual resolution, so it is recorded in
+  // intent_mispayments — refusing resolves nothing on chain, and an irreversible
+  // transfer must not be left with only a log line pointing at it.
   const expectsToken = intent.paymentMethod === PaymentMethod.USDC_ETH
   const suppliedAmount = expectsToken ? tokenAmount : paymentAmount
   if (suppliedAmount === undefined) {
@@ -602,8 +738,18 @@ const markIntentAsConfirmed = async ({
         paymentMethod: intent.paymentMethod,
         gotPaymentAmount: paymentAmount?.toString(),
         gotTokenAmount: tokenAmount?.toString(),
+        txHash,
       },
     )
+    await recordMispayment({
+      intentId,
+      reason: IntentMispaymentReason.ASSET_MISMATCH,
+      expectedPaymentMethod: intent.paymentMethod ?? PaymentMethod.AI3_NATIVE,
+      paymentAmount,
+      tokenAmount,
+      fromAddress,
+      txHash,
+    })
     return err(
       new BadRequestError(
         `Cannot confirm intent ${intentId}: it is denominated in ` +
@@ -634,10 +780,13 @@ const markIntentAsConfirmed = async ({
  *
  * That rate is `quotedTokenAmount / quotedAi3Shannons`, held as the pair rather
  * than as a stored ratio so the conversion is exact. It is emphatically NOT
- * `usdRateAtCreation`: that is the pool's marginal price, while the user paid the
- * executable quote plus the margin. Converting at the marginal rate refunds the
- * swap fee, the price impact and the margin as free storage — 5-8% on a realistic
- * purchase — and grants more bytes than the pre-payment cap check allowed for.
+ * `usdRateAtCreation`: that is the raw rate the oracle reported — a
+ * volume-weighted average of the pool's realized fills — while the user paid
+ * that rate plus USD_QUOTE_MARGIN. Since #807 the margin is the entire wedge
+ * between the two (the swap fee and price impact are inside the rate, paid by
+ * the fills it averages), so converting at the raw rate hands the whole margin
+ * back as free storage and grants more bytes than the pre-payment cap check
+ * allowed for.
  *
  * Multiplication before division throughout, so no intermediate floors. Paying
  * exactly `quotedTokenAmount` makes the first division exact
@@ -810,6 +959,19 @@ const getOverCapIntents = async (executor: User) => {
   return ok(intents)
 }
 
+// Returns refused on-chain payments for admin review — payments naming an
+// unknown intent, or denominated in the other asset.
+//
+// The queue OVER_CAP has for payments we accepted but could not convert. These
+// are the ones we never accepted at all, and they are less visible: the intent
+// they name is untouched, so nothing about its row says a payment happened.
+const getMispayments = async (executor: User) => {
+  if (executor.role !== UserRole.Admin) {
+    return err(new ForbiddenError('Admin access required'))
+  }
+  return ok(await intentMispaymentsRepository.list())
+}
+
 // Resets an OVER_CAP intent back to CONFIRMED so the payment manager polling
 // loop will attempt to grant credits on its next tick.
 //
@@ -917,6 +1079,7 @@ export const IntentsUseCases = {
   markIntentAsConfirmed,
   getConfirmedIntents,
   getOverCapIntents,
+  getMispayments,
   getPendingWithTxHash,
   reprocessOverCapIntent,
   getIntentCredits,

--- a/apps/backend/src/core/users/intents.ts
+++ b/apps/backend/src/core/users/intents.ts
@@ -17,6 +17,9 @@ import {
   ForbiddenError,
   GoneError,
   ObjectNotFoundError,
+  QuoteErrorCode,
+  QuoteFailedError,
+  ServiceUnavailableError,
 } from '../../errors/index.js'
 import { err, ok, Result } from 'neverthrow'
 import { config } from '../../config.js'
@@ -25,6 +28,12 @@ import { createLogger } from '../../infrastructure/drivers/logger.js'
 import { AccountsUseCases } from './accounts.js'
 import { transactionByteFee } from '@autonomys/auto-consensus'
 import { ApiPromise, WsProvider } from '@polkadot/api'
+import { priceOracle } from '../../infrastructure/services/priceOracle/index.js'
+import { OracleUnavailableError } from '../../infrastructure/services/priceOracle/types.js'
+import {
+  ai3ShannonsToUsdcBaseUnits,
+  applyMarginPercent,
+} from '../../shared/utils/index.js'
 
 const logger = createLogger('IntentsUseCases')
 
@@ -139,6 +148,35 @@ const parseRequestedBytes = (
   )
 }
 
+/**
+ * Parse the wire form of `paymentMethod`.
+ *
+ * Absent means AI3 — the live frontend posts no body at all, and that request
+ * must keep meaning exactly what it means today.
+ *
+ * An unrecognised value is rejected rather than defaulted. Defaulting would let a
+ * typo ('usdc', 'USDC_ETH') quietly create an AI3 intent, and the caller would
+ * only find out when the payment they were told to make in USDC was expected in
+ * AI3. Like parseRequestedBytes this checks the wire shape only.
+ */
+const parsePaymentMethod = (
+  raw: unknown,
+): Result<PaymentMethod, BadRequestError> => {
+  if (raw === undefined || raw === null) {
+    return ok(PaymentMethod.AI3_NATIVE)
+  }
+  const known = Object.values(PaymentMethod) as string[]
+  if (typeof raw === 'string' && known.includes(raw)) {
+    return ok(raw as PaymentMethod)
+  }
+  return err(
+    new BadRequestError(
+      `Invalid paymentMethod: expected one of ${known.join(', ')} (got ` +
+        `${JSON.stringify(raw)})`,
+    ),
+  )
+}
+
 // Reject a purchase that cannot fit under the per-user credit cap, before the
 // user has been asked to pay anything.
 //
@@ -209,11 +247,63 @@ const checkCapHeadroom = async (
   return ok(undefined)
 }
 
+// Map a price-oracle failure onto an HTTP status and a client-facing code.
+//
+// Every one of them is a 503. That is a narrowing: this mapping used to send two
+// of four causes back as 4xx — 409 "the pool cannot fill it, ask for less" and
+// 400 "the amount is out of the quoter's range". Both told the user to change
+// the size, and since #807 no oracle failure is about the size. The rate is one
+// size-independent average of realized fills; it is refused for the market or
+// for the source, never for how much was asked for. A 4xx here would blame a
+// request that was fine.
+//
+// Still two codes rather than one, because the oracle draws the distinction
+// deliberately and flattening it misdirects whoever reads the response: a market
+// that has re-priced past its own window is a different fact from a source we
+// could not read, even though both mean "not right now".
+const quoteErrorToHttpError = (error: Error): QuoteFailedError => {
+  if (
+    error instanceof OracleUnavailableError &&
+    error.reason === 'market-moved'
+  ) {
+    return new QuoteFailedError(
+      ServiceUnavailableError.statusCode,
+      QuoteErrorCode.PRICE_UNSTABLE,
+      error.message,
+    )
+  }
+  // Every other reason, and anything the oracle grows later: an unrecognised
+  // failure is our problem and retryable, which is the safe default.
+  return new QuoteFailedError(
+    ServiceUnavailableError.statusCode,
+    QuoteErrorCode.ORACLE_UNAVAILABLE,
+    error.message,
+  )
+}
+
+type CreateIntentOptions = {
+  // How many bytes the purchase is for. Optional on the AI3 path, where it only
+  // gates creation against the cap. REQUIRED for USDC_ETH, which has to quote a
+  // specific size.
+  requestedBytes?: bigint
+  // Defaults to AI3_NATIVE so existing callers — including the live frontend,
+  // which posts no body — keep their current behaviour exactly.
+  paymentMethod?: PaymentMethod
+}
+
+// An options object rather than a third positional parameter. Two optional
+// bigint/enum arguments in a row on a money path is the shape where a
+// transposed call site silently prices the wrong thing, and the compiler would
+// not catch swapping them if both were positional.
 const createIntent = async (
   executor: UserWithOrganization,
-  requestedBytes?: bigint,
-  paymentMethod: PaymentMethod = PaymentMethod.AI3_NATIVE,
-): Promise<Result<Intent, BadRequestError | CreditCapExceededError>> => {
+  {
+    requestedBytes,
+    paymentMethod = PaymentMethod.AI3_NATIVE,
+  }: CreateIntentOptions = {},
+): Promise<
+  Result<Intent, BadRequestError | CreditCapExceededError | QuoteFailedError>
+> => {
   // The USDC path cannot price a purchase without knowing its size, so the size
   // is required there and optional on AI3.
   //
@@ -225,15 +315,13 @@ const createIntent = async (
   // (a VWAP of realized fills, size-independent since #807), so without a size
   // there is no amount to charge and nothing to put in quoted_token_amount.
   //
-  // Enforced here rather than by making the field required on the endpoint,
-  // because `POST /intents` is a documented API-key flow for third-party
-  // integrators (see featureFlags.hasGoogleAuth) and every one of them is on
-  // AI3 today. Requiring it outright would break them to close a hole that only
-  // exists on a path they cannot reach.
-  if (
-    paymentMethod === PaymentMethod.USDC_ETH &&
-    requestedBytes === undefined
-  ) {
+  // Checked here rather than in parseRequestedBytes because a caller reaching
+  // this use case directly must be held to the same rule — the parser's job
+  // ends at the wire shape. Enforced at all rather than by making the field
+  // required on the endpoint, because `POST /intents` is a documented API-key
+  // flow for third-party integrators (see featureFlags.hasGoogleAuth) and every
+  // one of them is on AI3 today.
+  if (paymentMethod === PaymentMethod.USDC_ETH && requestedBytes === undefined) {
     return err(
       new BadRequestError(
         'requestedBytes is required when paying in USDC: the amount charged ' +
@@ -275,23 +363,100 @@ const createIntent = async (
   }
 
   const { price } = await IntentsUseCases.getPrice()
+  const shannonsPerByte = BigInt(price)
 
   const expiresAt = new Date(
     Date.now() + config.credits.intentExpiryMinutes * 60 * 1000,
+  )
+
+  // AI3 path: requestedBytes is deliberately not persisted. It exists to gate
+  // creation against the cap, and nothing downstream reads it — credits are
+  // derived from paymentAmount / shannonsPerByte, so a stored copy would be a
+  // number that looks like a balance, never agrees with one, and has no reader.
+  if (paymentMethod !== PaymentMethod.USDC_ETH) {
+    const intent = await intentsRepository.createIntent({
+      id: randomBytes32(),
+      userPublicId: executor.publicId,
+      status: IntentStatus.PENDING,
+      paymentAmount: undefined,
+      shannonsPerByte,
+      paymentMethod,
+      expiresAt,
+    })
+
+    return ok(intent)
+  }
+
+  // USDC path. requestedBytes is guaranteed present by the guard above.
+  //
+  // Quote the AI3 the purchase is worth, not the bytes: the oracle prices AI3,
+  // and shannonsPerByte is what ties the two together. Locking both numbers on
+  // the same intent is what makes the charge reproducible.
+  const quotedAi3Shannons = requestedBytes! * shannonsPerByte
+
+  const price = await priceOracle.getPrice()
+  if (price.isErr()) {
+    logger.info(
+      'Rejecting USDC intent creation — could not quote the purchase',
+      {
+        userPublicId: executor.publicId,
+        requestedBytes: requestedBytes!.toString(),
+        quotedAi3Shannons: quotedAi3Shannons.toString(),
+        // The reason, not just the message: it is the enum the admin dashboard
+        // and #811's kill switch read, and it says which guard closed the door.
+        reason: price.error.reason,
+        message: price.error.message,
+      },
+    )
+    return err(quoteErrorToHttpError(price.error))
+  }
+
+  // A rate times an amount, because the rate prices ONE BYTE and knows nothing
+  // about size — the same number quotes a $5 purchase and a $500 one. This used
+  // to ask the pool what this specific size would fill at, which folded the swap
+  // fee and that size's own price impact into the answer; #807 replaced it with
+  // an average of realized fills, and those two costs now arrive inside the rate
+  // (the fills paid them) rather than as a function of what is being bought.
+  //
+  // So the margin is the ONLY wedge left between the rate shown and the amount
+  // charged. It carries drift while the price lock is open and the cost of
+  // converting a batch later, since the treasury no longer swaps per intent.
+  // Reasoning lives in pricing.ts; do not re-derive it here.
+  const quotedTokenAmount = applyMarginPercent(
+    ai3ShannonsToUsdcBaseUnits(quotedAi3Shannons, price.value.usdPerAi3),
+    config.credits.usdQuoteMarginPercent,
   )
 
   const intent = await intentsRepository.createIntent({
     id: randomBytes32(),
     userPublicId: executor.publicId,
     status: IntentStatus.PENDING,
-    paymentMethod,
     paymentAmount: undefined,
-    shannonsPerByte: BigInt(price),
-    // requestedBytes is deliberately not persisted. It exists to gate creation
-    // against the cap, and nothing downstream reads it: credits are derived from
-    // paymentAmount / shannonsPerByte, so a stored copy would be a number that
-    // looks like a balance, never agrees with one, and has no reader.
+    shannonsPerByte,
+    paymentMethod,
+    // The charge, and what it was charged for. The pair is the effective rate the
+    // confirmation path converts at — see getIntentCredits.
+    quotedTokenAmount,
+    quotedAi3Shannons,
+    // The raw oracle rate, for display and reconciliation only. NEVER convert a
+    // payment at this rate: it is short by the margin the user actually paid, so
+    // doing so grants that margin back as free storage.
+    usdRateAtCreation: price.value.usdPerAi3,
     expiresAt,
+  })
+
+  logger.info('Created USDC intent with a locked quote', {
+    intentId: intent.id,
+    userPublicId: executor.publicId,
+    requestedBytes: requestedBytes!.toString(),
+    quotedAi3Shannons: quotedAi3Shannons.toString(),
+    quotedTokenAmount: quotedTokenAmount.toString(),
+    usdPerAi3: price.value.usdPerAi3.toString(),
+    // Whether the rate that priced this purchase was the last-good fallback
+    // rather than a fresh read, and how old it is. Both are needed to explain a
+    // charge after the fact.
+    rateAsOf: price.value.asOf.toISOString(),
+    rateStale: price.value.stale,
   })
 
   return ok(intent)
@@ -356,12 +521,32 @@ const triggerWatchIntent = async ({
 const markIntentAsConfirmed = async ({
   intentId,
   paymentAmount,
+  tokenAmount,
   fromAddress,
 }: {
   intentId: string
-  paymentAmount: bigint
+  // AI3 path: shannons received on Auto EVM.
+  paymentAmount?: bigint
+  // USDC path: token base units received (USDC has 6 decimals). Recorded on its
+  // own column rather than reusing paymentAmount, which is denominated in
+  // shannons — putting USDC in it would make every AI3-shaped read of the row
+  // silently wrong, starting with the dust guard in onConfirmedIntent.
+  tokenAmount?: bigint
   fromAddress?: string
 }) => {
+  // Exactly one of the two is expected, but neither is the failure worth
+  // catching: it would confirm an intent with nothing received, which later
+  // surfaces as a 0-credit FAILED row that has to be diagnosed backwards from
+  // an on-chain payment.
+  if (paymentAmount === undefined && tokenAmount === undefined) {
+    return err(
+      new BadRequestError(
+        `Cannot confirm intent ${intentId}: neither an AI3 paymentAmount nor a ` +
+          'tokenAmount was supplied',
+      ),
+    )
+  }
+
   const intent = await intentsRepository.getById(intentId)
   if (!intent) {
     return err(new ObjectNotFoundError('Intent not found'))
@@ -393,13 +578,55 @@ const markIntentAsConfirmed = async ({
     await intentsRepository.updateIntent({
       ...intent,
       status: IntentStatus.CONFIRMED,
-      paymentAmount,
+      paymentAmount: paymentAmount ?? intent.paymentAmount,
+      tokenAmount: tokenAmount ?? intent.tokenAmount,
       fromAddress: fromAddress ?? intent.fromAddress,
     }),
   )
 }
 
+/**
+ * Bytes of storage a confirmed payment buys.
+ *
+ * Both paths are the same idea — convert what was received into AI3, then divide
+ * by the price per byte locked at creation. They differ only in what "convert"
+ * means, because an AI3 payment already IS AI3 and a USDC payment has to be
+ * converted at the rate the user was quoted.
+ *
+ * That rate is `quotedTokenAmount / quotedAi3Shannons`, held as the pair rather
+ * than as a stored ratio so the conversion is exact. It is emphatically NOT
+ * `usdRateAtCreation`: that is the pool's marginal price, while the user paid the
+ * executable quote plus the margin. Converting at the marginal rate refunds the
+ * swap fee, the price impact and the margin as free storage — 5-8% on a realistic
+ * purchase — and grants more bytes than the pre-payment cap check allowed for.
+ *
+ * Multiplication before division throughout, so no intermediate floors. Paying
+ * exactly `quotedTokenAmount` makes the first division exact
+ * (quotedTokenAmount * quotedAi3Shannons / quotedTokenAmount), leaving
+ * quotedAi3Shannons, and since that was requestedBytes * shannonsPerByte the
+ * second division is exact too. The user receives exactly the size they were
+ * quoted — no rounding in either direction. There is a regression test pinning
+ * this.
+ */
 const getIntentCredits = (intent: Intent): bigint => {
+  if (intent.paymentMethod === PaymentMethod.USDC_ETH) {
+    // A USDC intent without all three is not convertible. Returning 0 routes it
+    // to the FAILED branch in onConfirmedIntent for admin review, rather than
+    // guessing at a rate and granting the wrong amount.
+    if (
+      !intent.tokenAmount ||
+      !intent.quotedTokenAmount ||
+      !intent.quotedAi3Shannons
+    ) {
+      return BigInt(0)
+    }
+
+    const shannons =
+      (intent.tokenAmount * intent.quotedAi3Shannons) / intent.quotedTokenAmount
+
+    return shannons / intent.shannonsPerByte
+  }
+
   if (!intent.paymentAmount) {
     return BigInt(0)
   }
@@ -417,31 +644,45 @@ const onConfirmedIntent = async (intentId: string) => {
     return err(new Error('Intent should be not completed'))
   }
 
-  if (!intent.paymentAmount) {
+  // Which column carries "what was received" depends on the asset: shannons in
+  // paymentAmount for AI3, token base units in tokenAmount for USDC.
+  const receivedAmount =
+    intent.paymentMethod === PaymentMethod.USDC_ETH
+      ? intent.tokenAmount
+      : intent.paymentAmount
+
+  if (!receivedAmount) {
     logger.warn('Intent has no deposit amount', {
       intentId,
+      paymentMethod: intent.paymentMethod,
     })
     return err(new Error('Intent has no deposit amount'))
   }
 
   // Guard: reject payments whose value is too small to purchase even a single
-  // byte of storage.  getIntentCredits divides paymentAmount by shannonsPerByte
-  // using BigInt integer division, so a dust payment (paymentAmount <
-  // shannonsPerByte) yields 0 credits.  Granting 0 credits would mark the
-  // intent COMPLETED while giving the user nothing — a misleading outcome that
-  // wastes a DB row and silently discards the payment.
+  // byte of storage.  getIntentCredits divides down to bytes using BigInt
+  // integer division, so a dust payment yields 0 credits.  Granting 0 credits
+  // would mark the intent COMPLETED while giving the user nothing — a misleading
+  // outcome that wastes a DB row and silently discards the payment.
   //
-  // Both paymentAmount and shannonsPerByte are immutable on a confirmed intent,
-  // so this condition is permanent.  We mark the intent FAILED (terminal) so
-  // the polling loop stops retrying.  The on-chain payment is irreversible;
-  // resolution requires admin review (similar to OVER_CAP handling).
+  // On the USDC path this also catches an intent that is missing one of the three
+  // numbers the conversion needs, which getIntentCredits reports as 0 rather than
+  // guessing at a rate.
+  //
+  // Every input is immutable on a confirmed intent, so this condition is
+  // permanent.  We mark the intent FAILED (terminal) so the polling loop stops
+  // retrying.  The on-chain payment is irreversible; resolution requires admin
+  // review (similar to OVER_CAP handling).
   const creditBytes = IntentsUseCases.getIntentCredits(intent)
   if (creditBytes === BigInt(0)) {
     logger.warn(
       'onConfirmedIntent: payment too small to yield any credits — marking FAILED',
       {
         intentId,
-        paymentAmount: intent.paymentAmount.toString(),
+        paymentMethod: intent.paymentMethod,
+        receivedAmount: receivedAmount.toString(),
+        quotedTokenAmount: intent.quotedTokenAmount?.toString(),
+        quotedAi3Shannons: intent.quotedAi3Shannons?.toString(),
         shannonsPerByte: intent.shannonsPerByte.toString(),
       },
     )
@@ -467,7 +708,9 @@ const onConfirmedIntent = async (intentId: string) => {
       logger.warn('Intent blocked by per-user cap — marking OVER_CAP', {
         intentId,
         userPublicId: intent.userPublicId,
-        paymentAmount: intent.paymentAmount.toString(),
+        paymentMethod: intent.paymentMethod,
+        receivedAmount: receivedAmount.toString(),
+        creditBytes: creditBytes.toString(),
       })
       await intentsRepository.updateIntent({
         ...intent,
@@ -599,6 +842,7 @@ const getPendingWithTxHash = async (): Promise<Intent[]> => {
 export const IntentsUseCases = {
   createIntent,
   parseRequestedBytes,
+  parsePaymentMethod,
   getIntent,
   updateIntent,
   triggerWatchIntent,

--- a/apps/backend/src/core/users/intents.ts
+++ b/apps/backend/src/core/users/intents.ts
@@ -394,8 +394,8 @@ const createIntent = async (
   // the same intent is what makes the charge reproducible.
   const quotedAi3Shannons = requestedBytes! * shannonsPerByte
 
-  const price = await priceOracle.getPrice()
-  if (price.isErr()) {
+  const rate = await priceOracle.getPrice()
+  if (rate.isErr()) {
     logger.info(
       'Rejecting USDC intent creation — could not quote the purchase',
       {
@@ -404,11 +404,11 @@ const createIntent = async (
         quotedAi3Shannons: quotedAi3Shannons.toString(),
         // The reason, not just the message: it is the enum the admin dashboard
         // and #811's kill switch read, and it says which guard closed the door.
-        reason: price.error.reason,
-        message: price.error.message,
+        reason: rate.error.reason,
+        message: rate.error.message,
       },
     )
-    return err(quoteErrorToHttpError(price.error))
+    return err(quoteErrorToHttpError(rate.error))
   }
 
   // A rate times an amount, because the rate prices ONE BYTE and knows nothing
@@ -423,7 +423,7 @@ const createIntent = async (
   // converting a batch later, since the treasury no longer swaps per intent.
   // Reasoning lives in pricing.ts; do not re-derive it here.
   const quotedTokenAmount = applyMarginPercent(
-    ai3ShannonsToUsdcBaseUnits(quotedAi3Shannons, price.value.usdPerAi3),
+    ai3ShannonsToUsdcBaseUnits(quotedAi3Shannons, rate.value.usdPerAi3),
     config.credits.usdQuoteMarginPercent,
   )
 
@@ -441,7 +441,7 @@ const createIntent = async (
     // The raw oracle rate, for display and reconciliation only. NEVER convert a
     // payment at this rate: it is short by the margin the user actually paid, so
     // doing so grants that margin back as free storage.
-    usdRateAtCreation: price.value.usdPerAi3,
+    usdRateAtCreation: rate.value.usdPerAi3,
     expiresAt,
   })
 
@@ -451,12 +451,12 @@ const createIntent = async (
     requestedBytes: requestedBytes!.toString(),
     quotedAi3Shannons: quotedAi3Shannons.toString(),
     quotedTokenAmount: quotedTokenAmount.toString(),
-    usdPerAi3: price.value.usdPerAi3.toString(),
+    usdPerAi3: rate.value.usdPerAi3.toString(),
     // Whether the rate that priced this purchase was the last-good fallback
     // rather than a fresh read, and how old it is. Both are needed to explain a
     // charge after the fact.
-    rateAsOf: price.value.asOf.toISOString(),
-    rateStale: price.value.stale,
+    rateAsOf: rate.value.asOf.toISOString(),
+    rateStale: rate.value.stale,
   })
 
   return ok(intent)

--- a/apps/backend/src/core/users/intents.ts
+++ b/apps/backend/src/core/users/intents.ts
@@ -574,6 +574,45 @@ const markIntentAsConfirmed = async ({
     return ok(intent)
   }
 
+  // The amount has to be denominated in the asset the intent was quoted in.
+  //
+  // Nothing upstream enforces this. payIntent(bytes32) on the AI3 receiver
+  // accepts ANY intent id with any non-zero msg.value, and the watcher reports
+  // every such event as `paymentAmount` regardless of what the intent expects. So
+  // an AI3 payment against a USDC intent reaches here as a well-formed call.
+  //
+  // Confirming it anyway is what makes it dangerous. The row would go CONFIRMED
+  // with payment_amount set and token_amount NULL, onConfirmedIntent would look
+  // for the USDC column, find nothing, and the intent would sit in the 30-second
+  // polling loop indefinitely — payment kept, no credits, and no terminal row for
+  // an admin to find. Worse, the idempotency guard above would then treat the
+  // intent as settled, so the user's real USDC payment would be silently
+  // discarded when it arrived.
+  //
+  // Refusing leaves the intent PENDING so it expires on its own schedule. The
+  // mispaid amount still needs manual resolution, which is the same position a
+  // payment to an unknown intent id is already in.
+  const expectsToken = intent.paymentMethod === PaymentMethod.USDC_ETH
+  const suppliedAmount = expectsToken ? tokenAmount : paymentAmount
+  if (suppliedAmount === undefined) {
+    logger.warn(
+      'markIntentAsConfirmed: payment asset does not match the intent — refusing',
+      {
+        intentId,
+        paymentMethod: intent.paymentMethod,
+        gotPaymentAmount: paymentAmount?.toString(),
+        gotTokenAmount: tokenAmount?.toString(),
+      },
+    )
+    return err(
+      new BadRequestError(
+        `Cannot confirm intent ${intentId}: it is denominated in ` +
+          `${intent.paymentMethod ?? PaymentMethod.AI3_NATIVE} but the ` +
+          `confirmation supplied ${expectsToken ? 'an AI3 paymentAmount' : 'a tokenAmount'}`,
+      ),
+    )
+  }
+
   return ok(
     await intentsRepository.updateIntent({
       ...intent,
@@ -609,6 +648,16 @@ const markIntentAsConfirmed = async ({
  * this.
  */
 const getIntentCredits = (intent: Intent): bigint => {
+  // Both branches divide by it, and BigInt division by zero throws rather than
+  // returning a Result — which would escape onConfirmedIntent as an exception and
+  // abort the whole _checkConfirmedIntents tick, not just this intent. Reporting
+  // 0 routes the row to FAILED for admin review and leaves the rest of the batch
+  // alone. Reachable via a misconfigured CREDITS_PRICE_MULTIPLIER=0 or a zero
+  // byte fee at creation.
+  if (intent.shannonsPerByte === 0n) {
+    return BigInt(0)
+  }
+
   if (intent.paymentMethod === PaymentMethod.USDC_ETH) {
     // A USDC intent without all three is not convertible. Returning 0 routes it
     // to the FAILED branch in onConfirmedIntent for admin review, rather than
@@ -651,12 +700,28 @@ const onConfirmedIntent = async (intentId: string) => {
       ? intent.tokenAmount
       : intent.paymentAmount
 
+  // Terminal, not a retry. A CONFIRMED intent whose received-amount column is
+  // empty can never fill it in — nothing writes that column after confirmation —
+  // so returning an error just re-runs this every 30 seconds forever, keeping the
+  // payment with no credits granted and nothing in the admin queue to find.
+  // FAILED stops the loop and surfaces the row, which is how every other
+  // unresolvable confirmation in this function is handled.
+  //
+  // markIntentAsConfirmed now refuses a mismatched asset, so this is
+  // defence-in-depth for rows written before that check existed.
   if (!receivedAmount) {
-    logger.warn('Intent has no deposit amount', {
-      intentId,
-      paymentMethod: intent.paymentMethod,
+    logger.warn(
+      'onConfirmedIntent: confirmed intent has no deposit amount — marking FAILED',
+      {
+        intentId,
+        paymentMethod: intent.paymentMethod,
+      },
+    )
+    await intentsRepository.updateIntent({
+      ...intent,
+      status: IntentStatus.FAILED,
     })
-    return err(new Error('Intent has no deposit amount'))
+    return ok()
   }
 
   // Guard: reject payments whose value is too small to purchase even a single
@@ -665,9 +730,11 @@ const onConfirmedIntent = async (intentId: string) => {
   // would mark the intent COMPLETED while giving the user nothing — a misleading
   // outcome that wastes a DB row and silently discards the payment.
   //
-  // On the USDC path this also catches an intent that is missing one of the three
-  // numbers the conversion needs, which getIntentCredits reports as 0 rather than
-  // guessing at a rate.
+  // On the USDC path this also catches an intent that has a tokenAmount but is
+  // missing one of the other two conversion inputs, which getIntentCredits
+  // reports as 0 rather than guessing at a rate. A missing tokenAmount is caught
+  // by the guard above instead, since there is no received amount to reason about
+  // at all.
   //
   // Every input is immutable on a confirmed intent, so this condition is
   // permanent.  We mark the intent FAILED (terminal) so the polling loop stops

--- a/apps/backend/src/docs/reference/intents.ts
+++ b/apps/backend/src/docs/reference/intents.ts
@@ -87,8 +87,16 @@ export const intents = {
                   requestedBytes: {
                     type: 'string',
                     description:
-                      'How many bytes the purchase is for, as a decimal string (a JSON number is also accepted while it is a safe integer). Optional when paying in AI3, where the intent locks a per-byte rate and any payment settles it; required when paying in USDC, where the amount charged is that rate times this size. When supplied it is checked against the per-user credit cap before the intent is created, so a purchase with no headroom fails here rather than after an irreversible on-chain payment. It is not stored and does not appear on the returned intent: credits are derived from the amount actually paid, so it would never agree with the balance eventually granted.',
+                      'How many bytes the purchase is for, as a decimal string (a JSON number is also accepted while it is a safe integer). Checked against the per-user credit cap before the intent is created, so a purchase with no headroom fails here rather than after an irreversible on-chain payment. Optional when `paymentMethod` is `ai3_native`, where the intent locks a per-byte rate, any payment settles it, and the size is used only for that pre-check and then discarded. REQUIRED when `paymentMethod` is `usdc_eth`, where the amount charged is the AI3/USD rate applied to this size, returned as `quotedTokenAmount`.',
                     example: '1073741824',
+                  },
+                  paymentMethod: {
+                    type: 'string',
+                    enum: ['ai3_native', 'usdc_eth'],
+                    default: 'ai3_native',
+                    description:
+                      'Which asset the intent will be paid in. Omit for native AI3. With `usdc_eth` the response carries `quotedTokenAmount` — the exact USDC amount (6-decimal base units) to pay — locked for the intent\'s expiry window. An unrecognised value is rejected rather than defaulted, so a typo cannot quietly create an AI3 intent for a caller who intended to pay in USDC.',
+                    example: 'usdc_eth',
                   },
                 },
               },
@@ -108,7 +116,7 @@ export const intents = {
           },
           '400': {
             description:
-              '`requestedBytes` was supplied but is not a positive whole number of bytes, or is larger than the per-account maximum; or the intent is paid in USDC and no `requestedBytes` was supplied',
+              '`requestedBytes` was supplied but is not a positive whole number of bytes, or is larger than the per-account maximum; `requestedBytes` was omitted on a `usdc_eth` intent; or `paymentMethod` was not a recognised value',
           },
           '401': {
             description: 'Unauthorized — missing or invalid credentials',
@@ -120,6 +128,10 @@ export const intents = {
           '404': {
             description:
               'Feature not available — the buyCredits feature flag is not active for this user',
+          },
+          '503': {
+            description:
+              'The USDC price could not be established, which is our problem rather than the caller\'s — retry unchanged. `PRICE_ORACLE_UNAVAILABLE` when the rate could not be read or failed one of its guards; `PRICE_UNSTABLE` when the market has re-priced past the window the rate is averaged over. Note there is no size-related refusal: the rate is a size-independent average, so asking for less never turns a refusal into a quote.',
           },
         },
       },
@@ -274,7 +286,8 @@ export const intents = {
           },
           paymentAmount: {
             type: 'string',
-            description: 'Payment amount in shannons (bigint as string)',
+            description:
+              'AI3 amount received, in shannons (bigint as string). Set on `ai3_native` intents once payment is confirmed; null on `usdc_eth` intents, where `tokenAmount` carries what was received instead.',
           },
           shannonsPerByte: {
             type: 'string',
@@ -285,6 +298,31 @@ export const intents = {
             type: 'string',
             format: 'date-time',
             description: 'Price-lock expiry timestamp',
+          },
+          paymentMethod: {
+            type: 'string',
+            enum: ['ai3_native', 'usdc_eth'],
+            description: 'Asset this intent is paid in',
+          },
+          quotedTokenAmount: {
+            type: 'string',
+            description:
+              'For `usdc_eth`: the exact amount to pay, in USDC base units (6 decimals), as a bigint string. Locked until `expiresAt`. Already includes the pool swap fee, the price impact of this purchase size, and the quote margin. Null on `ai3_native`.',
+          },
+          quotedAi3Shannons: {
+            type: 'string',
+            description:
+              'For `usdc_eth`: the AI3 amount, in shannons, that `quotedTokenAmount` was quoted for. Together the two are the rate the payment converts to storage at, which is why paying exactly `quotedTokenAmount` grants exactly the bytes requested. Null on `ai3_native`.',
+          },
+          tokenAmount: {
+            type: 'string',
+            description:
+              'For `usdc_eth`: token base units actually received on-chain, set once payment is confirmed. Null on `ai3_native`.',
+          },
+          usdRateAtCreation: {
+            type: 'string',
+            description:
+              'For `usdc_eth`: the pool\'s marginal AI3/USD price at creation, scaled by 1e18. Reporting and reconciliation only — it excludes the fee, price impact and margin that `quotedTokenAmount` includes, so it is not the rate credits are granted at. Null on `ai3_native`.',
           },
         },
       },

--- a/apps/backend/src/docs/reference/intents.ts
+++ b/apps/backend/src/docs/reference/intents.ts
@@ -95,7 +95,7 @@ export const intents = {
                     enum: ['ai3_native', 'usdc_eth'],
                     default: 'ai3_native',
                     description:
-                      'Which asset the intent will be paid in. Omit for native AI3. With `usdc_eth` the response carries `quotedTokenAmount` — the exact USDC amount (6-decimal base units) to pay — locked for the intent\'s expiry window. An unrecognised value is rejected rather than defaulted, so a typo cannot quietly create an AI3 intent for a caller who intended to pay in USDC.',
+                      'Which asset the intent will be paid in. Omit for native AI3. With `usdc_eth` the response carries `quotedTokenAmount` — the exact USDC amount (6-decimal base units) to pay — locked for the intent\'s expiry window. An unrecognised value is rejected rather than defaulted, so a typo cannot quietly create an AI3 intent for a caller who intended to pay in USDC. `usdc_eth` is gated: it is available to admin accounts always, and to everyone else only where the deployment has enabled it (`PAY_WITH_USDC_ACTIVE`). A caller without access gets 403 `USDC_PAYMENTS_DISABLED`.',
                     example: 'usdc_eth',
                   },
                 },
@@ -123,7 +123,7 @@ export const intents = {
           },
           '403': {
             description:
-              'Google-verified account required (`GOOGLE_ACCOUNT_REQUIRED`), or the purchase would exceed the per-user credit cap (`CREDIT_CAP_EXCEEDED`, with the cap and current balance in `message`)',
+              'Google-verified account required (`GOOGLE_ACCOUNT_REQUIRED`); the purchase would exceed the per-user credit cap (`CREDIT_CAP_EXCEEDED`, with the cap and current balance in `message`); or `paymentMethod` was `usdc_eth` and paying in USDC is not open to this account (`USDC_PAYMENTS_DISABLED`)',
           },
           '404': {
             description:
@@ -131,7 +131,7 @@ export const intents = {
           },
           '503': {
             description:
-              'The USDC price could not be established, which is our problem rather than the caller\'s — retry unchanged. `PRICE_ORACLE_UNAVAILABLE` when the rate could not be read or failed one of its guards; `PRICE_UNSTABLE` when the market has re-priced past the window the rate is averaged over. Note there is no size-related refusal: the rate is a size-independent average, so asking for less never turns a refusal into a quote.',
+              'Storage could not be priced, which is our problem rather than the caller\'s — retry unchanged. On a `usdc_eth` intent: `PRICE_ORACLE_UNAVAILABLE` when the AI3/USD rate could not be read or failed one of its guards, `PRICE_UNSTABLE` when the market has re-priced past the window the rate is averaged over. Note there is no size-related refusal: the rate is a size-independent average, so asking for less never turns a refusal into a quote. On either payment method, also returned when the per-byte AI3 rate resolves to zero, which is a server misconfiguration rather than a market condition.',
           },
         },
       },
@@ -307,7 +307,7 @@ export const intents = {
           quotedTokenAmount: {
             type: 'string',
             description:
-              'For `usdc_eth`: the exact amount to pay, in USDC base units (6 decimals), as a bigint string. Locked until `expiresAt`. Already includes the pool swap fee, the price impact of this purchase size, and the quote margin. Null on `ai3_native`.',
+              'For `usdc_eth`: the exact amount to pay, in USDC base units (6 decimals), as a bigint string. Locked until `expiresAt`. It is the AI3/USD rate applied to `quotedAi3Shannons` plus the quote margin — and the margin is the whole of the difference, because the rate is an average of realized fills that already paid the pool\'s swap fee. This purchase adds no price impact of its own; the treasury converts USDC in batches rather than swapping per intent. Null on `ai3_native`.',
           },
           quotedAi3Shannons: {
             type: 'string',
@@ -322,7 +322,7 @@ export const intents = {
           usdRateAtCreation: {
             type: 'string',
             description:
-              'For `usdc_eth`: the pool\'s marginal AI3/USD price at creation, scaled by 1e18. Reporting and reconciliation only — it excludes the fee, price impact and margin that `quotedTokenAmount` includes, so it is not the rate credits are granted at. Null on `ai3_native`.',
+              'For `usdc_eth`: the raw AI3/USD rate at creation, scaled by 1e18 — a volume-weighted average of the pool\'s recent realized fills. Reporting and reconciliation only. It is short by the quote margin that `quotedTokenAmount` includes, so it is not the rate credits are granted at; that rate is the `quotedTokenAmount` / `quotedAi3Shannons` pair. Null on `ai3_native`.',
           },
         },
       },

--- a/apps/backend/src/errors/index.ts
+++ b/apps/backend/src/errors/index.ts
@@ -137,6 +137,65 @@ export class GoneError extends HttpError {
   }
 }
 
+// 503 Service Unavailable — a dependency we need was unreachable, or the data it
+// returned was not trustworthy enough to act on.
+//
+// Deliberately not 500: nothing is wrong with the request, the condition is
+// usually transient, and a client should be told to retry rather than to change
+// what it asked for.
+export class ServiceUnavailableError extends HttpError {
+  static readonly statusCode = 503
+  constructor(message: string) {
+    super(ServiceUnavailableError.statusCode, message)
+    this.name = 'ServiceUnavailableError'
+  }
+}
+
+// Why a USDC quote could not be produced. The price oracle draws four distinct
+// causes and they mean genuinely different things to whoever is buying: two are
+// our problem and retryable, two are about the requested size and are not. An
+// Ethereum outage reaching the user as "your purchase is too large" would send
+// them to shrink a purchase that was never the problem, so the cause travels to
+// the client as a code instead of being flattened into a 500 or into prose.
+export enum QuoteErrorCode {
+  // We could not reach the chain, or what we read failed its sanity checks.
+  ORACLE_UNAVAILABLE = 'PRICE_ORACLE_UNAVAILABLE',
+  // The pool's price is currently moving in a way we will not quote against.
+  PRICE_UNSTABLE = 'PRICE_UNSTABLE',
+  // The pool has no liquidity to fill a conversion this large.
+  QUOTE_TOO_LARGE = 'QUOTE_TOO_LARGE',
+  // The amount is unquotable on its own terms — below the minimum, or out of
+  // range for the quoter.
+  AMOUNT_INVALID = 'QUOTE_AMOUNT_INVALID',
+}
+
+// A quote failure, carrying both the HTTP status the cause maps to and the
+// machine-readable code.
+//
+// One class parameterised by cause rather than four subclasses: the mapping from
+// oracle error to (status, code) is a small table that is far easier to review as
+// a table than as four near-identical class bodies, and the response shape has to
+// be identical across all four regardless.
+export class QuoteFailedError extends HttpError {
+  public readonly code: QuoteErrorCode
+
+  constructor(statusCode: number, code: QuoteErrorCode, message: string) {
+    super(statusCode, message)
+    this.name = 'QuoteFailedError'
+    this.code = code
+  }
+
+  // Mirrors the { error: <code>, message: <human-readable> } shape the intents
+  // controller already uses for GOOGLE_ACCOUNT_REQUIRED and CREDIT_CAP_EXCEEDED,
+  // so a client branches on `error` and can surface `message` verbatim.
+  override handleResponse(res: Response) {
+    res.status(this.statusCode).json({
+      error: this.code,
+      message: this.message,
+    })
+  }
+}
+
 export const handleError = (error: Error, res: Response) => {
   if (error instanceof HttpError) {
     error.handleResponse(res)

--- a/apps/backend/src/errors/index.ts
+++ b/apps/backend/src/errors/index.ts
@@ -157,16 +157,16 @@ export class ServiceUnavailableError extends HttpError {
 // Ethereum outage reaching the user as "your purchase is too large" would send
 // them to shrink a purchase that was never the problem, so the cause travels to
 // the client as a code instead of being flattened into a 500 or into prose.
+// Both codes are 503s. There is deliberately no code here for "ask for less":
+// the oracle reports one size-independent rate, so it never refuses a quote on
+// account of the size, and a code the mapping cannot produce is a promise to
+// clients we would not keep.
 export enum QuoteErrorCode {
-  // We could not reach the chain, or what we read failed its sanity checks.
+  // We could not read a trustworthy rate, or what we read failed its guards.
   ORACLE_UNAVAILABLE = 'PRICE_ORACLE_UNAVAILABLE',
-  // The pool's price is currently moving in a way we will not quote against.
+  // The market has re-priced past the window the average is built from, so the
+  // rate describes a regime that has already been left.
   PRICE_UNSTABLE = 'PRICE_UNSTABLE',
-  // The pool has no liquidity to fill a conversion this large.
-  QUOTE_TOO_LARGE = 'QUOTE_TOO_LARGE',
-  // The amount is unquotable on its own terms — below the minimum, or out of
-  // range for the quoter.
-  AMOUNT_INVALID = 'QUOTE_AMOUNT_INVALID',
 }
 
 // A quote failure, carrying both the HTTP status the cause maps to and the

--- a/apps/backend/src/errors/index.ts
+++ b/apps/backend/src/errors/index.ts
@@ -137,6 +137,28 @@ export class GoneError extends HttpError {
   }
 }
 
+// 403 Forbidden — paying in USDC is not open to this caller.
+//
+// A subclass rather than a bare ForbiddenError for the same reason as
+// CreditCapExceededError: a client has to be able to tell "this asset is not
+// available to you" apart from "you need a Google account" without matching on
+// prose, and the code travels with the error rather than being re-attached at
+// each call site.
+export class UsdcPaymentsDisabledError extends ForbiddenError {
+  static readonly code = 'USDC_PAYMENTS_DISABLED'
+  constructor(message: string) {
+    super(message)
+    this.name = 'UsdcPaymentsDisabledError'
+  }
+
+  override handleResponse(res: Response) {
+    res.status(this.statusCode).json({
+      error: UsdcPaymentsDisabledError.code,
+      message: this.message,
+    })
+  }
+}
+
 // 503 Service Unavailable — a dependency we need was unreachable, or the data it
 // returned was not trustworthy enough to act on.
 //
@@ -151,16 +173,19 @@ export class ServiceUnavailableError extends HttpError {
   }
 }
 
-// Why a USDC quote could not be produced. The price oracle draws four distinct
-// causes and they mean genuinely different things to whoever is buying: two are
-// our problem and retryable, two are about the requested size and are not. An
-// Ethereum outage reaching the user as "your purchase is too large" would send
-// them to shrink a purchase that was never the problem, so the cause travels to
-// the client as a code instead of being flattened into a 500 or into prose.
-// Both codes are 503s. There is deliberately no code here for "ask for less":
-// the oracle reports one size-independent rate, so it never refuses a quote on
-// account of the size, and a code the mapping cannot produce is a promise to
-// clients we would not keep.
+// Why a USDC quote could not be produced.
+//
+// The oracle refuses for a dozen distinct reasons (see OracleUnavailableReason)
+// and they collapse into two facts a buyer can act on: the market has re-priced
+// past the window the average is built from, or we could not obtain a rate we
+// trust. Both are our problem and both are retryable, so both are 503s — the
+// cause still travels as a code, because "the market moved" and "the source is
+// down" call for different words on a screen and different alerts behind it.
+//
+// There is deliberately no code here for "ask for less". The rate is one
+// size-independent average of realized fills, so no oracle failure is about the
+// requested size, and a code the mapping cannot produce is a promise to clients
+// we would not keep.
 export enum QuoteErrorCode {
   // We could not read a trustworthy rate, or what we read failed its guards.
   ORACLE_UNAVAILABLE = 'PRICE_ORACLE_UNAVAILABLE',
@@ -169,18 +194,21 @@ export enum QuoteErrorCode {
   PRICE_UNSTABLE = 'PRICE_UNSTABLE',
 }
 
-// A quote failure, carrying both the HTTP status the cause maps to and the
-// machine-readable code.
+// A quote failure, carrying the machine-readable cause.
 //
-// One class parameterised by cause rather than four subclasses: the mapping from
-// oracle error to (status, code) is a small table that is far easier to review as
-// a table than as four near-identical class bodies, and the response shape has to
-// be identical across all four regardless.
-export class QuoteFailedError extends HttpError {
+// Extends ServiceUnavailableError rather than taking a status: every quote
+// failure is a 503, so the status belongs in the type rather than at each
+// construction site where it could be passed inconsistently.
+//
+// One class parameterised by cause rather than one subclass per code: the
+// mapping from oracle reason to code is a small table, far easier to review as a
+// table than as near-identical class bodies, and the response shape is identical
+// across all of them regardless.
+export class QuoteFailedError extends ServiceUnavailableError {
   public readonly code: QuoteErrorCode
 
-  constructor(statusCode: number, code: QuoteErrorCode, message: string) {
-    super(statusCode, message)
+  constructor(code: QuoteErrorCode, message: string) {
+    super(message)
     this.name = 'QuoteFailedError'
     this.code = code
   }

--- a/apps/backend/src/infrastructure/repositories/users/intentMispayments.ts
+++ b/apps/backend/src/infrastructure/repositories/users/intentMispayments.ts
@@ -1,0 +1,95 @@
+import { getDatabase } from '../../drivers/pg.js'
+import {
+  IntentMispayment,
+  IntentMispaymentReason,
+  PaymentMethod,
+} from '@auto-drive/models'
+
+type DBIntentMispayment = {
+  id: string
+  intent_id: string
+  reason: IntentMispaymentReason
+  expected_payment_method: PaymentMethod | null
+  payment_amount: string | null
+  token_amount: string | null
+  from_address: string | null
+  tx_hash: string | null
+  created_at: Date
+}
+
+const mapRows = (rows: DBIntentMispayment[]): IntentMispayment[] => {
+  return rows.map((row) => ({
+    // bigserial arrives as a string from pg and stays one: it is an identifier,
+    // never arithmetic.
+    id: row.id,
+    intentId: row.intent_id,
+    reason: row.reason,
+    expectedPaymentMethod: row.expected_payment_method ?? undefined,
+    paymentAmount: row.payment_amount
+      ? BigInt(row.payment_amount).valueOf()
+      : undefined,
+    tokenAmount: row.token_amount
+      ? BigInt(row.token_amount).valueOf()
+      : undefined,
+    fromAddress: row.from_address ?? undefined,
+    txHash: row.tx_hash ?? undefined,
+    createdAt: row.created_at,
+  }))
+}
+
+/**
+ * Record a refused payment. Returns the stored row, or null when this
+ * (transaction, intent) pair was already recorded.
+ *
+ * ON CONFLICT DO NOTHING because the watcher replays: reorgs re-emit events and
+ * the startup sweep re-runs every PENDING intent that carries a tx_hash. A
+ * mispayment is one fact about one transfer, so a second sighting must not
+ * become a second row — an admin queue that grows on every restart is one nobody
+ * reads.
+ *
+ * A payment with no tx_hash cannot be de-duplicated (NULLs are distinct in the
+ * index) and will insert again on replay. Every production caller has the hash;
+ * the parameter is optional only because the use case cannot require what its
+ * signature does not guarantee.
+ */
+const record = async (
+  mispayment: Omit<IntentMispayment, 'id' | 'createdAt'>,
+): Promise<IntentMispayment | null> => {
+  const db = await getDatabase()
+  const result = await db.query<DBIntentMispayment>(
+    `INSERT INTO intent_mispayments
+       (intent_id, reason, expected_payment_method, payment_amount,
+        token_amount, from_address, tx_hash)
+     VALUES ($1, $2, $3, $4, $5, $6, $7)
+     ON CONFLICT DO NOTHING
+     RETURNING *`,
+    [
+      mispayment.intentId,
+      mispayment.reason,
+      mispayment.expectedPaymentMethod ?? null,
+      mispayment.paymentAmount?.toString() ?? null,
+      mispayment.tokenAmount?.toString() ?? null,
+      mispayment.fromAddress ?? null,
+      mispayment.txHash ?? null,
+    ],
+  )
+  return mapRows(result.rows)[0] ?? null
+}
+
+// Newest first: an admin working this queue is working the most recent
+// incident, and the oldest rows are the ones already resolved out-of-band.
+const list = async (limit = 200): Promise<IntentMispayment[]> => {
+  const db = await getDatabase()
+  const result = await db.query<DBIntentMispayment>(
+    `SELECT * FROM intent_mispayments
+     ORDER BY created_at DESC, id DESC
+     LIMIT $1`,
+    [limit],
+  )
+  return mapRows(result.rows)
+}
+
+export const intentMispaymentsRepository = {
+  record,
+  list,
+}

--- a/apps/backend/src/infrastructure/repositories/users/intents.ts
+++ b/apps/backend/src/infrastructure/repositories/users/intents.ts
@@ -15,6 +15,9 @@ type DBIntent = {
   // Token-payment columns: populated for USDC_ETH intents, NULL for AI3_NATIVE.
   token_amount: string | null
   quoted_token_amount: string | null
+  // The AI3 amount the quote was priced for. With quoted_token_amount this is
+  // the effective rate the confirmation path converts at.
+  quoted_ai3_shannons: string | null
   usd_rate_at_creation: string | null
 }
 
@@ -37,6 +40,9 @@ const mapRows = (rows: DBIntent[]): Intent[] => {
     quotedTokenAmount: row.quoted_token_amount
       ? BigInt(row.quoted_token_amount).valueOf()
       : undefined,
+    quotedAi3Shannons: row.quoted_ai3_shannons
+      ? BigInt(row.quoted_ai3_shannons).valueOf()
+      : undefined,
     usdRateAtCreation: row.usd_rate_at_creation
       ? BigInt(row.usd_rate_at_creation).valueOf()
       : undefined,
@@ -58,8 +64,8 @@ const createIntent = async (intent: Intent): Promise<Intent> => {
     `INSERT INTO intents
        (id, user_public_id, status, tx_hash, payment_amount, shannons_per_byte,
         expires_at, payment_method, token_amount, quoted_token_amount,
-        usd_rate_at_creation)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+        quoted_ai3_shannons, usd_rate_at_creation)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
      RETURNING *`,
     [
       intent.id,
@@ -74,6 +80,7 @@ const createIntent = async (intent: Intent): Promise<Intent> => {
       intent.paymentMethod ?? PaymentMethod.AI3_NATIVE,
       intent.tokenAmount?.toString() ?? null,
       intent.quotedTokenAmount?.toString() ?? null,
+      intent.quotedAi3Shannons?.toString() ?? null,
       intent.usdRateAtCreation?.toString() ?? null,
     ],
   )
@@ -87,8 +94,9 @@ const updateIntent = async (intent: Intent): Promise<Intent> => {
      SET status = $1, user_public_id = $2, tx_hash = $3,
          payment_amount = $4, shannons_per_byte = $5, expires_at = $6,
          from_address = $7, payment_method = $8, token_amount = $9,
-         quoted_token_amount = $10, usd_rate_at_creation = $11
-     WHERE id = $12
+         quoted_token_amount = $10, quoted_ai3_shannons = $11,
+         usd_rate_at_creation = $12
+     WHERE id = $13
      RETURNING *`,
     [
       intent.status,
@@ -105,6 +113,7 @@ const updateIntent = async (intent: Intent): Promise<Intent> => {
       intent.paymentMethod ?? PaymentMethod.AI3_NATIVE,
       intent.tokenAmount?.toString() ?? null,
       intent.quotedTokenAmount?.toString() ?? null,
+      intent.quotedAi3Shannons?.toString() ?? null,
       intent.usdRateAtCreation?.toString() ?? null,
       intent.id,
     ],

--- a/apps/backend/src/infrastructure/services/paymentManager/index.ts
+++ b/apps/backend/src/infrastructure/services/paymentManager/index.ts
@@ -81,15 +81,34 @@ const _checkConfirmedIntents = async () => {
     intents: intents.map((intent) => intent.id),
   })
   for (const intent of intents) {
-    const result = await IntentsUseCases.onConfirmedIntent(intent.id)
+    // Per-intent, because `result.isErr()` only catches what onConfirmedIntent
+    // RETURNS. A thrown exception escapes this loop entirely and is swallowed by
+    // the safeCallback wrapping the interval, so one bad row stops every intent
+    // behind it in the batch from being credited — and since the batch is
+    // re-fetched each tick, it stops them forever, from users who paid
+    // correctly, with nothing terminal written anywhere to show why.
+    //
+    // getIntentCredits dividing by a zero shannonsPerByte is the known way in
+    // (guarded there too), but the point of this catch is the ones that are not
+    // known: an intent that cannot be processed must cost its own turn, never
+    // the queue's.
+    try {
+      const result = await IntentsUseCases.onConfirmedIntent(intent.id)
 
-    if (result.isErr()) {
-      logger.error('Error on confirmed intent', {
-        error: result.error,
-      })
-    } else {
-      logger.info('Marked intent as confirmed', {
+      if (result.isErr()) {
+        logger.error('Error on confirmed intent', {
+          intentId: intent.id,
+          error: result.error,
+        })
+      } else {
+        logger.info('Marked intent as confirmed', {
+          intentId: intent.id,
+        })
+      }
+    } catch (error) {
+      logger.error('Unhandled error on confirmed intent — skipping it', {
         intentId: intent.id,
+        error,
       })
     }
   }

--- a/apps/backend/src/infrastructure/services/paymentManager/index.ts
+++ b/apps/backend/src/infrastructure/services/paymentManager/index.ts
@@ -61,6 +61,10 @@ const watchTransaction = async (txHash: string) => {
         // receipt.from is the EVM wallet address that submitted the tx.
         // Stored so admins can identify the payer and process refunds.
         fromAddress: receipt.from,
+        // Passed for the refusal paths: a payment we decline to attach is
+        // recorded in intent_mispayments, and the hash is the only field that
+        // finds it again on a block explorer.
+        txHash,
       })
     }),
   )

--- a/packages/models/src/users/intent.ts
+++ b/packages/models/src/users/intent.ts
@@ -63,30 +63,54 @@ export const IntentSchema = z.object({
   // (USDC has 6 decimals). Set by the payment manager on confirmation.
   tokenAmount: z.bigint().optional(),
   // Token amount quoted to the user at creation, in the token's smallest unit.
-  // Nothing writes it yet; #747 does, when it prices a USDC intent.
+  // `usdRateAtCreation` applied to `quotedAi3Shannons`, plus USD_QUOTE_MARGIN.
+  //
+  // The fee and price impact the pool charged are inside it, but by way of the
+  // rate rather than this purchase: the rate averages realized fills, and those
+  // fills paid both. This purchase adds no impact of its own, because the
+  // treasury no longer swaps per intent.
   //
   // This is what the user was ASKED to pay, so it is margin-inclusive and
   // rounded up — it must never sit below what the purchase costs. It is
   // therefore not what credits are derived from either: those follow the amount
-  // actually received (paymentAmount / shannonsPerByte), which may be more or
-  // less than this.
+  // actually received, which may be more or less than this.
+  //
+  // One half of the effective rate. `quotedAi3Shannons` is the other half.
   quotedTokenAmount: z.bigint().optional(),
+  // The AI3 amount (shannons) `quotedTokenAmount` was quoted FOR — the
+  // requested byte count times `shannonsPerByte`. Not something the oracle is
+  // asked about: it reports one size-independent rate, and this is the amount
+  // that rate is applied to.
+  //
+  // Paired with `quotedTokenAmount` this IS the effective rate the user was
+  // charged at, and it is the pair rather than a rate because a rate here would
+  // have to be a rounded ratio: USDC carries 6 decimals against byte counts near
+  // 1e11, so USDC-per-byte is ~0.0027 base units and only survives as an integer
+  // if it is scaled — at which point it no longer round-trips the quote exactly.
+  // Two exact integers do:
+  //
+  //   bytes = tokenAmount * quotedAi3Shannons
+  //             / quotedTokenAmount / shannonsPerByte
+  //
+  // When the user pays exactly what was quoted the ratio cancels and the result
+  // is the requested size exactly. NULL for AI3_NATIVE.
+  quotedAi3Shannons: z.bigint().optional(),
   // AI3/USD rate at creation, scaled by USD_RATE_SCALE (1e18). Display,
   // reporting and oracle reconciliation — NOT the rate credits convert at.
   //
-  // This is the RAW rate the oracle reported, whatever its source at the time
-  // (the source has already changed twice; see #746). The user is charged that
-  // rate plus USD_QUOTE_MARGIN, so converting a received payment back to AI3 at
-  // this one returns the margin as free storage on every purchase — the whole
-  // margin, exactly, since a rate is a scalar and the error scales with the
-  // amount.
+  // This is the RAW rate the oracle reported: a volume-weighted average of the
+  // pool's recent realized fills (#746). The user is charged that rate plus
+  // USD_QUOTE_MARGIN, so converting a received payment back to AI3 at this one
+  // hands the margin back as free storage on every purchase — the whole margin,
+  // exactly, since a rate is a scalar and the error scales with the amount —
+  // and grants more bytes than the pre-payment cap check was run against.
   //
   // It stays raw on purpose, so it remains comparable to the market and usable
-  // for reconciliation. The consequence is that the USDC credit path has to
-  // persist its own margin-inclusive effective rate (see #747), and that no
-  // other field here can stand in for it: this one is short by the margin, and
-  // quotedTokenAmount above is an amount for one specific purchase rather than a
-  // rate.
+  // for reconciliation. The rate credits actually convert at is the
+  // `quotedTokenAmount` / `quotedAi3Shannons` pair above, which is why that pair
+  // is persisted: neither field here can stand in for it. This one is short by
+  // the margin, and `quotedTokenAmount` alone is an amount for one specific
+  // purchase rather than a rate.
   usdRateAtCreation: z.bigint().optional(),
 });
 

--- a/packages/models/src/users/intent.ts
+++ b/packages/models/src/users/intent.ts
@@ -116,6 +116,52 @@ export const IntentSchema = z.object({
 
 export type Intent = z.infer<typeof IntentSchema>;
 
+/**
+ * Why an on-chain payment could not be attached to the intent it named.
+ *
+ * Both receivers take any `intentId` from anyone — `payIntent(bytes32)` on Auto
+ * EVM and `payIntentWithToken(bytes32, uint256)` on Ethereum — so a payment can
+ * name an intent that does not exist, or one denominated in the other asset.
+ * Neither is resolvable in code: the money has moved and the only remaining
+ * question is who it belongs to.
+ */
+export enum IntentMispaymentReason {
+  // The intent id in the event matches no row.
+  UNKNOWN_INTENT = "unknown_intent",
+  // The row exists but is denominated in the other asset — AI3 sent to a USDC
+  // intent, or vice versa.
+  ASSET_MISMATCH = "asset_mismatch",
+}
+
+/**
+ * A payment that arrived and was refused, recorded so it can be resolved.
+ *
+ * Refusing is the right call — confirming a mispayment strands the intent and
+ * makes the idempotency guard discard the user's real payment when it lands —
+ * but a refusal that exists only as a log line leaves an irreversible on-chain
+ * transfer with nothing durable pointing at it. This row is what an admin works
+ * from: which intent was named, what actually arrived, who sent it, and the
+ * transaction to look it up by.
+ *
+ * Deliberately NOT foreign-keyed to `intents`: the UNKNOWN_INTENT case has no
+ * row to point at, and that is precisely the case with the least other evidence.
+ */
+export type IntentMispayment = {
+  id: string;
+  // The id named by the on-chain event. Not necessarily an existing intent.
+  intentId: string;
+  reason: IntentMispaymentReason;
+  // What the named intent was denominated in; absent for UNKNOWN_INTENT.
+  expectedPaymentMethod?: PaymentMethod;
+  // Whichever the watcher reported. Exactly one is set — which one is itself
+  // the evidence of what went wrong.
+  paymentAmount?: bigint;
+  tokenAmount?: bigint;
+  fromAddress?: string;
+  txHash?: string;
+  createdAt: Date;
+};
+
 export const intentCreationSchema = z.object({
   expiresAt: z
     .string()


### PR DESCRIPTION
Prices a USDC intent at creation and locks the rate the payment converts back at. Step #747 of epic #742. **Stacked on #808** — review that first; this diff is only the commits on top.

**Off by default.** `usdc_eth` sits behind `payWithUsdc` (`PAY_WITH_USDC_ACTIVE`), with admins exempt. Nothing settles a USDC intent yet — the payment manager subscribes to the AI3 receiver only, and no watcher reads `intentTokenPaymentReceivedAbi` — so a quote created today would be a binding amount the backend cannot observe payment of, returned without an address to send it to. Merging this lands the pricing half; opening the flag waits on #748.

## The problem

An AI3 intent stores one number and credits are `payment_amount / shannons_per_byte`. That works because the user pays in the asset the price is denominated in.

USDC does not. The user pays dollars, and converting back to bytes needs the AI3/USD rate — but **the rate they were charged at is not stored anywhere.** `usd_rate_at_creation` is the raw oracle rate, and the user pays that plus `USD_QUOTE_MARGIN`. Convert a received payment at the raw rate and the margin comes back as free storage on every purchase — the whole margin, exactly, since a rate is a scalar so the error scales with the amount. It also grants more bytes than #808's cap pre-check was run against.

## `quoted_ai3_shannons`, and why a rate column would not do

`quoted_token_amount` is what the user was charged. This new column is what they were charged **for**. The pair *is* the effective rate.

It is a pair rather than a single rate column because a rate here cannot be stored exactly. USDC carries 6 decimals against byte counts near 1e11, so USDC-per-byte is ~0.0027 base units — deeply sub-unit, and once scaled to survive as an integer it is a rounded ratio that no longer round-trips the quote. Two exact integers do:

```
bytes = token_amount * quoted_ai3_shannons / quoted_token_amount / shannons_per_byte
```

Pay exactly what was quoted and the ratio cancels: the user receives exactly the size they asked for, with no rounding in either direction. Overpay and it scales proportionally at the same effective rate.

Worked example — at 1 USDC = 1 AI3 = 1 GB with a 5% margin, a 1 GB purchase is quoted at 1.05 USDC and grants **1 GB, not 1.05 GB**. The margin is part of the price, not a payment for extra storage; it exists to cover FX drift until an operator converts the batch, and handing it back as bytes would make it cover nothing. Both behaviours are pinned by tests — one asserting the exact grant, one asserting that the raw-rate conversion over-credits.

## Also in the quoting path

- **`paymentMethod` on `POST /intents`**, defaulting to AI3 for body-less requests. An unrecognised value is rejected rather than defaulted: silently treating `'usdc'` as AI3 would quote in the wrong asset and the caller would find out at payment time.
- **Ordering**: flag, then validation, then cap pre-check, then the rate. A purchase that cannot be granted never costs a subgraph round-trip, and a failed quote writes no row.
- **Oracle failures are 503s**, `PRICE_UNSTABLE` distinguished from `PRICE_ORACLE_UNAVAILABLE`. There is deliberately no size-related code — see the rebase note.
- **A last-good (stale) rate still prices a binding quote.** Deliberate: the number is a days-long average, and refusing through every subgraph blip would shut the path further than the drift justifies.
- **An intent at a zero per-byte price is refused at creation**, on both payment methods. Every payment against one converts to zero credits and lands in FAILED with the money kept; on the USDC path the quote itself computes to 0 — a binding charge of "nothing" for a purchase that will never be granted. A 503, not a 4xx: the request was fine, the deployment is not.

## Rebased onto the subgraph-VWAP oracle

This branch was written against the oracle #807 replaced. Three things had to change, and none was mechanical:

| Written against | Now |
|---|---|
| `getExecutableQuote(ai3)` — priced a specific size | `getPrice()` — one size-independent rate, applied by multiplication |
| `409 QUOTE_TOO_LARGE` / `400 QUOTE_AMOUNT_INVALID` | deleted — no oracle failure is about the requested size, so no 4xx can tell the user to ask for less |
| over-credit test asserting >600bps (fee + impact + margin) | asserts against the configured margin, now the entire wedge |

The swap fee and price impact did not disappear — they moved inside the rate, which averages realized fills, and those fills paid both. What no longer exists is *this* purchase's own impact, because the treasury does not swap per intent.

## A payment bug found in review

`payIntent(bytes32)` on the AI3 receiver takes **any** intent id from anyone — no registry, no allowlist, just a non-zero value check — and the watcher reports it as `paymentAmount` regardless of what the intent expects. So an AI3 payment against a USDC intent arrived as a well-formed confirmation.

The row went CONFIRMED with `token_amount` NULL; `onConfirmedIntent` looked for the USDC column, found nothing, and returned an error **without writing a terminal status** — so the 30-second poller retried it forever. Payment kept, no credits, no admin row. Worse, the idempotency guard then treated the intent as settled, so the user's real USDC payment would be silently discarded on arrival.

Griefable rather than merely accidental: the intent id is visible in the calldata of a pending Ethereum tx, and racing Auto EVM against Ethereum confirmations is easy.

Fixes, defence in depth:

1. **`markIntentAsConfirmed` refuses an asset mismatch** before writing. The intent stays PENDING and expires on its own schedule. Ordered after the idempotency guard, so re-delivery for a settled intent stays a no-op.
2. **A confirmed-but-amountless intent is marked FAILED** rather than retried. Nothing writes that column after confirmation, so the state can never resolve itself.
3. **`getIntentCredits` returns 0 when `shannonsPerByte` is 0** — BigInt division by zero throws.
4. **`_checkConfirmedIntents` catches per intent.** It checked `result.isErr()`, which only covers what `onConfirmedIntent` *returns*; a **thrown** exception escaped the loop and was swallowed by the `safeCallback` on the interval, abandoning every intent queued behind it — from users who paid correctly, on every tick, with nothing written to explain why. The guard fixes the cause we found; the catch bounds the blast radius of the ones we did not. The existing batch tests only ever returned errors, which were always handled; the new one throws mid-batch and asserts the intent *after* the thrower still runs.

## Refusing is not resolving: `intent_mispayments`

Refusing a mispayment is correct, but it settles nothing on chain — the transfer happened, and a log line is not something an admin queries. Refused payments are now recorded, with the tx hash threaded from the watcher: an amount and a sender describe a payment, but only the hash finds it again. `GET /intents/mispayments` (admin) reads it, mirroring `/intents/over-cap` — that queue is for payments we accepted and could not convert, this one for payments we never accepted at all.

Two cases, and they are not equally new:

- **`ASSET_MISMATCH`** — the intent exists but is denominated in the other asset. New with USDC.
- **`UNKNOWN_INTENT`** — the id matches no row. **This is reachable on `main` today**, by anyone with a wallet, and until now produced only a log line. It is also the case with the least evidence anywhere else, since no intent row shows the money arrived at all.

Design notes: no foreign key to `intents`, because the unknown-intent case has nothing to point at — a FK would make the table incapable of recording precisely the case that needs it most. `ON CONFLICT DO NOTHING` on `(tx_hash, intent_id)`, because the watcher replays: reorgs re-emit events and the startup sweep re-runs every PENDING intent carrying a tx hash, so without it one mispayment becomes a fresh row per restart. Recording never throws — failing to file the paperwork must not change which error actually happened, and on the startup-sweep path a throw would abort the recovery of unrelated transactions.

## Down-migration is destructive

Credit derivation routes purely on `payment_method` and does **not** fall back to the AI3 formula, so a `usdc_eth` row without `quoted_ai3_shannons` yields 0 credits and is marked FAILED. Running the down-migration while paid USDC intents are in flight strands them. Drain or settle first.

## Verification

| Check | Result |
|---|---|
| `yarn models build && yarn backend build` | clean |
| `yarn backend lint` | clean |
| intents + PaymentManager + intentMispayments suites | 135 passed |
| `yarn frontend lint` + `tsc --noEmit` | clean |

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
