### PR TITLE
fix(downloads): stop cold-cache downloads failing silently, and fetch gateway chunks in parallel

### DIFF
--- a/apps/backend/__tests__/e2e/downloads/async.spec.ts
+++ b/apps/backend/__tests__/e2e/downloads/async.spec.ts
@@ -20,12 +20,22 @@ import { err } from 'neverthrow'
 describe('Async Downloads', () => {
   let user: User
   let cid: string
+  // A second object, untouched by the other tests. They all share `cid` and
+  // never clean up, so any test that needs to observe a first-ever request for
+  // an object needs one of its own. Content-addressed, hence the distinct body.
+  let dedupeCid: string
 
   beforeAll(async () => {
     await dbMigration.up()
     const mockUser = createMockUser()
     user = mockUser
     cid = await uploadFile(mockUser, 'test.txt', 'test', 'text/plain')
+    dedupeCid = await uploadFile(
+      mockUser,
+      'dedupe.txt',
+      'dedupe-test-content',
+      'text/plain',
+    )
   })
 
   afterAll(async () => {
@@ -207,26 +217,52 @@ describe('Async Downloads', () => {
     )
   })
 
-  it('should get all downloads for a user', async () => {
-    // Create multiple downloads for the same user
-    const download1 = await AsyncDownloadsUseCases.createDownload(
+  it('should reuse the in-flight download instead of queueing another', async () => {
+    const mockPublish = jest.spyOn(Rabbit, 'publish').mockResolvedValue()
+
+    const first = await AsyncDownloadsUseCases.createDownload(
+      user,
+      dedupeCid,
+    ).then((e) => e._unsafeUnwrap())
+    const second = await AsyncDownloadsUseCases.createDownload(
+      user,
+      dedupeCid,
+    ).then((e) => e._unsafeUnwrap())
+
+    // Same row, and crucially only one task: a retrieval runs for minutes, so
+    // a user will click again while it works. Before this, every click queued
+    // another full pull of the same object against the same gateway.
+    expect(second.id).toBe(first.id)
+    expect(mockPublish).toHaveBeenCalledTimes(1)
+
+    await AsyncDownloadsUseCases.dismissDownload(user, first.id)
+  })
+
+  it('should exclude dismissed downloads and allow a fresh request afterwards', async () => {
+    jest.spyOn(Rabbit, 'publish').mockResolvedValue()
+
+    const dismissed = await AsyncDownloadsUseCases.createDownload(
       user,
       cid,
     ).then((e) => e._unsafeUnwrap())
-    const download2 = await AsyncDownloadsUseCases.createDownload(
-      user,
-      cid,
-    ).then((e) => e._unsafeUnwrap())
+    await AsyncDownloadsUseCases.dismissDownload(user, dismissed.id)
 
-    await AsyncDownloadsUseCases.dismissDownload(user, download1.id)
-
-    // Get all downloads for the user
-    const downloads = await AsyncDownloadsUseCases.getDownloadsByUser(user)
-
-    // Verify that the downloads include the ones we just created
-    expect(downloads).toEqual(
-      expect.arrayContaining([expect.objectContaining({ id: download2.id })]),
+    // A dismissed row is no longer in flight, so asking again starts a new one
+    // rather than handing back the row the user just dismissed.
+    const fresh = await AsyncDownloadsUseCases.createDownload(user, cid).then(
+      (e) => e._unsafeUnwrap(),
     )
+    expect(fresh.id).not.toBe(dismissed.id)
+
+    const downloads = await AsyncDownloadsUseCases.getDownloadsByUser(user)
+    expect(downloads).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: fresh.id })]),
+    )
+    expect(downloads).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: dismissed.id })]),
+    )
+
+    await AsyncDownloadsUseCases.dismissDownload(user, fresh.id)
   })
 
   it('should get a specific download by id', async () => {

--- a/apps/backend/__tests__/unit/useCases/gatewayFileFetcher.spec.ts
+++ b/apps/backend/__tests__/unit/useCases/gatewayFileFetcher.spec.ts
@@ -16,11 +16,15 @@ import { asyncIterableToPromiseOfArray } from '@autonomys/asynchronous'
  * stays small enough to assert on byte for byte.
  */
 const CHUNK_CONCURRENCY = 4
+const GATEWAY_TIMEOUT_MS = 250
 process.env.FILES_GATEWAY_CHUNK_CONCURRENCY = String(CHUNK_CONCURRENCY)
 process.env.FILES_GATEWAY_CHUNK_RETRY_DELAY_MS = '1'
+process.env.FILES_GATEWAY_FETCH_TIMEOUT_MS = String(GATEWAY_TIMEOUT_MS)
 
 const fetchFileChunk =
-  jest.fn<(cid: string, chunk: number) => Promise<Buffer | null>>()
+  jest.fn<
+    (cid: string, chunk: number, signal?: AbortSignal) => Promise<Buffer | null>
+  >()
 const isFileCachedOnGateway = jest.fn<(cid: string) => Promise<boolean>>()
 const fetchGatewayFile = jest.fn<(cid: string) => Promise<Readable>>()
 
@@ -225,6 +229,52 @@ describe('FileGatewayObjectFetcher.fetchFile', () => {
     // Silently ending the stream here would hand the user a short file that
     // looks like a successful download.
     await expect(readAll('test-cid')).rejects.toThrow('gateway exploded')
+  })
+
+  it('aborts a chunk request it has given up on, and retries with a fresh signal', async () => {
+    jest
+      .spyOn(ObjectUseCases, 'getMetadata')
+      .mockResolvedValue(ok(metadataWithChunks(2)))
+
+    // Up to CHUNK_CONCURRENCY of these are open at once, so a request the
+    // fetcher has stopped waiting for is holding a connection its own retry
+    // needs. Timing out without aborting leaves it held for as long as the
+    // gateway does.
+    let attempts = 0
+    fetchFileChunk.mockImplementation(async (_cid, chunk, signal) => {
+      if (chunk >= 2) return null
+      if (chunk === 1 && attempts++ === 0) {
+        return new Promise((_resolve, reject) => {
+          signal?.addEventListener('abort', () => reject(new Error('aborted')))
+        })
+      }
+      return Buffer.from(`[${chunk}]`)
+    })
+
+    expect((await readAll('test-cid')).toString()).toBe('[0][1]')
+
+    const signalsForChunkOne = fetchFileChunk.mock.calls
+      .filter(([, chunk]) => chunk === 1)
+      .map(([, , signal]) => signal)
+
+    expect(signalsForChunkOne).toHaveLength(2)
+    expect(signalsForChunkOne[0]?.aborted).toBe(true)
+    // A controller shared across attempts would hand the retry a signal that
+    // is already aborted, so the retry could never succeed.
+    expect(signalsForChunkOne[1]?.aborted).toBe(false)
+  })
+
+  it('bounds the cached-file fetch with a timeout', async () => {
+    jest
+      .spyOn(ObjectUseCases, 'getMetadata')
+      .mockResolvedValue(ok(metadataWithChunks(1)))
+
+    isFileCachedOnGateway.mockResolvedValue(true)
+    // A gateway that accepts the connection and then says nothing. Nothing
+    // downstream has started yet, so nothing else would ever time this out.
+    fetchGatewayFile.mockReturnValue(new Promise(() => {}))
+
+    await expect(readAll('test-cid')).rejects.toThrow('timed out')
   })
 
   it('streams a file the gateway already holds in one request', async () => {

--- a/apps/backend/__tests__/unit/useCases/gatewayFileFetcher.spec.ts
+++ b/apps/backend/__tests__/unit/useCases/gatewayFileFetcher.spec.ts
@@ -1,0 +1,121 @@
+import { jest } from '@jest/globals'
+import { OffchainMetadata } from '@autonomys/auto-dag-data'
+import { ok } from 'neverthrow'
+import { asyncIterableToPromiseOfArray } from '@autonomys/asynchronous'
+
+/**
+ * The gateway fetcher composes a file out of per-chunk requests instead of the
+ * SDK's one-chunk-per-read stream. These cover the two things that change if
+ * that composition is wrong in a way a smoke test would not notice: the bytes
+ * must come back in chunk order, and the end of the file is decided by the
+ * gateway's 204 rather than by our chunk count.
+ */
+const fetchFileChunk = jest.fn<(cid: string, chunk: number) => Promise<Buffer | null>>()
+
+jest.unstable_mockModule(
+  '../../../src/infrastructure/services/dsn/fileGateway/index.js',
+  () => ({
+    fetchFileChunk,
+    FileGateway: { getNode: jest.fn() },
+  }),
+)
+
+const { FileGatewayObjectFetcher } = await import(
+  '../../../src/core/objects/files/fetchers.js'
+)
+const { ObjectUseCases } = await import('../../../src/core/objects/object.js')
+
+const metadataWithChunks = (count: number): OffchainMetadata =>
+  ({
+    totalSize: BigInt(count),
+    type: 'file',
+    dataCid: 'test-cid',
+    totalChunks: count,
+    chunks: Array.from({ length: count }, (_, i) => ({
+      cid: `chunk-${i}`,
+      size: 1n,
+    })),
+  }) as unknown as OffchainMetadata
+
+const readAll = async (cid: string): Promise<Buffer> => {
+  const stream = await FileGatewayObjectFetcher.fetchFile(cid)
+  return Buffer.concat(await asyncIterableToPromiseOfArray(stream))
+}
+
+describe('FileGatewayObjectFetcher.fetchFile', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('reassembles chunks in order regardless of the order they resolve in', async () => {
+    jest
+      .spyOn(ObjectUseCases, 'getMetadata')
+      .mockResolvedValue(ok(metadataWithChunks(5)))
+
+    // Resolve earlier chunks later, so a composer that emitted on completion
+    // rather than by index would produce visibly scrambled output.
+    fetchFileChunk.mockImplementation(async (_cid, chunk) => {
+      if (chunk >= 5) return null
+      await new Promise((resolve) => setTimeout(resolve, (5 - chunk) * 5))
+      return Buffer.from(`[${chunk}]`)
+    })
+
+    expect((await readAll('test-cid')).toString()).toBe('[0][1][2][3][4]')
+  })
+
+  it('issues the chunk requests concurrently rather than one at a time', async () => {
+    jest
+      .spyOn(ObjectUseCases, 'getMetadata')
+      .mockResolvedValue(ok(metadataWithChunks(8)))
+
+    let inFlight = 0
+    let peakInFlight = 0
+    fetchFileChunk.mockImplementation(async (_cid, chunk) => {
+      if (chunk >= 8) return null
+      inFlight++
+      peakInFlight = Math.max(peakInFlight, inFlight)
+      await new Promise((resolve) => setTimeout(resolve, 5))
+      inFlight--
+      return Buffer.from('x')
+    })
+
+    await readAll('test-cid')
+
+    // The whole point of this fetcher: serially it would peak at 1, and a
+    // 19,649-chunk object would cost 19,649 sequential round-trips.
+    expect(peakInFlight).toBeGreaterThan(1)
+  })
+
+  it('ends the file where the gateway says it ends, not where our count does', async () => {
+    // Metadata claims 3 chunks; the gateway 204s after 2. The 204 wins, so the
+    // file ends cleanly instead of hanging on a chunk that will never arrive.
+    jest
+      .spyOn(ObjectUseCases, 'getMetadata')
+      .mockResolvedValue(ok(metadataWithChunks(3)))
+
+    fetchFileChunk.mockImplementation(async (_cid, chunk) =>
+      chunk < 2 ? Buffer.from(`[${chunk}]`) : null,
+    )
+
+    expect((await readAll('test-cid')).toString()).toBe('[0][1]')
+  })
+
+  it('propagates a chunk failure instead of truncating the file', async () => {
+    jest
+      .spyOn(ObjectUseCases, 'getMetadata')
+      .mockResolvedValue(ok(metadataWithChunks(4)))
+
+    fetchFileChunk.mockImplementation(async (_cid, chunk) => {
+      if (chunk === 2) throw new Error('gateway exploded')
+      return Buffer.from(`[${chunk}]`)
+    })
+
+    // Silently ending the stream here would hand the user a short file that
+    // looks like a successful download.
+    await expect(readAll('test-cid')).rejects.toThrow('gateway exploded')
+  })
+})

--- a/apps/backend/__tests__/unit/useCases/gatewayFileFetcher.spec.ts
+++ b/apps/backend/__tests__/unit/useCases/gatewayFileFetcher.spec.ts
@@ -1,21 +1,35 @@
 import { jest } from '@jest/globals'
+import { Readable } from 'stream'
 import { OffchainMetadata } from '@autonomys/auto-dag-data'
 import { ok } from 'neverthrow'
 import { asyncIterableToPromiseOfArray } from '@autonomys/asynchronous'
 
 /**
- * The gateway fetcher composes a file out of per-chunk requests instead of the
- * SDK's one-chunk-per-read stream. These cover the two things that change if
+ * The gateway fetcher composes an uncached file out of per-chunk requests
+ * instead of the SDK's one-chunk-per-read stream. These cover what changes if
  * that composition is wrong in a way a smoke test would not notice: the bytes
- * must come back in chunk order, and the end of the file is decided by the
- * gateway's 204 rather than by our chunk count.
+ * must come back in chunk order and exactly once, the end of the file is
+ * decided by the gateway's 204 rather than by our chunk count, and a file the
+ * gateway already holds must not be composed chunk by chunk at all.
+ *
+ * Concurrency and the retry delay are turned down here so a multi-batch file
+ * stays small enough to assert on byte for byte.
  */
-const fetchFileChunk = jest.fn<(cid: string, chunk: number) => Promise<Buffer | null>>()
+const CHUNK_CONCURRENCY = 4
+process.env.FILES_GATEWAY_CHUNK_CONCURRENCY = String(CHUNK_CONCURRENCY)
+process.env.FILES_GATEWAY_CHUNK_RETRY_DELAY_MS = '1'
+
+const fetchFileChunk =
+  jest.fn<(cid: string, chunk: number) => Promise<Buffer | null>>()
+const isFileCachedOnGateway = jest.fn<(cid: string) => Promise<boolean>>()
+const fetchGatewayFile = jest.fn<(cid: string) => Promise<Readable>>()
 
 jest.unstable_mockModule(
   '../../../src/infrastructure/services/dsn/fileGateway/index.js',
   () => ({
     fetchFileChunk,
+    isFileCachedOnGateway,
+    fetchGatewayFile,
     FileGateway: { getNode: jest.fn() },
   }),
 )
@@ -42,9 +56,13 @@ const readAll = async (cid: string): Promise<Buffer> => {
   return Buffer.concat(await asyncIterableToPromiseOfArray(stream))
 }
 
+const requestedChunks = (): number[] =>
+  fetchFileChunk.mock.calls.map(([, chunk]) => chunk)
+
 describe('FileGatewayObjectFetcher.fetchFile', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    isFileCachedOnGateway.mockResolvedValue(false)
   })
 
   afterEach(() => {
@@ -67,15 +85,67 @@ describe('FileGatewayObjectFetcher.fetchFile', () => {
     expect((await readAll('test-cid')).toString()).toBe('[0][1][2][3][4]')
   })
 
-  it('issues the chunk requests concurrently rather than one at a time', async () => {
+  /**
+   * The regression that matters, and the reason read() must not be async.
+   *
+   * push() clears Node's own re-entrancy guard, so a read() that pushes and
+   * then awaits gets called again while it is still suspended. Both calls read
+   * the same cursor and request the same range. Two conditions arm it, and both
+   * hold in production: a chunk payload just under the 64 KiB high-water mark
+   * (the gateway's is 65,066), so a single push leaves the buffer with room and
+   * returns true; and any latency on the chunk request, so the second call
+   * lands during the await.
+   *
+   * What it costs depends on who wins the race. Measured against the previous
+   * implementation at this shape: 37 requests for a 21-request file, 16 of the
+   * 20 chunks fetched twice — the gateway doing half its work again on the one
+   * path this PR exists to make cheaper. When the consumer is slower than the
+   * gateway, which is the normal case for a browser on a real connection, the
+   * duplicate arrives before end-of-stream and is emitted as file content
+   * instead of being dropped: a download longer than the file, under a content
+   * address, written into the cache for everyone behind it.
+   *
+   * The request-side assertion is the deterministic one; the byte assertion
+   * catches the same defect only when the timing exposes it.
+   */
+  it('requests and emits every chunk exactly once across several batches', async () => {
+    const CHUNKS = CHUNK_CONCURRENCY * 5
+    const CHUNK_SIZE = 65066 // the gateway's payload size, just under the mark
     jest
       .spyOn(ObjectUseCases, 'getMetadata')
-      .mockResolvedValue(ok(metadataWithChunks(8)))
+      .mockResolvedValue(ok(metadataWithChunks(CHUNKS)))
+
+    const chunkBytes = (chunk: number) =>
+      Buffer.alloc(CHUNK_SIZE, `${chunk % 10}`)
+
+    fetchFileChunk.mockImplementation(async (_cid, chunk) => {
+      if (chunk >= CHUNKS) return null
+      await new Promise((resolve) => setTimeout(resolve, 1))
+      return chunkBytes(chunk)
+    })
+
+    const expected = Buffer.concat(
+      Array.from({ length: CHUNKS }, (_, i) => chunkBytes(i)),
+    )
+    const received = await readAll('test-cid')
+
+    const requested = requestedChunks().filter((chunk) => chunk < CHUNKS)
+    expect(requested.length).toBe(CHUNKS)
+    expect(new Set(requested).size).toBe(CHUNKS)
+
+    expect(received.length).toBe(expected.length)
+    expect(received.equals(expected)).toBe(true)
+  })
+
+  it('keeps at most FILES_GATEWAY_CHUNK_CONCURRENCY requests in flight', async () => {
+    jest
+      .spyOn(ObjectUseCases, 'getMetadata')
+      .mockResolvedValue(ok(metadataWithChunks(CHUNK_CONCURRENCY * 3)))
 
     let inFlight = 0
     let peakInFlight = 0
     fetchFileChunk.mockImplementation(async (_cid, chunk) => {
-      if (chunk >= 8) return null
+      if (chunk >= CHUNK_CONCURRENCY * 3) return null
       inFlight++
       peakInFlight = Math.max(peakInFlight, inFlight)
       await new Promise((resolve) => setTimeout(resolve, 5))
@@ -85,9 +155,11 @@ describe('FileGatewayObjectFetcher.fetchFile', () => {
 
     await readAll('test-cid')
 
-    // The whole point of this fetcher: serially it would peak at 1, and a
-    // 19,649-chunk object would cost 19,649 sequential round-trips.
+    // Serially this peaks at 1 and a 19,649-chunk object costs 19,649
+    // sequential round-trips; unbounded it would open all 19,649 at once and
+    // bury the gateway. Both directions have to be pinned.
     expect(peakInFlight).toBeGreaterThan(1)
+    expect(peakInFlight).toBeLessThanOrEqual(CHUNK_CONCURRENCY)
   })
 
   it('ends the file where the gateway says it ends, not where our count does', async () => {
@@ -104,6 +176,42 @@ describe('FileGatewayObjectFetcher.fetchFile', () => {
     expect((await readAll('test-cid')).toString()).toBe('[0][1]')
   })
 
+  it('discards whatever a batch returns after the gateway 204s', async () => {
+    // The 204 can land mid-batch while the requests after it are still in
+    // flight and still returning bytes. Appending those would put data past the
+    // end of the file.
+    jest
+      .spyOn(ObjectUseCases, 'getMetadata')
+      .mockResolvedValue(ok(metadataWithChunks(CHUNK_CONCURRENCY)))
+
+    fetchFileChunk.mockImplementation(async (_cid, chunk) => {
+      if (chunk === 1) return null
+      return Buffer.from(`[${chunk}]`)
+    })
+
+    expect((await readAll('test-cid')).toString()).toBe('[0]')
+  })
+
+  it('retries a chunk that fails transiently instead of failing the file', async () => {
+    jest
+      .spyOn(ObjectUseCases, 'getMetadata')
+      .mockResolvedValue(ok(metadataWithChunks(3)))
+
+    // One flaky request out of ~19,650 is a near-certainty on a large object,
+    // and without a retry it takes the whole retrieval with it.
+    let failuresLeft = 1
+    fetchFileChunk.mockImplementation(async (_cid, chunk) => {
+      if (chunk >= 3) return null
+      if (chunk === 1 && failuresLeft > 0) {
+        failuresLeft--
+        throw new Error('gateway hiccup')
+      }
+      return Buffer.from(`[${chunk}]`)
+    })
+
+    expect((await readAll('test-cid')).toString()).toBe('[0][1][2]')
+  })
+
   it('propagates a chunk failure instead of truncating the file', async () => {
     jest
       .spyOn(ObjectUseCases, 'getMetadata')
@@ -117,5 +225,21 @@ describe('FileGatewayObjectFetcher.fetchFile', () => {
     // Silently ending the stream here would hand the user a short file that
     // looks like a successful download.
     await expect(readAll('test-cid')).rejects.toThrow('gateway exploded')
+  })
+
+  it('streams a file the gateway already holds in one request', async () => {
+    jest
+      .spyOn(ObjectUseCases, 'getMetadata')
+      .mockResolvedValue(ok(metadataWithChunks(1000)))
+
+    isFileCachedOnGateway.mockResolvedValue(true)
+    fetchGatewayFile.mockResolvedValue(Readable.from([Buffer.from('cached')]))
+
+    expect((await readAll('test-cid')).toString()).toBe('cached')
+
+    // Composing it per chunk would be a thousand requests, each a fresh DAG
+    // walk gateway-side, for bytes it has on disk.
+    expect(fetchGatewayFile).toHaveBeenCalledWith('test-cid')
+    expect(fetchFileChunk).not.toHaveBeenCalled()
   })
 })

--- a/apps/backend/src/app/controllers/download.ts
+++ b/apps/backend/src/app/controllers/download.ts
@@ -22,6 +22,7 @@ import {
   handleInternalErrorResult,
 } from '../../shared/utils/neverthrow.js'
 import { TimeoutError } from '../../shared/utils/timeout.js'
+import { DownloadStatus } from '@auto-drive/models'
 
 const logger = createLogger('http:controllers:download')
 
@@ -40,7 +41,29 @@ downloadController.get(
       handleError(checkStatusResult.error, res)
       return
     }
-    res.json({ status: checkStatusResult.value })
+
+    // `status` keeps its two-value shape so existing clients and the SDK are
+    // unaffected; `reconstruction` is additive. Without it "not-cached" is the
+    // only thing this endpoint can say, and it says the same thing whether a
+    // pull from the DSN is twelve minutes in or was never started — which is
+    // exactly the ambiguity that makes a slow file look like a dead one.
+    const reconstruction =
+      checkStatusResult.value === DownloadStatus.Cached
+        ? null
+        : await AsyncDownloadsUseCases.getReconstructionByCid(cid).catch(
+            (error) => {
+              // Advisory only: never fail the status check over it, or the
+              // client loses the one signal it can still act on.
+              logger.warn(
+                error as Error,
+                'Failed to read reconstruction state (cid=%s)',
+                cid,
+              )
+              return null
+            },
+          )
+
+    res.json({ status: checkStatusResult.value, reconstruction })
   }),
 )
 

--- a/apps/backend/src/config.ts
+++ b/apps/backend/src/config.ts
@@ -151,6 +151,12 @@ export const config = {
     // matching the DB path's concurrentChunks turns that into batches.
     // Raising it trades gateway load for wall-clock on cold downloads.
     chunkConcurrency: positiveIntEnv('FILES_GATEWAY_CHUNK_CONCURRENCY', 100),
+    // Attempts per chunk request, matching what the SDK's own chunk fetch
+    // does. A 1.28 GB object is ~19,650 requests, so at any realistic
+    // per-request failure rate an unretried chunk fetch is a retrieval that
+    // fails somewhere in the middle almost every time.
+    chunkRetries: positiveIntEnv('FILES_GATEWAY_CHUNK_RETRIES', 3),
+    chunkRetryDelayMs: positiveIntEnv('FILES_GATEWAY_CHUNK_RETRY_DELAY_MS', 500),
   },
   authService: {
     url: env('AUTH_SERVICE_URL', 'http://localhost:3030'),
@@ -359,6 +365,18 @@ export const config = {
     taskManagerMaxRetries: Number(env('TASK_MANAGER_MAX_RETRIES', '3')),
     downloadInactivityTimeoutMs: Number(
       env('DOWNLOAD_INACTIVITY_TIMEOUT_MS', '300000'),
+    ),
+    // How often a running async download stamps its row so it still reads as
+    // alive, and how long a row may go unstamped before it is treated as dead.
+    // The window has to clear several heartbeats so a slow database write or a
+    // requeued task doesn't declare a healthy download abandoned.
+    asyncDownloadHeartbeatMs: positiveIntEnv(
+      'ASYNC_DOWNLOAD_HEARTBEAT_MS',
+      30000,
+    ),
+    asyncDownloadStaleAfterMs: positiveIntEnv(
+      'ASYNC_DOWNLOAD_STALE_AFTER_MS',
+      300000,
     ),
   },
   featureFlags: {

--- a/apps/backend/src/config.ts
+++ b/apps/backend/src/config.ts
@@ -145,6 +145,12 @@ export const config = {
     fetchTimeoutMs: Number(
       env('FILES_GATEWAY_FETCH_TIMEOUT_MS', '60000'),
     ),
+    // How many chunk requests to keep in flight when reconstructing a file
+    // from the gateway. The SDK's whole-file reader fetches one chunk per
+    // read(), so a large object cost one sequential round-trip per chunk;
+    // matching the DB path's concurrentChunks turns that into batches.
+    // Raising it trades gateway load for wall-clock on cold downloads.
+    chunkConcurrency: positiveIntEnv('FILES_GATEWAY_CHUNK_CONCURRENCY', 100),
   },
   authService: {
     url: env('AUTH_SERVICE_URL', 'http://localhost:3030'),

--- a/apps/backend/src/config.ts
+++ b/apps/backend/src/config.ts
@@ -150,6 +150,12 @@ export const config = {
     // read(), so a large object cost one sequential round-trip per chunk;
     // matching the DB path's concurrentChunks turns that into batches.
     // Raising it trades gateway load for wall-clock on cold downloads.
+    //
+    // Safe above 5 only because FILES_GATEWAY_URL addresses the gateway
+    // process directly. The public gateway vhost caps a single client at
+    // `limit_conn addr 5`, so pointing this at that hostname would leave 95 of
+    // every 100 chunk requests answered with a 503 that no amount of retrying
+    // clears — the limit is not transient.
     chunkConcurrency: positiveIntEnv('FILES_GATEWAY_CHUNK_CONCURRENCY', 100),
     // Attempts per chunk request, matching what the SDK's own chunk fetch
     // does. A 1.28 GB object is ~19,650 requests, so at any realistic

--- a/apps/backend/src/config.ts
+++ b/apps/backend/src/config.ts
@@ -151,11 +151,14 @@ export const config = {
     // matching the DB path's concurrentChunks turns that into batches.
     // Raising it trades gateway load for wall-clock on cold downloads.
     //
-    // Safe above 5 only because FILES_GATEWAY_URL addresses the gateway
-    // process directly. The public gateway vhost caps a single client at
-    // `limit_conn addr 5`, so pointing this at that hostname would leave 95 of
-    // every 100 chunk requests answered with a 503 that no amount of retrying
-    // clears — the limit is not transient.
+    // The ceiling is not ours to choose alone: FILES_GATEWAY_URL is the
+    // gateway's public hostname, so this fan-out crosses whatever the origin
+    // enforces, and that host's vhost caps one client at `limit_conn addr 5`.
+    // Whether this trips it depends on how many connections actually reach the
+    // origin — the hostname is CDN-fronted, so the limiter counts the edge's
+    // connections rather than ours. A 503 from a connection limiter is not
+    // transient, so the retries below will not clear one. Lower this before
+    // assuming a failing cold download is the gateway's fault.
     chunkConcurrency: positiveIntEnv('FILES_GATEWAY_CHUNK_CONCURRENCY', 100),
     // Attempts per chunk request, matching what the SDK's own chunk fetch
     // does. A 1.28 GB object is ~19,650 requests, so at any realistic

--- a/apps/backend/src/core/downloads/async.ts
+++ b/apps/backend/src/core/downloads/async.ts
@@ -30,6 +30,25 @@ const createDownload = async (
     return err(new ObjectNotFoundError(`Object with cid=${cid} not found`))
   }
 
+  // Repeat requests join the run already in flight instead of starting another.
+  // The UI calls this from both the download modal and "Bring to Cache", and a
+  // reconstruction takes long enough that a user will click again — which used
+  // to mean a second row, a second task, and a second full pull of the same
+  // object competing with the first for the same gateway.
+  const existing = await asyncDownloadsRepository.getActiveDownloadByCidAndUser(
+    cid,
+    user.oauthProvider,
+    user.oauthUserId,
+  )
+  if (existing) {
+    logger.info(
+      'Reusing in-flight async download id=%s cid=%s',
+      existing.id,
+      cid,
+    )
+    return ok(existing)
+  }
+
   const download = await asyncDownloadsRepository.createDownload(
     v4(),
     user.oauthProvider,
@@ -161,6 +180,23 @@ const asyncDownload = async (
   if (result.isErr()) {
     return err(result.error)
   }
+
+  // Nothing ever wrote this status before, so a reconstruction sat on "Pending"
+  // for its entire run — the badge renders a percentage only for Downloading,
+  // which meant the one screen the user watches showed no sign of progress for
+  // twenty minutes and read as a stuck job. Setting it here also un-sticks a
+  // row a previous attempt left as Failed: a retry of this task now visibly
+  // takes over instead of leaving the earlier failure on screen.
+  await AsyncDownloadsUseCases.updateStatus(
+    downloadId,
+    AsyncDownloadStatus.Downloading,
+  ).catch((e) =>
+    logger.warn(
+      e as Error,
+      'Failed to mark download as downloading id=%s',
+      downloadId,
+    ),
+  )
 
   let file: Awaited<ReturnType<typeof downloadService.download>>
   try {
@@ -362,9 +398,40 @@ const getDownloadById = async (
   return ok(download)
 }
 
+/**
+ * Whatever the server can currently say about an uncached object being pulled
+ * back from the DSN, for the download-status endpoint.
+ *
+ * Deliberately not scoped to the caller: the cache is shared, so a job another
+ * user started is the reason this caller's file is about to become available,
+ * and reporting a bare "not cached" while that runs is what makes the UI look
+ * like the file is gone.
+ */
+const getReconstructionByCid = async (
+  cid: string,
+): Promise<{
+  state: 'running' | 'idle'
+  downloadedBytes: string
+  totalSize: string
+  startedAt: Date | null
+} | null> => {
+  const active = await asyncDownloadsRepository.getActiveDownloadByCid(cid)
+  if (!active) {
+    return null
+  }
+
+  return {
+    state: 'running',
+    downloadedBytes: active.downloadedBytes ?? '0',
+    totalSize: active.fileSize ?? '0',
+    startedAt: active.createdAt ?? null,
+  }
+}
+
 export const AsyncDownloadsUseCases = {
   createDownload,
   getDownloadsByUser,
+  getReconstructionByCid,
   updateProgress,
   updateStatus,
   dismissDownload,

--- a/apps/backend/src/core/downloads/async.ts
+++ b/apps/backend/src/core/downloads/async.ts
@@ -39,6 +39,7 @@ const createDownload = async (
     cid,
     user.oauthProvider,
     user.oauthUserId,
+    config.params.asyncDownloadStaleAfterMs,
   )
   if (existing) {
     logger.info(
@@ -219,10 +220,31 @@ const asyncDownload = async (
 
   return new Promise((resolve) => {
     let settled = false
+
+    // Keeps the row readable as alive while nothing else is writing to it. The
+    // status endpoint reports any recently-stamped Pending/Downloading row for
+    // a cid to every user, and the client disables its own request while one is
+    // running — so without a heartbeat the only way to tell a worker that died
+    // from one still waiting on the gateway's first byte would be to wait long
+    // enough that a dead row blocks the cid for everyone in the meantime.
+    const heartbeat = setInterval(() => {
+      asyncDownloadsRepository
+        .touchDownload(downloadId)
+        .catch((e) =>
+          logger.warn(
+            e as Error,
+            'Failed to stamp heartbeat for download id=%s',
+            downloadId,
+          ),
+        )
+    }, config.params.asyncDownloadHeartbeatMs)
+    heartbeat.unref()
+
     const settle = (value: Result<void, ObjectNotFoundError | InternalError>) => {
       if (settled) return
       settled = true
       clearTimeout(inactivityTimer)
+      clearInterval(heartbeat)
       resolve(value)
     }
 
@@ -405,17 +427,23 @@ const getDownloadById = async (
  * Deliberately not scoped to the caller: the cache is shared, so a job another
  * user started is the reason this caller's file is about to become available,
  * and reporting a bare "not cached" while that runs is what makes the UI look
- * like the file is gone.
+ * like the file is gone. That same lack of scoping is why the repository only
+ * counts a row that has been stamped recently — the client disables its own
+ * request while a reconstruction is running, so a row nothing is working on
+ * would take the feature away from everyone who asks about that cid.
  */
 const getReconstructionByCid = async (
   cid: string,
 ): Promise<{
-  state: 'running' | 'idle'
+  state: 'running'
   downloadedBytes: string
   totalSize: string
   startedAt: Date | null
 } | null> => {
-  const active = await asyncDownloadsRepository.getActiveDownloadByCid(cid)
+  const active = await asyncDownloadsRepository.getActiveDownloadByCid(
+    cid,
+    config.params.asyncDownloadStaleAfterMs,
+  )
   if (!active) {
     return null
   }

--- a/apps/backend/src/core/objects/files/fetchers.ts
+++ b/apps/backend/src/core/objects/files/fetchers.ts
@@ -7,10 +7,13 @@ import { NodesUseCases } from '../nodes.js'
 import {
   FileGateway,
   fetchFileChunk,
+  fetchGatewayFile,
+  isFileCachedOnGateway,
 } from '../../../infrastructure/services/dsn/fileGateway/index.js'
 import { handleReadableError } from '../../../shared/utils/index.js'
 import { ObjectUseCases } from '../object.js'
 import { withTimeout } from '../../../shared/utils/timeout.js'
+import { withBackingOffRetries } from '../../../shared/utils/retries.js'
 import { config } from '../../../config.js'
 import { createLogger } from '../../../infrastructure/drivers/logger.js'
 import PizZip from 'pizzip'
@@ -52,15 +55,20 @@ export const DBObjectFetcher: ObjectFetcher = {
 }
 
 const CHUNK_CONCURRENCY = config.filesGateway.chunkConcurrency
+const CHUNK_RETRIES = config.filesGateway.chunkRetries
+const CHUNK_RETRY_DELAY_MS = config.filesGateway.chunkRetryDelayMs
 
 /**
  * Streams a file out of the gateway with many chunk requests in flight.
  *
- * FileGateway.getFile does the same job one chunk per read(), strictly in
- * series — 19,649 round-trips for a 1.28 GB object, which is where most of the
- * twenty-plus minutes of a cold download goes. Chunk order is preserved and the
- * end is detected the same way the SDK detects it (a 204 past the last chunk),
- * so the bytes are identical; only the request pattern changes.
+ * This is the cold path only — a file the gateway already holds is served by
+ * fetchGatewayFile in a single streaming response, and composing it per chunk
+ * instead would be ~19,650 requests to rebuild bytes the gateway has on disk.
+ * Uncached, the SDK composes one chunk per read(), strictly in series: 19,649
+ * round-trips for a 1.28 GB object, which is where most of the twenty-plus
+ * minutes of a cold download goes. Chunk order is preserved and the end is
+ * still decided by the gateway's 204, so the bytes are identical; only the
+ * request pattern changes.
  *
  * `expectedChunks` comes from our own metadata and is a sizing hint, not a
  * bound: batches are capped to it so the tail doesn't fan out into requests
@@ -74,9 +82,10 @@ const composeGatewayFileReadable = (
 ): Readable => {
   let nextChunk = 0
   let exhausted = false
+  let pumping = false
   const pending: Buffer[] = []
 
-  // Held across read() calls rather than re-fetched: a consumer that fills up
+  // Held across pump turns rather than re-fetched: a consumer that fills up
   // mid-batch would otherwise throw away up to CHUNK_CONCURRENCY chunks that
   // were already paid for, and pull them again on the next read.
   const drainPending = (stream: Readable): boolean => {
@@ -88,47 +97,90 @@ const composeGatewayFileReadable = (
     return true
   }
 
-  const readable = new Readable({
-    async read() {
-      try {
-        if (!drainPending(this)) return
+  // One transient 5xx or timeout out of ~19,650 requests would otherwise fail
+  // the whole retrieval. The SDK's own per-chunk fetch retries three times for
+  // the same reason; this path has to do it itself.
+  const fetchChunk = (index: number): Promise<Buffer | null> =>
+    withBackingOffRetries(
+      () =>
+        withTimeout(
+          fetchFileChunk(cid, index),
+          GATEWAY_TIMEOUT_MS,
+          `FileGateway.chunk(${cid},${index})`,
+        ),
+      { maxRetries: CHUNK_RETRIES, startingDelay: CHUNK_RETRY_DELAY_MS },
+    )
+
+  /**
+   * Fetches until the consumer's buffer is full or the file ends.
+   *
+   * This is a loop rather than one batch per read() because read() MUST NOT be
+   * async here. Node clears its own re-entrancy guard (`state.reading`) on the
+   * first push(), so an async read() that pushes and then awaits is called
+   * again while it is still suspended, and the second call reads the same
+   * `nextChunk` and requests the same range. Both conditions that arm it hold
+   * on this path: a chunk payload just under the 64 KiB high-water mark, so a
+   * single push leaves room and returns true, and latency on the request, so
+   * the second call lands inside the await.
+   *
+   * Measured against the async-read() version: 37 requests for a 21-request
+   * file, over half the chunks fetched twice. Where the duplicate lands depends
+   * on who wins the race — after end-of-stream it is dropped, before it the
+   * chunk is emitted a second time as file content, which is a download longer
+   * than the file it claims to be.
+   *
+   * So: `pumping` makes the pump single-flight, and the pump keeps going by
+   * itself instead of relying on the read() it displaced. Claiming the range
+   * before awaiting keeps `nextChunk` monotonic even if a future edit finds
+   * another way in.
+   */
+  const pump = async (stream: Readable): Promise<void> => {
+    if (pumping) return
+    pumping = true
+    try {
+      for (;;) {
+        // Buffer full: read() resumes us once the consumer has drained it.
+        if (!drainPending(stream)) return
 
         if (exhausted) {
-          this.push(null)
+          stream.push(null)
           return
         }
 
         const remaining = expectedChunks - nextChunk
         const batchSize =
           remaining > 0 ? Math.min(CHUNK_CONCURRENCY, remaining) : 1
+        const batchStart = nextChunk
+        nextChunk += batchSize
 
         const batch = await Promise.all(
-          Array.from({ length: batchSize }, (_, offset) => {
-            const index = nextChunk + offset
-            return withTimeout(
-              fetchFileChunk(cid, index),
-              GATEWAY_TIMEOUT_MS,
-              `FileGateway.chunk(${cid},${index})`,
-            )
-          }),
+          Array.from({ length: batchSize }, (_, offset) =>
+            fetchChunk(batchStart + offset),
+          ),
         )
 
-        for (const data of batch) {
-          // A 204 means we're past the last chunk, and so is everything after
-          // it in this batch.
-          if (data === null) {
-            exhausted = true
-            break
-          }
-          nextChunk++
-          pending.push(data)
+        // A 204 means we're past the last chunk, and so is everything after it
+        // in this batch — rewind to what the file actually contains.
+        const end = batch.indexOf(null)
+        if (end !== -1) {
+          exhausted = true
+          nextChunk = batchStart + end
         }
 
-        if (!drainPending(this)) return
-        if (exhausted) this.push(null)
-      } catch (error) {
-        this.destroy(error instanceof Error ? error : new Error(String(error)))
+        for (const data of end === -1 ? batch : batch.slice(0, end)) {
+          pending.push(data!)
+        }
       }
+    } catch (error) {
+      stream.destroy(error instanceof Error ? error : new Error(String(error)))
+    } finally {
+      pumping = false
+    }
+  }
+
+  const readable = new Readable({
+    read() {
+      void pump(this)
     },
   })
 
@@ -146,6 +198,16 @@ export const FileGatewayObjectFetcher: ObjectFetcher = {
     const metadata = getMetadataResult.value
 
     if (metadata.type === 'file') {
+      // A file the gateway has already reconstructed comes back in one
+      // streaming response, which is what the SDK's getFile does on a cache hit
+      // and what this used to get for free. Per-chunk composition is for the
+      // cold path only: on a hit it would be ~19,650 requests, each one a fresh
+      // DAG walk from the root gateway-side, for bytes already on its disk.
+      if (await isFileCachedOnGateway(cid)) {
+        logger.debug('Fetching cached file from gateway cid=%s', cid)
+        return fetchGatewayFile(cid)
+      }
+
       logger.debug(
         'Fetching file from gateway cid=%s (chunks=%d, concurrency=%d)',
         cid,

--- a/apps/backend/src/core/objects/files/fetchers.ts
+++ b/apps/backend/src/core/objects/files/fetchers.ts
@@ -100,14 +100,23 @@ const composeGatewayFileReadable = (
   // One transient 5xx or timeout out of ~19,650 requests would otherwise fail
   // the whole retrieval. The SDK's own per-chunk fetch retries three times for
   // the same reason; this path has to do it itself.
+  //
+  // A controller per attempt, not per chunk: timing out is what arms it, so a
+  // shared one would abort the retries as soon as it fired. Aborting matters
+  // here because up to CHUNK_CONCURRENCY of these are open at once — a
+  // timed-out request that keeps its connection is holding a slot the retry
+  // now needs.
   const fetchChunk = (index: number): Promise<Buffer | null> =>
     withBackingOffRetries(
-      () =>
-        withTimeout(
-          fetchFileChunk(cid, index),
+      () => {
+        const abortController = new AbortController()
+        return withTimeout(
+          fetchFileChunk(cid, index, abortController.signal),
           GATEWAY_TIMEOUT_MS,
           `FileGateway.chunk(${cid},${index})`,
-        ),
+          abortController,
+        )
+      },
       { maxRetries: CHUNK_RETRIES, startingDelay: CHUNK_RETRY_DELAY_MS },
     )
 
@@ -205,7 +214,15 @@ export const FileGatewayObjectFetcher: ObjectFetcher = {
       // DAG walk from the root gateway-side, for bytes already on its disk.
       if (await isFileCachedOnGateway(cid)) {
         logger.debug('Fetching cached file from gateway cid=%s', cid)
-        return fetchGatewayFile(cid)
+        // Bounds getting the stream, not the transfer over it — a gateway that
+        // accepts the connection and then says nothing would otherwise never
+        // reject, and this call is upstream of everything that reports a
+        // download as running, so nothing would be there to time it out.
+        return withTimeout(
+          fetchGatewayFile(cid),
+          GATEWAY_TIMEOUT_MS,
+          `FileGateway.getFile(${cid})`,
+        )
       }
 
       logger.debug(

--- a/apps/backend/src/core/objects/files/fetchers.ts
+++ b/apps/backend/src/core/objects/files/fetchers.ts
@@ -4,7 +4,11 @@ import {
   retrieveAndReassembleFolderAsZip,
 } from './nodeComposer.js'
 import { NodesUseCases } from '../nodes.js'
-import { FileGateway } from '../../../infrastructure/services/dsn/fileGateway/index.js'
+import {
+  FileGateway,
+  fetchFileChunk,
+} from '../../../infrastructure/services/dsn/fileGateway/index.js'
+import { handleReadableError } from '../../../shared/utils/index.js'
 import { ObjectUseCases } from '../object.js'
 import { withTimeout } from '../../../shared/utils/timeout.js'
 import { config } from '../../../config.js'
@@ -47,6 +51,92 @@ export const DBObjectFetcher: ObjectFetcher = {
   },
 }
 
+const CHUNK_CONCURRENCY = config.filesGateway.chunkConcurrency
+
+/**
+ * Streams a file out of the gateway with many chunk requests in flight.
+ *
+ * FileGateway.getFile does the same job one chunk per read(), strictly in
+ * series — 19,649 round-trips for a 1.28 GB object, which is where most of the
+ * twenty-plus minutes of a cold download goes. Chunk order is preserved and the
+ * end is detected the same way the SDK detects it (a 204 past the last chunk),
+ * so the bytes are identical; only the request pattern changes.
+ *
+ * `expectedChunks` comes from our own metadata and is a sizing hint, not a
+ * bound: batches are capped to it so the tail doesn't fan out into requests
+ * that can only 204, but the 204 still decides where the file ends. If the
+ * gateway ever disagreed with our chunk count, this would keep reading rather
+ * than truncate the file.
+ */
+const composeGatewayFileReadable = (
+  cid: string,
+  expectedChunks: number,
+): Readable => {
+  let nextChunk = 0
+  let exhausted = false
+  const pending: Buffer[] = []
+
+  // Held across read() calls rather than re-fetched: a consumer that fills up
+  // mid-batch would otherwise throw away up to CHUNK_CONCURRENCY chunks that
+  // were already paid for, and pull them again on the next read.
+  const drainPending = (stream: Readable): boolean => {
+    while (pending.length > 0) {
+      if (!stream.push(pending.shift()!)) {
+        return false
+      }
+    }
+    return true
+  }
+
+  const readable = new Readable({
+    async read() {
+      try {
+        if (!drainPending(this)) return
+
+        if (exhausted) {
+          this.push(null)
+          return
+        }
+
+        const remaining = expectedChunks - nextChunk
+        const batchSize =
+          remaining > 0 ? Math.min(CHUNK_CONCURRENCY, remaining) : 1
+
+        const batch = await Promise.all(
+          Array.from({ length: batchSize }, (_, offset) => {
+            const index = nextChunk + offset
+            return withTimeout(
+              fetchFileChunk(cid, index),
+              GATEWAY_TIMEOUT_MS,
+              `FileGateway.chunk(${cid},${index})`,
+            )
+          }),
+        )
+
+        for (const data of batch) {
+          // A 204 means we're past the last chunk, and so is everything after
+          // it in this batch.
+          if (data === null) {
+            exhausted = true
+            break
+          }
+          nextChunk++
+          pending.push(data)
+        }
+
+        if (!drainPending(this)) return
+        if (exhausted) this.push(null)
+      } catch (error) {
+        this.destroy(error instanceof Error ? error : new Error(String(error)))
+      }
+    },
+  })
+
+  handleReadableError(readable, 'Gateway file stream error cid=%s', cid)
+
+  return readable
+}
+
 export const FileGatewayObjectFetcher: ObjectFetcher = {
   async fetchFile(cid: string): Promise<Readable> {
     const getMetadataResult = await ObjectUseCases.getMetadata(cid)
@@ -57,15 +147,12 @@ export const FileGatewayObjectFetcher: ObjectFetcher = {
 
     if (metadata.type === 'file') {
       logger.debug(
-        'Fetching file from gateway cid=%s (timeout=%dms)',
+        'Fetching file from gateway cid=%s (chunks=%d, concurrency=%d)',
         cid,
-        GATEWAY_TIMEOUT_MS,
+        metadata.chunks.length,
+        CHUNK_CONCURRENCY,
       )
-      return withTimeout(
-        FileGateway.getFile(cid),
-        GATEWAY_TIMEOUT_MS,
-        `FileGateway.getFile(${cid})`,
-      )
+      return composeGatewayFileReadable(cid, metadata.chunks.length)
     }
 
     return retrieveAndReassembleFolderAsZip(new PizZip(), cid)

--- a/apps/backend/src/infrastructure/repositories/asyncDownloads/index.ts
+++ b/apps/backend/src/infrastructure/repositories/asyncDownloads/index.ts
@@ -72,18 +72,33 @@ const getDownloadByCid = async (
  * to every other user's "is this being fetched?" — without this the status
  * endpoint can only say "not cached", which reads as "broken" while a
  * reconstruction is minutes into running.
+ *
+ * "Still running" has to mean recently alive, not merely Pending or
+ * Downloading. A worker that dies mid-pull, or a task that never arrives,
+ * leaves a row in one of those states forever — and since this query is not
+ * scoped to a user, one such row would tell every user that the cid is already
+ * being fetched, disabling their own request permanently and leaving only its
+ * owner able to dismiss it. The running worker stamps updated_at (see
+ * touchDownload), so anything older than staleAfterMs is a corpse.
  */
 const getActiveDownloadByCid = async (
   cid: string,
+  staleAfterMs: number,
 ): Promise<AsyncDownload | null> => {
   const db = await getDatabase()
 
   const download = await db.query<AsyncDownloadDB>(
     `SELECT * FROM public.async_downloads
      WHERE cid = $1 AND status IN ($2, $3)
+       AND updated_at > NOW() - ($4::bigint * INTERVAL '1 millisecond')
      ORDER BY created_at DESC
      LIMIT 1`,
-    [cid, AsyncDownloadStatus.Pending, AsyncDownloadStatus.Downloading],
+    [
+      cid,
+      AsyncDownloadStatus.Pending,
+      AsyncDownloadStatus.Downloading,
+      staleAfterMs,
+    ],
   )
 
   return download.rows.map(mapAsyncDownloadDBToAsyncDownload).at(0) ?? null
@@ -92,14 +107,20 @@ const getActiveDownloadByCid = async (
 /**
  * This user's own still-running request for this cid, used to make repeat
  * clicks idempotent. Without it every click on Download or "Bring to Cache"
- * inserts another row and publishes another task, so N clicks (or N users on a
- * popular file) become N concurrent full reconstructions competing for the
- * same gateway.
+ * inserts another row and publishes another task, so N clicks become N
+ * concurrent full reconstructions of the same object competing for the same
+ * gateway. Scoped to the user because the row is the user's own record of the
+ * request — two users asking for one cid still get a row each.
+ *
+ * Bounded by staleAfterMs for the same reason as getActiveDownloadByCid: a dead
+ * row must not make a user's every later request a no-op that hands back a job
+ * nothing is working on.
  */
 const getActiveDownloadByCidAndUser = async (
   cid: string,
   oauth_provider: string,
   oauth_user_id: string,
+  staleAfterMs: number,
 ): Promise<AsyncDownload | null> => {
   const db = await getDatabase()
 
@@ -107,6 +128,7 @@ const getActiveDownloadByCidAndUser = async (
     `SELECT * FROM public.async_downloads
      WHERE cid = $1 AND oauth_provider = $2 AND oauth_user_id = $3
        AND status IN ($4, $5)
+       AND updated_at > NOW() - ($6::bigint * INTERVAL '1 millisecond')
      ORDER BY created_at DESC
      LIMIT 1`,
     [
@@ -115,10 +137,29 @@ const getActiveDownloadByCidAndUser = async (
       oauth_user_id,
       AsyncDownloadStatus.Pending,
       AsyncDownloadStatus.Downloading,
+      staleAfterMs,
     ],
   )
 
   return download.rows.map(mapAsyncDownloadDBToAsyncDownload).at(0) ?? null
+}
+
+/**
+ * Stamps updated_at so the row still reads as alive.
+ *
+ * Progress writes already do this, but only once bytes are flowing: a cold
+ * retrieval can spend minutes reconstructing before its first byte, and for
+ * that whole window a healthy download and a dead worker are indistinguishable
+ * in the table. The heartbeat is what lets the staleness bound above be short
+ * enough to be useful.
+ */
+const touchDownload = async (id: string): Promise<void> => {
+  const db = await getDatabase()
+
+  await db.query(
+    'UPDATE public.async_downloads SET updated_at = NOW() WHERE id = $1',
+    [id],
+  )
 }
 
 const createDownload = async (
@@ -200,6 +241,7 @@ export const asyncDownloadsRepository = {
   getDownloadByCid,
   getActiveDownloadByCid,
   getActiveDownloadByCidAndUser,
+  touchDownload,
   createDownload,
   updateDownloadStatus,
   updateDownloadProgress,

--- a/apps/backend/src/infrastructure/repositories/asyncDownloads/index.ts
+++ b/apps/backend/src/infrastructure/repositories/asyncDownloads/index.ts
@@ -66,6 +66,61 @@ const getDownloadByCid = async (
   return download.rows.map(mapAsyncDownloadDBToAsyncDownload).at(0) ?? null
 }
 
+/**
+ * The most recent still-running reconstruction for this cid, regardless of who
+ * asked for it. The cache is shared, so one user's in-flight job is the answer
+ * to every other user's "is this being fetched?" — without this the status
+ * endpoint can only say "not cached", which reads as "broken" while a
+ * reconstruction is minutes into running.
+ */
+const getActiveDownloadByCid = async (
+  cid: string,
+): Promise<AsyncDownload | null> => {
+  const db = await getDatabase()
+
+  const download = await db.query<AsyncDownloadDB>(
+    `SELECT * FROM public.async_downloads
+     WHERE cid = $1 AND status IN ($2, $3)
+     ORDER BY created_at DESC
+     LIMIT 1`,
+    [cid, AsyncDownloadStatus.Pending, AsyncDownloadStatus.Downloading],
+  )
+
+  return download.rows.map(mapAsyncDownloadDBToAsyncDownload).at(0) ?? null
+}
+
+/**
+ * This user's own still-running request for this cid, used to make repeat
+ * clicks idempotent. Without it every click on Download or "Bring to Cache"
+ * inserts another row and publishes another task, so N clicks (or N users on a
+ * popular file) become N concurrent full reconstructions competing for the
+ * same gateway.
+ */
+const getActiveDownloadByCidAndUser = async (
+  cid: string,
+  oauth_provider: string,
+  oauth_user_id: string,
+): Promise<AsyncDownload | null> => {
+  const db = await getDatabase()
+
+  const download = await db.query<AsyncDownloadDB>(
+    `SELECT * FROM public.async_downloads
+     WHERE cid = $1 AND oauth_provider = $2 AND oauth_user_id = $3
+       AND status IN ($4, $5)
+     ORDER BY created_at DESC
+     LIMIT 1`,
+    [
+      cid,
+      oauth_provider,
+      oauth_user_id,
+      AsyncDownloadStatus.Pending,
+      AsyncDownloadStatus.Downloading,
+    ],
+  )
+
+  return download.rows.map(mapAsyncDownloadDBToAsyncDownload).at(0) ?? null
+}
+
 const createDownload = async (
   id: string,
   oauth_provider: string,
@@ -143,6 +198,8 @@ export const asyncDownloadsRepository = {
   getDownloadById,
   getUndismissedDownloadsByUser,
   getDownloadByCid,
+  getActiveDownloadByCid,
+  getActiveDownloadByCidAndUser,
   createDownload,
   updateDownloadStatus,
   updateDownloadProgress,

--- a/apps/backend/src/infrastructure/services/download/index.ts
+++ b/apps/backend/src/infrastructure/services/download/index.ts
@@ -10,7 +10,10 @@ import {
 import { config } from '../../../config.js'
 import { Readable } from 'stream'
 import { DownloadServiceOptions, DownloadStatus } from '@auto-drive/models'
-import { handleReadableError } from '../../../shared/utils/index.js'
+import {
+  handleReadableError,
+  propagateReadableError,
+} from '../../../shared/utils/index.js'
 
 const logger = createLogger('download-service')
 
@@ -102,6 +105,17 @@ export const downloadService = {
         ? await forkStream(stream)
         : await forkAsyncIterable(stream)
 
+    propagateReadableError(stream, returnStream, cacheStream)
+
+    // Every branch needs a listener of its own before it can be failed: an
+    // 'error' with no listener at all is an uncaught exception, and the point
+    // of propagating is to make these branches emit one. Consumers that pipe
+    // still see the error and still fail the response.
+    handleReadableError(
+      returnStream,
+      'Return branch stream error for cid %s',
+      cid,
+    )
     handleReadableError(
       cacheStream,
       'Cache branch stream error for cid %s',
@@ -138,6 +152,7 @@ export const downloadService = {
     // Fork the stream again for caching w/o blocking the main thread
     forkStream(cacheStream)
       .then(async ([fsCacheStream, memoryCacheStream]) => {
+        propagateReadableError(cacheStream, fsCacheStream, memoryCacheStream)
         handleReadableError(
           fsCacheStream,
           'Filesystem cache stream error for cid %s',

--- a/apps/backend/src/infrastructure/services/download/index.ts
+++ b/apps/backend/src/infrastructure/services/download/index.ts
@@ -108,6 +108,33 @@ export const downloadService = {
       cid,
     )
 
+    // lru-cache refuses any entry bigger than maxEntrySize, which defaults to
+    // maxSize when it isn't set — as it isn't here. memoryDownloadCache.set
+    // only discovers that after asyncIterableToBuffer has assembled the entire
+    // object in the worker's heap, so a file above the cap costs its full size
+    // in RAM to produce a guaranteed miss, on a process that also serves every
+    // other download. Decide from the size we already hold instead, and give
+    // the filesystem tier the undivided stream when memory is out of the
+    // question. An unknown size means the bytes came from the memory tier in
+    // the first place, so there is nothing to put back there either.
+    const fitsInMemoryCache =
+      size !== undefined &&
+      size <= BigInt(config.memoryDownloadCache.maxCacheSize)
+
+    if (!fitsInMemoryCache) {
+      logger.debug(
+        'Skipping memory cache for cid=%s (size=%s, cap=%d)',
+        cid,
+        size?.toString() ?? 'unknown',
+        config.memoryDownloadCache.maxCacheSize,
+      )
+      fsCache.set(cid, { data: cacheStream, size }).catch((error) => {
+        logger.warn(error, 'Error setting filesystem cache for cid %s', cid)
+      })
+
+      return returnStream
+    }
+
     // Fork the stream again for caching w/o blocking the main thread
     forkStream(cacheStream)
       .then(async ([fsCacheStream, memoryCacheStream]) => {

--- a/apps/backend/src/infrastructure/services/dsn/fileGateway/index.ts
+++ b/apps/backend/src/infrastructure/services/dsn/fileGateway/index.ts
@@ -1,10 +1,46 @@
+import { Readable } from 'stream'
 import { config } from '../../../../config.js'
 import { createAutoFilesApi } from '@autonomys/auto-files'
+import { createLogger } from '../../../drivers/logger.js'
+
+const logger = createLogger('services:dsn:fileGateway')
 
 export const FileGateway = createAutoFilesApi(
   config.filesGateway.url,
   config.filesGateway.token,
 )
+
+/**
+ * Whether the gateway already holds this file, and can therefore stream it back
+ * in one response instead of being asked for it chunk by chunk.
+ *
+ * Answers false when the check itself fails: the caller's fallback is to
+ * compose the file from chunks, which works either way, so a status hiccup must
+ * not fail a download that could still succeed.
+ */
+export const isFileCachedOnGateway = async (cid: string): Promise<boolean> => {
+  try {
+    return (await FileGateway.isFileCached(cid)) === true
+  } catch (error) {
+    logger.warn(
+      error as Error,
+      'Could not read gateway cache status for cid=%s; assuming uncached',
+      cid,
+    )
+    return false
+  }
+}
+
+/**
+ * The gateway's own single-response stream for a file it has already
+ * reconstructed.
+ *
+ * Only worth calling behind isFileCachedOnGateway: on a miss the SDK falls back
+ * to composing the file one chunk per read(), in series, which is the pathology
+ * composeGatewayFileReadable exists to avoid.
+ */
+export const fetchGatewayFile = (cid: string): Promise<Readable> =>
+  FileGateway.getFile(cid)
 
 /**
  * Fetches one chunk's payload from the gateway.

--- a/apps/backend/src/infrastructure/services/dsn/fileGateway/index.ts
+++ b/apps/backend/src/infrastructure/services/dsn/fileGateway/index.ts
@@ -5,3 +5,45 @@ export const FileGateway = createAutoFilesApi(
   config.filesGateway.url,
   config.filesGateway.token,
 )
+
+/**
+ * Fetches one chunk's payload from the gateway.
+ *
+ * This is the same endpoint the SDK's own getChunkedFile uses, reimplemented
+ * here for one reason: the SDK only exposes it behind getFile, whose Readable
+ * pulls exactly one chunk per read() call. That makes a cold retrieval one
+ * sequential HTTP round-trip per chunk — for a 1.28 GB object, 19,649 of them
+ * in series, which is the bulk of the twenty-plus minutes a large uncached
+ * download takes. Calling the endpoint directly lets us keep many requests in
+ * flight at once.
+ *
+ * Deliberately not built on FileGateway.getNode: that route returns a decoded
+ * PBNode as JSON (res.json), so its bytes are JSON text rather than the chunk
+ * payload, and nothing IPLD-decodes them on the way back.
+ *
+ * @returns the chunk's bytes, or null once the index is past the last chunk
+ *   (the gateway answers 204 there, which is how the end is detected).
+ */
+export const fetchFileChunk = async (
+  cid: string,
+  chunk: number,
+): Promise<Buffer | null> => {
+  const url = new URL(`${config.filesGateway.url}/files/${cid}/partial`)
+  url.searchParams.set('chunk', chunk.toString())
+
+  const response = await fetch(url.toString(), {
+    headers: { Authorization: `Bearer ${config.filesGateway.token}` },
+  })
+
+  if (response.status === 204) {
+    return null
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `Error fetching chunk ${chunk} of ${cid}: ${response.status} ${response.statusText}`,
+    )
+  }
+
+  return Buffer.from(await response.arrayBuffer())
+}

--- a/apps/backend/src/infrastructure/services/dsn/fileGateway/index.ts
+++ b/apps/backend/src/infrastructure/services/dsn/fileGateway/index.ts
@@ -2,6 +2,7 @@ import { Readable } from 'stream'
 import { config } from '../../../../config.js'
 import { createAutoFilesApi } from '@autonomys/auto-files'
 import { createLogger } from '../../../drivers/logger.js'
+import { withTimeout } from '../../../../shared/utils/timeout.js'
 
 const logger = createLogger('services:dsn:fileGateway')
 
@@ -20,7 +21,13 @@ export const FileGateway = createAutoFilesApi(
  */
 export const isFileCachedOnGateway = async (cid: string): Promise<boolean> => {
   try {
-    return (await FileGateway.isFileCached(cid)) === true
+    return (
+      (await withTimeout(
+        FileGateway.isFileCached(cid),
+        config.filesGateway.fetchTimeoutMs,
+        `FileGateway.isFileCached(${cid})`,
+      )) === true
+    )
   } catch (error) {
     logger.warn(
       error as Error,
@@ -57,18 +64,25 @@ export const fetchGatewayFile = (cid: string): Promise<Readable> =>
  * PBNode as JSON (res.json), so its bytes are JSON text rather than the chunk
  * payload, and nothing IPLD-decodes them on the way back.
  *
+ * Takes a signal so a caller that gives up on a chunk can hand the connection
+ * back. Without it an abandoned request keeps its slot for as long as the
+ * gateway holds it open, and the callers here run many at once — so the ones
+ * that timed out would crowd out the ones still worth waiting for.
+ *
  * @returns the chunk's bytes, or null once the index is past the last chunk
  *   (the gateway answers 204 there, which is how the end is detected).
  */
 export const fetchFileChunk = async (
   cid: string,
   chunk: number,
+  signal?: AbortSignal,
 ): Promise<Buffer | null> => {
   const url = new URL(`${config.filesGateway.url}/files/${cid}/partial`)
   url.searchParams.set('chunk', chunk.toString())
 
   const response = await fetch(url.toString(), {
     headers: { Authorization: `Bearer ${config.filesGateway.token}` },
+    signal,
   })
 
   if (response.status === 204) {

--- a/apps/backend/src/shared/utils/index.ts
+++ b/apps/backend/src/shared/utils/index.ts
@@ -1,5 +1,9 @@
 export { safeCallback } from './safe.js'
-export { handleReadableError, sliceReadable } from './readable.js'
+export {
+  handleReadableError,
+  propagateReadableError,
+  sliceReadable,
+} from './readable.js'
 export { withTimeout, TimeoutError } from './timeout.js'
 export {
   applyMarginPercent,

--- a/apps/backend/src/shared/utils/readable.ts
+++ b/apps/backend/src/shared/utils/readable.ts
@@ -20,6 +20,36 @@ export const handleReadableError = (
   return stream
 }
 
+/**
+ * Fails streams derived from `source` when `source` itself fails.
+ *
+ * forkStream is `source.pipe(fork([a, b]))`, and pipe() does not forward errors
+ * downstream. So a source that dies mid-file leaves both branches open with
+ * neither 'end' nor 'error': the response never completes, and the client sits
+ * there until the proxy read timeout — 30 minutes, after this PR — waiting on a
+ * download that is already over. Destroying the branches turns that hang into a
+ * failed request the caller can report and the user can retry.
+ *
+ * No-ops for an AsyncIterable source: forkAsyncIterable drains it before it
+ * returns, so an error there rejects the fork call instead of being swallowed.
+ */
+export const propagateReadableError = (
+  source: Readable | AsyncIterable<Buffer>,
+  ...targets: Readable[]
+) => {
+  if (!(source instanceof Readable)) {
+    return
+  }
+
+  source.on('error', (error) => {
+    for (const target of targets) {
+      if (!target.destroyed) {
+        target.destroy(error as Error)
+      }
+    }
+  })
+}
+
 export const sliceReadable = async (
   readable: Readable,
   start: number,

--- a/apps/frontend/src/components/molecules/BulkObjectDownloadModal.tsx
+++ b/apps/frontend/src/components/molecules/BulkObjectDownloadModal.tsx
@@ -26,6 +26,7 @@ import { useEncryptionStore } from 'globalStates/encryption';
 import { InvalidDecryptKey } from 'utils/file';
 import {
   ObjectDownloadAbortedError,
+  ObjectDownloadStillPreparingError,
   runObjectDownloadFlow,
 } from 'services/objectDownloadFlow';
 import {
@@ -43,6 +44,15 @@ import { shortenString } from 'utils/misc';
 import { useUserAsyncDownloadsStore } from '../organisms/UserAsyncDownloads/state';
 
 const toastId = 'bulk-object-download-modal';
+
+/**
+ * How long a bulk run waits on one item's reconstruction before moving on.
+ *
+ * Items run one at a time, so an unbounded wait would let a single uncached
+ * file hold up every file behind it. Past this the item is handed to the
+ * background auto-download machinery — it still completes, just not inline.
+ */
+const BULK_ASYNC_WAIT_MS = 3 * 60 * 1000;
 
 const statusLabel: Record<BulkDownloadStatus, string> = {
   pending: 'Pending',
@@ -251,6 +261,7 @@ export const BulkObjectDownloadModal = ({
           password,
           skipDecryption,
           signal: abortController.signal,
+          maxAsyncWaitMs: BULK_ASYNC_WAIT_MS,
           onAsyncDownloadsRefresh: updateAsyncDownloads,
           getAsyncDownloads: () =>
             useUserAsyncDownloadsStore.getState().asyncDownloads,
@@ -290,6 +301,29 @@ export const BulkObjectDownloadModal = ({
           break;
         }
 
+        // Still reconstructing server-side, not broken. Hand it to the
+        // background auto-download so the rest of the batch can proceed, and
+        // record it as skipped-for-now rather than failed — marking a healthy
+        // retrieval "Failed" is what taught users to distrust the screen.
+        if (error instanceof ObjectDownloadStillPreparingError) {
+          addPendingAutoDownload({
+            cid: item.cid,
+            password,
+            skipDecryption,
+            fileName: item.information?.metadata.name ?? undefined,
+          });
+          updateItem(item.cid, (current) => ({
+            ...current,
+            status: 'skipped',
+            skippedReason: 'Still being retrieved — will download in background',
+          }));
+          toast.success(
+            `${shortenString(itemName(item), 30)} is still being retrieved; it will download automatically`,
+            { id: `${toastId}-${item.cid}` },
+          );
+          continue;
+        }
+
         const errorMessage =
           error instanceof InvalidDecryptKey
             ? 'Wrong password'
@@ -311,6 +345,7 @@ export const BulkObjectDownloadModal = ({
     setIsRunning(false);
     setIsComplete(true);
   }, [
+    addPendingAutoDownload,
     canStart,
     encryptionContext,
     hasConfirmedInsecure,

--- a/apps/frontend/src/components/molecules/ObjectDownloadModal.tsx
+++ b/apps/frontend/src/components/molecules/ObjectDownloadModal.tsx
@@ -28,6 +28,8 @@ import { useUserAsyncDownloadsStore } from '../organisms/UserAsyncDownloads/stat
 import {
   ObjectDownloadAbortedError,
   ObjectDownloadPhase,
+  ObjectDownloadPreparationProgress,
+  ObjectDownloadStillPreparingError,
   runObjectDownloadFlow,
 } from 'services/objectDownloadFlow';
 
@@ -52,6 +54,8 @@ export const ObjectDownloadModal = ({
   const [downloadError, setDownloadError] = useState<string | null>(null);
   const [checkingStatus, setCheckingStatus] = useState<boolean>(false);
   const [asyncPreparing, setAsyncPreparing] = useState<boolean>(false);
+  const [preparationProgress, setPreparationProgress] =
+    useState<ObjectDownloadPreparationProgress | null>(null);
   const defaultPassword = useEncryptionStore((store) => store.password);
   const network = useNetwork();
   const updateAsyncDownloads = useUserAsyncDownloadsStore((e) => e.update);
@@ -63,8 +67,12 @@ export const ObjectDownloadModal = ({
   const downloadAbortRef = useRef<AbortController | null>(null);
   const downloadPhaseRef = useRef<ObjectDownloadPhase | null>(null);
 
-  const handleCloseWhileAsyncPreparing = useCallback(() => {
-    if (!asyncPreparing || !metadata) return;
+  // Kept free of `asyncPreparing` so it is safe to call from inside the
+  // download flow's own error handling: that code runs in a closure created
+  // before preparation started, and a stale `asyncPreparing === false` there
+  // would silently drop the hand-off and lose the user's download.
+  const registerBackgroundDownload = useCallback(() => {
+    if (!metadata) return;
 
     addPendingAutoDownload({
       cid: metadata.dataCid,
@@ -72,18 +80,18 @@ export const ObjectDownloadModal = ({
       skipDecryption,
       fileName: metadata.name ?? undefined,
     });
+  }, [metadata, password, skipDecryption, addPendingAutoDownload]);
+
+  const handleCloseWhileAsyncPreparing = useCallback(() => {
+    if (!asyncPreparing || !metadata) return;
+
+    registerBackgroundDownload();
 
     toast.success(
       'Download continues in the background. Check Cached Downloads for progress.',
       { id: toastId, duration: 5000 },
     );
-  }, [
-    asyncPreparing,
-    metadata,
-    password,
-    skipDecryption,
-    addPendingAutoDownload,
-  ]);
+  }, [asyncPreparing, metadata, registerBackgroundDownload]);
 
   useEffect(() => {
     if (!cid) {
@@ -97,6 +105,7 @@ export const ObjectDownloadModal = ({
       setDownloadError(null);
       setCheckingStatus(false);
       setAsyncPreparing(false);
+      setPreparationProgress(null);
       downloadInitiatedRef.current = null;
       downloadPhaseRef.current = null;
     }
@@ -155,6 +164,7 @@ export const ObjectDownloadModal = ({
           setDownloadProgress(progress);
         },
         onAsyncDownloadsRefresh: updateAsyncDownloads,
+        onPreparationProgress: setPreparationProgress,
         getAsyncDownloads: () =>
           useUserAsyncDownloadsStore.getState().asyncDownloads,
         onPhaseChange: (phase) => {
@@ -191,6 +201,16 @@ export const ObjectDownloadModal = ({
         downloadInitiatedRef.current = null;
       } else if (e instanceof ObjectDownloadAbortedError) {
         return;
+      } else if (e instanceof ObjectDownloadStillPreparingError) {
+        // Not a failure — the server is still pulling this back from the DSN.
+        // Hand it to the background auto-download and say so, instead of
+        // showing a red error box for a retrieval that is working.
+        registerBackgroundDownload();
+        toast.success(e.message, { id: toastId, duration: 6000 });
+        setIsDownloading(false);
+        setAsyncPreparing(false);
+        setCheckingStatus(false);
+        onClose();
       } else {
         console.error('Download failed:', e);
         const errorMessage =
@@ -211,6 +231,7 @@ export const ObjectDownloadModal = ({
     network.api,
     network.downloadService,
     updateAsyncDownloads,
+    registerBackgroundDownload,
     onClose,
   ]);
 
@@ -329,11 +350,39 @@ export const ObjectDownloadModal = ({
           <div className='flex items-center gap-3'>
             <div className='h-5 w-5 animate-spin rounded-full border-2 border-gray-300 border-t-primary' />
             <p className='text-sm text-gray-600'>
-              This file is being retrieved from the network. This may take
-              several minutes — your download will start automatically when
-              it&apos;s ready.
+              This file is being retrieved from the network. Large files can
+              take 20 minutes or more — your download will start automatically
+              when it&apos;s ready.
             </p>
           </div>
+
+          {/* Server-reported reconstruction progress. Without it this screen
+              was an indefinite spinner, and a retrieval that was working
+              looked identical to one that had died. */}
+          {preparationProgress && preparationProgress.totalBytes > 0 && (
+            <div className='w-full'>
+              <div className='mb-2 flex justify-between text-xs text-gray-600'>
+                <span>
+                  {formatBytes(preparationProgress.downloadedBytes)} retrieved
+                </span>
+                <span>{formatBytes(preparationProgress.totalBytes)}</span>
+              </div>
+              <div className='h-2 w-full overflow-hidden rounded-full bg-gray-200'>
+                <div
+                  className='h-full rounded-full bg-primary transition-all duration-300 ease-out'
+                  style={{ width: `${preparationProgress.percentage}%` }}
+                  role='progressbar'
+                  aria-valuenow={preparationProgress.percentage}
+                  aria-valuemin={0}
+                  aria-valuemax={100}
+                />
+              </div>
+              <div className='mt-1 text-center text-xs text-gray-500'>
+                {preparationProgress.percentage}% ·{' '}
+                {Math.floor(preparationProgress.elapsedMs / 60000)}m elapsed
+              </div>
+            </div>
+          )}
           <p className='text-center text-xs text-gray-500'>
             You can close this dialog and continue browsing. Your download will
             start automatically when it&apos;s ready.
@@ -466,6 +515,7 @@ export const ObjectDownloadModal = ({
     downloadError,
     progressView,
     asyncPreparing,
+    preparationProgress,
     insecure,
     passwordOrNotEncrypted,
     passwordConfirmed,

--- a/apps/frontend/src/components/organisms/ObjectDetails/ObjectDetailsActions.tsx
+++ b/apps/frontend/src/components/organisms/ObjectDetails/ObjectDetailsActions.tsx
@@ -20,15 +20,23 @@ import { useNetwork } from '../../../contexts/network';
 import { ObjectDownloadModal } from '../../molecules/ObjectDownloadModal';
 import { ObjectShareModal } from '../../molecules/ObjectShareModal';
 import { ObjectDeleteModal } from '../../molecules/ObjectDeleteModal';
+import { useUserAsyncDownloadsStore } from '../UserAsyncDownloads/state';
 
 export const ObjectDetailsActions = ({
   object,
   isOwner,
   isCached,
+  reconstruction,
 }: {
   object: ObjectInformation;
   isOwner: boolean;
   isCached: boolean | null;
+  reconstruction?: {
+    state: 'running' | 'idle';
+    downloadedBytes: string;
+    totalSize: string;
+    startedAt: string | null;
+  } | null;
 }) => {
   const { user } = useUserStore();
   const { api } = useNetwork();
@@ -38,6 +46,7 @@ export const ObjectDetailsActions = ({
   const [deleteModalCid, setDeleteModalCid] = useState<string | null>(null);
   const [isReporting, setIsReporting] = useState(false);
   const [isBringingToCache, setIsBringingToCache] = useState(false);
+  const updateAsyncDownloads = useUserAsyncDownloadsStore((e) => e.update);
 
   const hasFileOwnership = object?.owners.some(
     (o) =>
@@ -88,14 +97,32 @@ export const ObjectDetailsActions = ({
     setIsBringingToCache(true);
     try {
       await api.createAsyncDownload(object.metadata.dataCid);
-      toast.success('File is being brought to cache');
+      // The old copy ("File is being brought to cache") implied the work was
+      // done. It only queues a retrieval that runs for minutes, and nothing
+      // reported on it afterwards — so a user who came back to an unchanged
+      // button concluded it had failed. Point them at the surface that does
+      // track it, and let the polled cache state drive the button from here.
+      toast.success(
+        'Retrieving this file from the network. Progress is shown in Cached Downloads — it can take 20 minutes or more for large files.',
+        { duration: 6000 },
+      );
+      updateAsyncDownloads();
     } catch (error) {
       console.error('Bring to cache error:', error);
-      toast.error('Failed to bring file to cache. Please try again.');
+      toast.error('Failed to start retrieval. Please try again.');
     } finally {
       setIsBringingToCache(false);
     }
-  }, [api, object?.metadata.dataCid]);
+  }, [api, object?.metadata.dataCid, updateAsyncDownloads]);
+
+  // A retrieval already running for this object — started here, by the download
+  // modal, or by another user, since the cache is shared.
+  const isReconstructing = reconstruction?.state === 'running';
+  const reconstructionPercentage = (() => {
+    const total = Number(reconstruction?.totalSize ?? 0);
+    const done = Number(reconstruction?.downloadedBytes ?? 0);
+    return total > 0 ? Math.min(100, Math.floor((done * 100) / total)) : 0;
+  })();
 
   return (
     <div className='flex space-x-2'>
@@ -119,14 +146,20 @@ export const ObjectDetailsActions = ({
           variant='primary'
           className={cn(
             'inline-flex items-center text-sm',
-            (isBanned(object.tags) || isBringingToCache) &&
+            (isBanned(object.tags) || isBringingToCache || isReconstructing) &&
               'cursor-not-allowed opacity-50',
           )}
-          disabled={isBanned(object.tags) || isBringingToCache}
+          disabled={
+            isBanned(object.tags) || isBringingToCache || isReconstructing
+          }
           onClick={handleBringToCache}
         >
           <CloudArrowDownIcon className='mr-2 h-4 w-4' />
-          {isBringingToCache ? 'Bringing to Cache...' : 'Bring to Cache'}
+          {isReconstructing
+            ? `Retrieving… ${reconstructionPercentage}%`
+            : isBringingToCache
+              ? 'Starting…'
+              : 'Bring to Cache'}
         </Button>
       )}
       <Button

--- a/apps/frontend/src/components/organisms/ObjectDetails/index.tsx
+++ b/apps/frontend/src/components/organisms/ObjectDetails/index.tsx
@@ -8,7 +8,7 @@ import { Loader } from 'lucide-react';
 import { FilePreview } from '@/components/molecules/FilePreview';
 import { IconByFileType } from '@/components/atoms/IconByFileType';
 import { GoBackButton } from '@/components/atoms/GoBackButton';
-import { useFileInCache } from 'hooks/useFileInCache';
+import { useFileCacheState } from 'hooks/useFileInCache';
 import { ObjectDetailsTags } from './ObjectDetailsTags';
 import { ObjectDetailsActions } from './ObjectDetailsActions';
 import { ObjectUploadDetails } from './ObjectUploadDetails';
@@ -32,7 +32,9 @@ export const ObjectDetails = ({
       o.role === OwnerRole.ADMIN,
   );
 
-  const isCached = useFileInCache(object?.metadata.dataCid ?? '');
+  const { isCached, reconstruction } = useFileCacheState(
+    object?.metadata.dataCid ?? '',
+  );
 
   const isLoading = object === null;
   if (isLoading) {
@@ -59,7 +61,12 @@ export const ObjectDetails = ({
           </div>
           <ObjectDetailsTags object={object} isCached={isCached} />
         </div>
-        <ObjectDetailsActions isOwner={isOwner} object={object} isCached={isCached} />
+        <ObjectDetailsActions
+          isOwner={isOwner}
+          object={object}
+          isCached={isCached}
+          reconstruction={reconstruction}
+        />
       </div>
       <ObjectUploadDetails object={object} isOwner={isOwner} />
       <ObjectUploadOptions object={object} />

--- a/apps/frontend/src/components/organisms/UserAsyncDownloads/AsyncStatusBadge.tsx
+++ b/apps/frontend/src/components/organisms/UserAsyncDownloads/AsyncStatusBadge.tsx
@@ -17,12 +17,17 @@ const getStatusColor = (status: AsyncDownloadStatus) => {
 };
 
 const getStatusLabel = (download: AsyncDownload) => {
-  const progress = Math.floor(
-    Number(
-      (BigInt(100) * BigInt(download.downloadedBytes ?? 0)) /
-        BigInt(download.fileSize ?? 0),
-    ),
-  );
+  // `?? 0` does not cover a stored '0' — and BigInt division by zero throws a
+  // RangeError, which escapes render and takes the whole Cached Downloads
+  // dialog down with it. A zero-byte object, or a row written before the size
+  // was known, was enough to break the one screen showing download state.
+  const totalBytes = BigInt(download.fileSize || 0);
+  const progress =
+    totalBytes > BigInt(0)
+      ? Math.floor(
+          Number((BigInt(100) * BigInt(download.downloadedBytes || 0)) / totalBytes),
+        )
+      : 0;
   switch (download.status) {
     case AsyncDownloadStatus.Completed:
       return 'Completed';

--- a/apps/frontend/src/components/organisms/UserAsyncDownloads/index.tsx
+++ b/apps/frontend/src/components/organisms/UserAsyncDownloads/index.tsx
@@ -5,11 +5,7 @@ import {
 } from '../../../../gql/graphql';
 import { useNetwork } from '../../../contexts/network';
 import { useUserAsyncDownloadsStore } from './state';
-import {
-  AsyncDownload,
-  AsyncDownloadStatus,
-  DownloadStatus,
-} from '@auto-drive/models';
+import { AsyncDownload, AsyncDownloadStatus } from '@auto-drive/models';
 import {
   Dialog,
   DialogPanel,
@@ -35,29 +31,21 @@ export const UserAsyncDownloads = () => {
   const removePendingAutoDownload = useUserAsyncDownloadsStore(
     (e) => e.removePendingAutoDownload,
   );
-  const { gql, api, downloadService } = useNetwork();
+  const { gql, downloadService } = useNetwork();
   const updateAsyncDownloads = useUserAsyncDownloadsStore((e) => e.update);
   const [isOpen, setIsOpen] = useState(false);
   const autoDownloadingRef = useRef<Set<string>>(new Set());
 
-  const dismissOutdatedAsyncDownloads = useCallback(async () => {
-    let hasDismissedSome = false;
-    for (const asyncDownload of asyncDownloads) {
-      if (asyncDownload.status !== AsyncDownloadStatus.Completed) return;
-      const status = await api.checkDownloadStatus(asyncDownload.cid);
-      if (status === DownloadStatus.NotCached) {
-        api.dismissAsyncDownload(asyncDownload.id);
-        hasDismissedSome = true;
-      }
-    }
-    if (hasDismissedSome) {
-      updateAsyncDownloads();
-    }
-  }, [api, asyncDownloads, updateAsyncDownloads]);
-
-  useEffect(() => {
-    dismissOutdatedAsyncDownloads();
-  }, [dismissOutdatedAsyncDownloads]);
+  // Previously this swept completed downloads whose cache entry had since gone
+  // and dismissed them. Two problems made it destructive: `return` instead of
+  // `continue` aborted the sweep at the first non-completed row, and a single
+  // NotCached read was treated as proof the entry was gone — so a completed
+  // download could be silently removed from the user's only record of it. The
+  // sweep is gone; a completed row stays until the user dismisses it, and a
+  // re-download simply repopulates the cache.
+  //
+  // Kept out of the render path entirely rather than fixed in place: nothing
+  // here needs to mutate server state just to display it.
 
   const fetcher = useCallback(async () => {
     const { data } = await gql.query<MyUndismissedAsyncDownloadsQuery>({
@@ -75,8 +63,13 @@ export const UserAsyncDownloads = () => {
   // Periodic polling so background async downloads are detected even when
   // the download modal is closed.
   useEffect(() => {
+    // Downloading counts as pending here. It didn't before, because nothing
+    // ever set that status — now that a running reconstruction reports it,
+    // omitting it would stop the polling that refreshes its progress.
     const hasPending = asyncDownloads.some(
-      (d) => d.status === AsyncDownloadStatus.Pending,
+      (d) =>
+        d.status === AsyncDownloadStatus.Pending ||
+        d.status === AsyncDownloadStatus.Downloading,
     );
     const hasPendingAuto = pendingAutoDownloads.length > 0;
     if (!hasPending && !hasPendingAuto) return;

--- a/apps/frontend/src/hooks/useFileInCache.ts
+++ b/apps/frontend/src/hooks/useFileInCache.ts
@@ -1,34 +1,76 @@
 import { useState, useEffect } from 'react';
 import { useNetwork } from 'contexts/network';
 import { DownloadStatus } from '@auto-drive/models';
+import type { DownloadAvailability } from 'services/api';
+
+const POLL_INTERVAL_MS = 10_000;
+
+export interface FileCacheState {
+  /** `true` if cached, `false` if not, `null` while the first check is in flight. */
+  isCached: boolean | null;
+  /** Server-side reconstruction in progress, if any. */
+  reconstruction: DownloadAvailability['reconstruction'];
+}
 
 /**
- * Hook to check if a file is available in the cache.
- * @param cid Content identifier of the file.
- * @returns `true` if cached, `false` if not cached, `null` while the check is in flight.
+ * Tracks whether a file can be served from cache, and whether a retrieval is
+ * currently running for it.
+ *
+ * Polls rather than checking once: a reconstruction takes minutes, so a
+ * single check on mount meant "Bring to Cache" stayed on screen for the whole
+ * run and then stayed on screen after it finished, with nothing to tell the
+ * user either had happened.
  */
-export const useFileInCache = (cid: string): boolean | null => {
+export const useFileCacheState = (cid: string): FileCacheState => {
   const { api } = useNetwork();
-  const [isCached, setIsCached] = useState<boolean | null>(null);
+  const [state, setState] = useState<FileCacheState>({
+    isCached: null,
+    reconstruction: null,
+  });
 
   useEffect(() => {
+    if (!cid) return;
+
     let mounted = true;
+    let timer: ReturnType<typeof setTimeout> | undefined;
 
-    const checkCache = async () => {
-      if (!cid) return;
+    const check = async () => {
+      try {
+        const availability = await api.checkDownloadAvailability(cid);
+        if (!mounted) return;
+        setState({
+          isCached: availability.status === DownloadStatus.Cached,
+          reconstruction: availability.reconstruction,
+        });
+      } catch {
+        // Leave the last known state alone on a transient failure — flipping to
+        // "not cached" on a network blip would make the file look unavailable.
+        if (!mounted) return;
+        setState((current) =>
+          current.isCached === null
+            ? { isCached: false, reconstruction: null }
+            : current,
+        );
+      }
 
-      const status = await api.checkDownloadStatus(cid).catch(() => false);
       if (mounted) {
-        setIsCached(status === DownloadStatus.Cached);
+        timer = setTimeout(check, POLL_INTERVAL_MS);
       }
     };
 
-    checkCache();
+    check();
 
     return () => {
       mounted = false;
+      clearTimeout(timer);
     };
   }, [cid, api]);
 
-  return isCached;
+  return state;
 };
+
+/**
+ * @returns `true` if cached, `false` if not cached, `null` while the check is in flight.
+ */
+export const useFileInCache = (cid: string): boolean | null =>
+  useFileCacheState(cid).isCached;

--- a/apps/frontend/src/services/api.ts
+++ b/apps/frontend/src/services/api.ts
@@ -110,6 +110,54 @@ export interface UploadResponse {
 
 export type Api = ReturnType<typeof createApiService>;
 
+/**
+ * What the server knows about an object's availability right now.
+ *
+ * `status` keeps its original two values. `reconstruction` is what lets the UI
+ * distinguish "this file is being pulled back from the DSN and is N% of the
+ * way there" from "nothing is happening" — previously both looked identical
+ * from the client, so a slow retrieval was indistinguishable from a dead file.
+ */
+export interface DownloadAvailability {
+  status: DownloadStatus;
+  reconstruction: {
+    state: 'running' | 'idle';
+    downloadedBytes: string;
+    totalSize: string;
+    startedAt: string | null;
+  } | null;
+}
+
+const fetchDownloadAvailability = async (
+  downloadApiUrl: string,
+  cid: string,
+): Promise<DownloadAvailability> => {
+  const session = await getAuthSession().catch(() => null);
+  const headers: Record<string, string> =
+    session?.accessToken && session.authProvider
+      ? {
+          Authorization: `Bearer ${session.accessToken}`,
+          'X-Auth-Provider': session.authProvider,
+        }
+      : {};
+
+  const response = await fetch(`${downloadApiUrl}/downloads/${cid}/status`, {
+    headers,
+  });
+
+  if (!response.ok) {
+    throw new Error(`Network response was not ok: ${response.statusText}`);
+  }
+
+  const data = (await response.json()) as DownloadAvailability;
+  return {
+    status: data.status,
+    // A backend that predates the richer payload answers with `status` alone;
+    // treat that as "nothing known" rather than letting undefined leak on.
+    reconstruction: data.reconstruction ?? null,
+  };
+};
+
 export const createApiService = ({
   apiBaseUrl,
   downloadApiUrl,
@@ -757,27 +805,16 @@ export const createApiService = ({
       },
     });
   },
+  // The server route is unauthenticated, so neither of these throws for
+  // signed-out users any more. They used to, which made every anonymous
+  // download skip the availability check entirely and go straight at a file
+  // that might need minutes of reconstruction, with no way to say so.
   checkDownloadStatus: async (cid: string): Promise<DownloadStatus> => {
-    const session = await getAuthSession();
-    if (!session?.authProvider || !session.accessToken) {
-      throw new Error('No session');
-    }
-
-    const response = await fetch(`${downloadApiUrl}/downloads/${cid}/status`, {
-      headers: {
-        Authorization: `Bearer ${session?.accessToken}`,
-        'X-Auth-Provider': session.authProvider,
-      },
-    });
-
-    if (!response.ok) {
-      throw new Error(`Network response was not ok: ${response.statusText}`);
-    }
-
-    return (response.json() as Promise<{ status: DownloadStatus }>).then(
-      (data) => data.status,
-    );
+    const { status } = await fetchDownloadAvailability(downloadApiUrl, cid);
+    return status;
   },
+  checkDownloadAvailability: (cid: string): Promise<DownloadAvailability> =>
+    fetchDownloadAvailability(downloadApiUrl, cid),
   getCreditSummary: async (): Promise<CreditSummaryResponse> => {
     const session = await getAuthSession();
     if (!session?.authProvider || !session.accessToken) {

--- a/apps/frontend/src/services/objectDownloadFlow.ts
+++ b/apps/frontend/src/services/objectDownloadFlow.ts
@@ -4,8 +4,21 @@ import { Api } from 'services/api';
 import { DownloadApi, DownloadOptions } from 'services/download';
 import { getAuthSession } from '@/utils/auth';
 
-const MAX_ASYNC_POLL_COUNT = 60;
-const ASYNC_POLL_INTERVAL_MS = 10_000;
+const ASYNC_POLL_INTERVAL_MS = 5_000;
+
+/**
+ * Upper bound on waiting for a reconstruction, as a backstop against polling
+ * forever if the server loses the job without recording a failure.
+ *
+ * This used to be 10 minutes (60 polls x 10s), against a retrieval path the
+ * codebase itself documents as taking 20+ minutes for a non-cached archived
+ * file. The client gave up first and reported "Download preparation timed out",
+ * so a healthy-but-slow reconstruction was indistinguishable from a broken one
+ * and the user concluded the file was gone. Two hours is far past any observed
+ * reconstruction, and progress reporting means the user is no longer staring at
+ * an unchanging spinner while it runs.
+ */
+const MAX_ASYNC_WAIT_MS = 2 * 60 * 60 * 1000;
 
 export type ObjectDownloadPhase =
   | 'checking'
@@ -13,13 +26,33 @@ export type ObjectDownloadPhase =
   | 'downloading'
   | 'completed';
 
+export interface ObjectDownloadPreparationProgress {
+  downloadedBytes: number;
+  totalBytes: number;
+  percentage: number;
+  elapsedMs: number;
+}
+
 export class ObjectDownloadAbortedError extends Error {
   constructor() {
     super('Download aborted');
   }
 }
 
+/** The server gave a terminal verdict: this retrieval will not complete. */
 class ObjectDownloadPreparationError extends Error {}
+
+/**
+ * The caller stopped waiting, but the server has not failed — the
+ * reconstruction is still running and will finish on its own.
+ *
+ * Distinct from ObjectDownloadPreparationError so callers can say "still
+ * coming, we'll grab it when it lands" instead of "failed". Bulk downloads in
+ * particular need this: they run one item at a time, so they wait briefly and
+ * then hand the slow item to the background auto-download machinery rather
+ * than holding up everything behind it.
+ */
+export class ObjectDownloadStillPreparingError extends Error {}
 
 export interface ObjectDownloadFlowOptions {
   api: Api;
@@ -30,13 +63,14 @@ export interface ObjectDownloadFlowOptions {
   signal?: AbortSignal;
   onProgress?: DownloadOptions['onProgress'];
   onPhaseChange?: (phase: ObjectDownloadPhase) => void;
+  onPreparationProgress?: (progress: ObjectDownloadPreparationProgress) => void;
   onAsyncDownloadsRefresh?: () => void;
   getAsyncDownloads?: () => {
     cid: string;
     status: AsyncDownloadStatus;
     errorMessage?: string | null;
   }[];
-  maxAsyncPollCount?: number;
+  maxAsyncWaitMs?: number;
   asyncPollIntervalMs?: number;
 }
 
@@ -73,59 +107,103 @@ export const runObjectDownloadFlow = async ({
   signal,
   onProgress,
   onPhaseChange,
+  onPreparationProgress,
   onAsyncDownloadsRefresh,
   getAsyncDownloads,
-  maxAsyncPollCount = MAX_ASYNC_POLL_COUNT,
+  maxAsyncWaitMs = MAX_ASYNC_WAIT_MS,
   asyncPollIntervalMs = ASYNC_POLL_INTERVAL_MS,
 }: ObjectDownloadFlowOptions) => {
   assertNotAborted(signal);
   onPhaseChange?.('checking');
 
-  let shouldPrepareAsync = false;
-  try {
-    const session = await getAuthSession().catch(() => null);
-    assertNotAborted(signal);
-    const hasSession = !!session?.accessToken && !!session?.authProvider;
+  const session = await getAuthSession().catch(() => null);
+  assertNotAborted(signal);
+  const hasSession = !!session?.accessToken && !!session?.authProvider;
 
-    if (hasSession) {
-      const status = await api.checkDownloadStatus(metadata.dataCid);
-      assertNotAborted(signal);
-      shouldPrepareAsync = status === DownloadStatus.NotCached;
-    }
+  // The cache is the fast source and the only one that answers immediately, so
+  // it decides the route: a hit streams straight through, a miss goes via a
+  // server-side reconstruction we can actually report on.
+  //
+  // A failed check no longer silently disables preparation. It used to set
+  // shouldPrepareAsync = false and fall through to a direct fetch — which, for
+  // an uncached file, is the request that sits silent until a proxy or the
+  // browser gives up. Assume the pessimistic answer instead: if we cannot
+  // confirm the file is cached, treat it as needing preparation.
+  let isCached = false;
+  try {
+    const availability = await api.checkDownloadAvailability(metadata.dataCid);
+    assertNotAborted(signal);
+    isCached = availability.status === DownloadStatus.Cached;
   } catch (error) {
     if (error instanceof ObjectDownloadAbortedError) {
       throw error;
     }
-    shouldPrepareAsync = false;
+    isCached = false;
   }
 
-  if (shouldPrepareAsync) {
+  // Queuing a reconstruction needs a session. Anonymous callers fall through to
+  // the direct download, which now holds while the server reconstructs rather
+  // than being cut short — slower, but it completes, and it is the only route
+  // available to them.
+  let preparing = !isCached && hasSession;
+
+  if (preparing) {
     onPhaseChange?.('preparing');
     try {
+      // Idempotent server-side: a repeat call joins the run already in flight
+      // instead of starting a competing one.
       await api.createAsyncDownload(metadata.dataCid);
       onAsyncDownloadsRefresh?.();
     } catch (error) {
       if (error instanceof ObjectDownloadAbortedError) {
         throw error;
       }
-      shouldPrepareAsync = false;
+      preparing = false;
       onPhaseChange?.('checking');
     }
   }
 
-  if (shouldPrepareAsync) {
-    for (let pollCount = 0; pollCount < maxAsyncPollCount; pollCount++) {
+  if (preparing) {
+    const startedAt = Date.now();
+
+    for (;;) {
       await delay(asyncPollIntervalMs, signal);
       assertNotAborted(signal);
 
-      let isCached = false;
+      let ready = false;
       try {
-        const status = await api.checkDownloadStatus(metadata.dataCid);
+        const availability = await api.checkDownloadAvailability(
+          metadata.dataCid,
+        );
         onAsyncDownloadsRefresh?.();
         assertNotAborted(signal);
-        if (status === DownloadStatus.Cached) {
-          isCached = true;
+
+        if (availability.status === DownloadStatus.Cached) {
+          ready = true;
         } else {
+          const reconstruction = availability.reconstruction;
+          if (reconstruction) {
+            const totalBytes = Number(reconstruction.totalSize ?? 0);
+            const downloadedBytes = Number(reconstruction.downloadedBytes ?? 0);
+            onPreparationProgress?.({
+              downloadedBytes,
+              totalBytes,
+              // Guarded: totalSize is 0 for an empty object and null on rows
+              // written before the size was recorded, and an unguarded divide
+              // renders NaN% into the one screen the user is watching.
+              percentage:
+                totalBytes > 0
+                  ? Math.min(
+                      100,
+                      Math.floor((downloadedBytes * 100) / totalBytes),
+                    )
+                  : 0,
+              elapsedMs: Date.now() - startedAt,
+            });
+          }
+
+          // Only a terminal server-side verdict ends the wait. A job that is
+          // merely slow is not a failure, and must not be reported as one.
           const matchingDownload = getAsyncDownloads?.().find(
             (d) => d.cid === metadata.dataCid,
           );
@@ -136,7 +214,7 @@ export const runObjectDownloadFlow = async ({
           ) {
             throw new ObjectDownloadPreparationError(
               matchingDownload.errorMessage ||
-                'Download failed on the server. Please try again.',
+                'The server could not retrieve this file from the network. Please try again.',
             );
           }
         }
@@ -150,21 +228,21 @@ export const runObjectDownloadFlow = async ({
         }
 
         // Transient poll-cycle failure (e.g. network blip). Don't fail the
-        // whole flow — we'll retry next cycle or hit the timeout. Surface
+        // whole flow — we'll retry next cycle or hit the backstop. Surface
         // for debugging so a fully broken gateway doesn't fail silently.
         console.warn(
-          `[objectDownloadFlow] poll cycle ${pollCount + 1}/${maxAsyncPollCount} failed for ${metadata.dataCid}; continuing`,
+          `[objectDownloadFlow] poll failed for ${metadata.dataCid}; continuing`,
           error,
         );
       }
 
-      if (isCached) {
+      if (ready) {
         break;
       }
 
-      if (pollCount === maxAsyncPollCount - 1) {
-        throw new ObjectDownloadPreparationError(
-          'Download preparation timed out. Please try again later.',
+      if (Date.now() - startedAt >= maxAsyncWaitMs) {
+        throw new ObjectDownloadStillPreparingError(
+          'This file is still being retrieved from the network. It will keep going in the background — check Cached Downloads for progress.',
         );
       }
     }

--- a/nginx/all.staging-mainnet.conf
+++ b/nginx/all.staging-mainnet.conf
@@ -62,6 +62,14 @@ server {
             add_header 'Content-Length' 0 always;
             return 204;
         }
+        # /api/downloads/:cid carries file bytes. On a cache miss nothing is
+        # written until the DSN reconstruction yields, which routinely outlives
+        # nginx's 60s default proxy_read_timeout and surfaces as a 504 the
+        # client cannot distinguish from a dead file. Idle timeout between
+        # upstream reads, so healthy streaming downloads are unaffected.
+        proxy_read_timeout 1800;
+        proxy_send_timeout 1800;
+
         rewrite /api/(.*) /$1 break;
     }
 
@@ -122,6 +130,14 @@ server {
             add_header 'Content-Length' 0 always;
             return 204;
         }
+        # /api/downloads/:cid carries file bytes. On a cache miss nothing is
+        # written until the DSN reconstruction yields, which routinely outlives
+        # nginx's 60s default proxy_read_timeout and surfaces as a 504 the
+        # client cannot distinguish from a dead file. Idle timeout between
+        # upstream reads, so healthy streaming downloads are unaffected.
+        proxy_read_timeout 1800;
+        proxy_send_timeout 1800;
+
         rewrite /api/(.*) /$1 break;
     }
 

--- a/nginx/all.staging-mainnet.conf
+++ b/nginx/all.staging-mainnet.conf
@@ -158,6 +158,16 @@ server {
         limit_req_log_level warn;
 
         proxy_buffering off;
+
+        # The gateway reconstructs objects from the DSN on demand, so a cold
+        # request can sit silent for minutes before the first byte. nginx's
+        # 60s default proxy_read_timeout cuts that with a 504, which reaches
+        # the backend as a failed retrieval and reaches the user as a file
+        # that appears not to exist. Idle timeout between upstream reads, so
+        # a healthy streaming response is unaffected.
+        proxy_read_timeout 1800;
+        proxy_send_timeout 1800;
+
         proxy_pass http://127.0.0.1:8090;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header Host $host;

--- a/nginx/backend.mainnet.file-gateway.conf
+++ b/nginx/backend.mainnet.file-gateway.conf
@@ -22,6 +22,16 @@ server {
         limit_req_log_level warn;
 
         proxy_buffering off;
+
+        # The gateway reconstructs objects from the DSN on demand, so a cold
+        # request can sit silent for minutes before the first byte. nginx's
+        # 60s default proxy_read_timeout cuts that with a 504, which reaches
+        # the backend as a failed retrieval and reaches the user as a file
+        # that appears not to exist. Idle timeout between upstream reads, so
+        # a healthy streaming response is unaffected.
+        proxy_read_timeout 1800;
+        proxy_send_timeout 1800;
+
         proxy_pass http://127.0.0.1:8090;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header Host $host;

--- a/nginx/backend.mainnet.private.conf
+++ b/nginx/backend.mainnet.private.conf
@@ -55,6 +55,14 @@ server {
             add_header 'Content-Length' 0 always;
             return 204;
         }
+        # /api/downloads/:cid carries file bytes. On a cache miss nothing is
+        # written until the DSN reconstruction yields, which routinely outlives
+        # nginx's 60s default proxy_read_timeout and surfaces as a 504 the
+        # client cannot distinguish from a dead file. Idle timeout between
+        # upstream reads, so healthy streaming downloads are unaffected.
+        proxy_read_timeout 1800;
+        proxy_send_timeout 1800;
+
         rewrite /api/(.*) /$1  break;
     }
 

--- a/nginx/backend.mainnet.public.conf
+++ b/nginx/backend.mainnet.public.conf
@@ -55,6 +55,18 @@ server {
             add_header 'Content-Length' 0 always;
             return 204;
         }
+        # This location serves the frontend's download API (the browser's
+        # NEXT_PUBLIC_MAINNET_DOWNLOAD_URL is .../api), so /api/downloads/:cid
+        # carries file bytes. On a cache miss the object is reconstructed from
+        # the DSN before the first byte can be written, which routinely takes
+        # minutes; nginx's default proxy_read_timeout is 60s, so without this
+        # the socket is cut with a 504 while the reconstruction is still
+        # running and the browser reports a generic network failure. These are
+        # idle timeouts between upstream reads, not a cap on total transfer
+        # time, so a healthy streaming download is unaffected.
+        proxy_read_timeout 1800;
+        proxy_send_timeout 1800;
+
 	    rewrite /api/(.*) /$1  break;
     }
 
@@ -128,6 +140,11 @@ server {
             return 204;
         }
 
+        # See the /api block: a cold-cache download produces no bytes until the
+        # DSN reconstruction yields, which outlives nginx's 60s default.
+        proxy_read_timeout 1800;
+        proxy_send_timeout 1800;
+
         rewrite ^/file/(.*)$ /downloads/$1?ignoreEncoding=false break;
     }
 
@@ -161,6 +178,11 @@ server {
             add_header 'Content-Length' 0 always;
             return 204;
         }
+
+        # See the /api block: a cold-cache download produces no bytes until the
+        # DSN reconstruction yields, which outlives nginx's 60s default.
+        proxy_read_timeout 1800;
+        proxy_send_timeout 1800;
 
         rewrite /folder/(.*) /downloads/$1?ignoreEncoding=false break;
     }
@@ -299,6 +321,11 @@ server {
             return 204;
         }
 
+        # See the /api block: a cold-cache download produces no bytes until the
+        # DSN reconstruction yields, which outlives nginx's 60s default.
+        proxy_read_timeout 1800;
+        proxy_send_timeout 1800;
+
         rewrite /file/(.*) /downloads/$1  break;
     }
 
@@ -332,6 +359,11 @@ server {
             add_header 'Content-Length' 0 always;
             return 204;
         }
+
+        # See the /api block: a cold-cache download produces no bytes until the
+        # DSN reconstruction yields, which outlives nginx's 60s default.
+        proxy_read_timeout 1800;
+        proxy_send_timeout 1800;
 
         rewrite /folder/(.*) /downloads/$1  break;
     }


### PR DESCRIPTION
## Why

An uncached object is reconstructed from the DSN before its first byte can be written. The codebase itself puts that at 20+ minutes for a large archived file ([`FilePreview/index.tsx:139`](../blob/main/apps/frontend/src/components/molecules/FilePreview/index.tsx#L139)). Every layer between the user and that work gave up first, and none of them could say why — so a slow-but-healthy retrieval was indistinguishable from a file that no longer existed. That is the "Bring to Cache / spinner crashes silently" report.

The timeout stack before this PR:

| Layer | Limit | What the user saw |
|---|---|---|
| nginx `/api`, `/file`, `/folder` | **60s** (never set — nginx default) | 504, connection cut |
| client poll loop | **600s** (60 × 10s) | "Download preparation timed out" |
| async-download inactivity | 300s, armed only after the first byte | marked `Failed` |

`location /s3` was the only block with a proxy timeout. The browser's download URL is `https://public.auto-drive.autonomys.xyz/api`, so the actual file transfer ran under the 60s default. Because these are idle timeouts *between upstream reads*, healthy streaming downloads never tripped them — which is why this stayed invisible.

## What changed

**nginx** — 1800s `proxy_read_timeout`/`proxy_send_timeout` on every download-serving location across all four configs, including both gateways' reconstruct-on-demand routes. `location /s3` is left at its existing 600s: that one was set deliberately, and raising it is a separate call from replacing a default nobody chose.

**Server-side truth** — `GET /downloads/:cid/status` now reports an in-flight reconstruction and its byte progress. `status` keeps its two values so existing clients and the SDK are unaffected; `reconstruction` is additive. Previously `not-cached` was the only thing the endpoint could say, and it said the same thing whether a pull was twelve minutes in or had never started.

**Liveness, not just state** — a row only counts as an in-flight reconstruction if it has been stamped within `ASYNC_DOWNLOAD_STALE_AFTER_MS` (5 min), and the running worker stamps it every `ASYNC_DOWNLOAD_HEARTBEAT_MS` (30s). Without both, `Pending` and `Downloading` mean "nothing has changed this row since it was created", which is equally true of a worker that died. That matters here because the status query is deliberately *not* scoped to a user and the client disables its own request while a reconstruction is running: one abandoned row would take "Bring to Cache" away from everyone asking about that cid, with only its owner able to dismiss it. The heartbeat is what lets the window be 5 minutes instead of longer than a cold retrieval's time-to-first-byte.

**Deduplication** — a user's repeat clicks join their run already in flight instead of queueing a competing full pull. Scoped to `(cid, provider, user)`, because the row is that user's own record of the request. Two users asking for the same cid still get a row each — they share the cache, so the second is cheap, and the status endpoint is what tells each of them the object is already being fetched. Still a check-then-insert with no unique index, so two genuinely simultaneous clicks can both insert; that needs a partial unique index and is not in this PR.

**Real progress** — nothing ever wrote `AsyncDownloadStatus.Downloading`, so a running job sat on `Pending` for its whole life, and the badge only renders a percentage for `Downloading`. Setting it also un-sticks a row a previous attempt left as `Failed`.

**Client** — waits on server state instead of a fixed poll count (2h backstop), shows retrieved bytes and elapsed time, and treats "still working" as a background hand-off rather than an error. Availability-check failures no longer silently disable preparation and fall through to the direct fetch — the request that 504s. Anonymous users can now check status; the route was always unauthenticated, only the client demanded a session. Bulk downloads keep a 3-minute bound so one slow item cannot hold up the batch.

**Parallel gateway retrieval — cold path only.** `FileGateway.getFile` streams a file the gateway already holds in one response, and only falls back to composing it one chunk per `read()`, strictly in series, on a cache miss. That serial fallback is 19,649 sequential round-trips for the 1.28 GB object in the backlog: at 50ms each, ~16 minutes before the first byte. Uncached retrievals now use the same per-chunk endpoint the SDK's own `getChunkedFile` uses, with `FILES_GATEWAY_CHUNK_CONCURRENCY` (default 100) requests in flight and `FILES_GATEWAY_CHUNK_RETRIES` (default 3) attempts each, every request carrying an abort signal so one that times out hands its connection back rather than holding it. Cached ones keep the single streaming request, still bounded by `FILES_GATEWAY_FETCH_TIMEOUT_MS` — composing those per chunk would be ~19,650 requests, each a fresh DAG walk gateway-side, for bytes already on its disk. Chunk order is preserved and the end is still decided by the gateway's 204, so the bytes are identical; only the request pattern changes.

**Stream failures reach the caller.** `forkStream` is `source.pipe(fork([a, b]))`, and `pipe()` does not forward errors, so a source that died mid-file left both branches open with neither `end` nor `error`. The response never completed and the client waited out the proxy timeout — which this PR raises to 30 minutes, so the same bug got 30× worse. Branches are now failed when their source fails, and each carries its own listener first, since an `error` with no listener is an uncaught exception rather than a failed request.

**Memory tier** — decides from the known size instead of assembling the whole object in the worker's heap only for lru-cache to refuse it (`maxEntrySize` defaults to `maxSize`, so any file above the 1 GB cap cost its full size in RAM to produce a guaranteed miss). Files under the cap are unaffected and still buffer as before.

### Two crashes fixed in passing

- BigInt division by zero in `AsyncStatusBadge` threw a `RangeError` out of render, taking down the Cached Downloads dialog for any row with a zero size.
- The stale-row sweep used `return` where it meant `continue`, bailing at the first non-completed row — and treated a single `NotCached` read as proof a completed download was gone, deleting the user's only record of it. Removed rather than patched: nothing there needed to mutate server state just to display it.

## Changes since the first push

An independent verification pass over the branch caught a defect in the parallel fetcher and three regressions, all fixed here. Worth reading if you reviewed the earlier commits.

**The fetcher's `read()` was `async`.** Node clears its own re-entrancy guard (`state.reading`) on the first `push()`, so an async `read()` that pushes and then awaits is called again while it is still suspended, and both calls read the same cursor and request the same range. Two conditions arm it and both hold on this path: a chunk payload just under the 64 KiB high-water mark (the gateway's is 65,066), so a single push leaves room and returns `true`; and any latency on the request, so the second call lands inside the await. Measured against the previous implementation: **37 requests for a 21-request file**, over half the chunks fetched twice. Where the duplicate lands depends on who wins the race — after end-of-stream it is dropped, before it the chunk is emitted a second time as file content, which is a download longer than the file it claims to be, under a content address, written into the cache for everyone behind it. One measured shape (100 chunks, consumer slower than the gateway — i.e. a browser on a real connection) emitted 8 duplicated chunks.

`read()` is now synchronous and starts a single-flight pump that keeps going by itself rather than relying on the `read()` it displaced, and claims its range before awaiting.

The other three: the cached single-request path was being bypassed for every file; per-chunk retries were dropped (the SDK wraps its own chunk fetch in three, and one transient failure out of ~19,650 requests otherwise kills the retrieval); and the `forkStream` error gap above. Plus the staging gateway's `location /` had been missed by the nginx change.

A second round then caught that restoring the cached path had dropped the `withTimeout` `main` had around `FileGateway.getFile`, which matters more than a lost 60s bound usually does — that call is upstream of the status row, the inactivity timer and the heartbeat, so nothing at any layer was left to notice a gateway that accepts a connection and then says nothing. Both it and the cache-status check are bounded again. Chunk requests also now carry an abort signal: `withTimeout` always took an `AbortController` and nothing was passing one, so a timed-out chunk kept running, kept buffering and kept its connection. The controller is per attempt, not per chunk — a shared one aborts the retries the moment it fires.

## Reviewer notes

- **The 1800s nginx timeouts are a deliberate tradeoff** against `limit_conn addr 5`. Right while reconstruction is slow; once the parallel fetcher is live in prod the honest number is probably much lower, and I would revisit rather than leave 30 minutes there permanently.
- **`fetchFileChunk` is deliberately not built on `FileGateway.getNode`.** That route returns a decoded `PBNode` via `res.json`, so its bytes are JSON text rather than chunk payload, and nothing IPLD-decodes them on the way back. Which leads to:
- **Pre-existing bug, not addressed here.** `retrieveFileByteRange` composes archived objects through `FileGatewayObjectFetcher.fetchNode` — the same `/nodes/:cid` route — so ranged reads on an archived, uncached object serve JSON text instead of file bytes. Traced end to end through the gateway's `res.json(node)`; it only bites on a cache miss, which is likely why it went unnoticed. Left alone rather than changing a path that could not be tested here. The fix is small now that `fetchFileChunk` exists.
- **The chunk concurrency is above the gateway vhost's `limit_conn addr 5` on purpose.** That limiter guards the public hostname; `FILES_GATEWAY_URL` addresses the gateway process directly, so backend chunk requests are never counted against the zone. Worth knowing before anyone repoints that variable at the public hostname — 95 of every 100 requests would 503, and because the limit is not transient the retries would burn their backoff and still fail. Noted next to the config value too.
- **Deliberately still open:** the dedupe check-then-insert race (needs a migration), and `/s3` at 600s.
- **Behaviour change covered by tests:** two existing cases encoded the old duplicate-creating semantics. Replaced with explicit coverage for the dedupe and for dismiss-then-request-again. The suite shares one user and cid without cleanup, so the dedupe test uploads its own object.

## Testing

- `yarn backend test` — **56 suites / 873 tests, all passing.**
- `yarn backend lint`, `yarn frontend lint`, `tsc --noEmit` on the frontend — clean.
- 10 unit tests for the gateway fetcher. The six new ones cover what the originals structurally could not: every original case used ≤8 chunks against concurrency 100, i.e. exactly one batch, so the multi-batch path was never exercised. The added multi-batch case fails against the pre-fix implementation (36 chunk requests where 20 are due, plus the tail 204 probe) and passes against this one; the concurrency test now pins the upper bound as well as the lower; and there is coverage for the retry, the cached single-request path, the timeout around it, and the per-attempt abort signal.

Unrelated but worth knowing: the backend test script uses `--forceExit`, which kills Jest before Testcontainers' reaper runs. Repeated local full-suite runs leak containers until new ones cannot start — every suite then fails with `globalSetup ... "Server startup complete" not received after 30000ms`. Worth a separate look at whether the flag is still needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
