### PR TITLE
Treat a failed payment intent as terminal so the purchase flow stops polling

### DIFF
--- a/apps/frontend/__tests__/unit/hooks/useTransactionConfirmation.spec.ts
+++ b/apps/frontend/__tests__/unit/hooks/useTransactionConfirmation.spec.ts
@@ -1,8 +1,10 @@
 /**
- * Unit tests for the intent-polling decision logic extracted from
- * useTransactionConfirmation.  These tests verify the correct terminal-state
- * handling for completed, over_cap, and expired intents without requiring a
- * React rendering environment.
+ * Unit tests for the intent-polling decision logic used by
+ * useTransactionConfirmation.  The try-branch decision now lives in a real,
+ * exported module (hooks/intentPolling) that both the hook and these tests
+ * import, so there is a single source of truth to verify — the earlier
+ * hook/test mirror is what let a terminal `failed` status go unhandled.  These
+ * tests still need no React rendering environment.
  *
  * IMPORTANT: The backend returns HTTP 410 Gone for expired intents instead of
  * an `{ status: 'expired' }` response body.  The `getIntent` call throws an
@@ -10,8 +12,11 @@
  * loop detects this via the catch block, not via `intent.status === 'expired'`.
  */
 
+import { evaluateIntentStatus } from 'hooks/intentPolling'
+
 // ---------------------------------------------------------------------------
-// Minimal ApiError replica (mirrors apps/frontend/src/services/api.ts)
+// Minimal ApiError replica (mirrors apps/frontend/src/services/api.ts) — used
+// only by the catch-branch tests below, which exercise thrown-error handling.
 // ---------------------------------------------------------------------------
 
 class ApiError extends Error {
@@ -24,89 +29,89 @@ class ApiError extends Error {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Polling decision logic (mirrors the try/catch in the `poll` callback)
-// ---------------------------------------------------------------------------
-
-type IntentStatus = 'pending' | 'confirmed' | 'completed' | 'failed' | 'over_cap'
-
-interface PollResult {
-  completed: boolean
-  overCap: boolean
+interface PollErrorResult {
   expired: boolean
   shouldContinue: boolean
 }
 
 /**
- * Mirrors the try-branch: evaluates the status string returned in the
- * response body when the API call succeeds (HTTP 2xx).
+ * Mirrors the catch-branch of the `poll` callback: evaluates the thrown error.
+ * The backend returns HTTP 410 for expired intents, so this is the only path
+ * through which `expired` can become true.
  */
-function evaluateIntentStatus(status: IntentStatus): PollResult {
-  if (status === 'completed') {
-    return { completed: true, overCap: false, expired: false, shouldContinue: false }
-  }
-  if (status === 'over_cap') {
-    return { completed: false, overCap: true, expired: false, shouldContinue: false }
-  }
-  return { completed: false, overCap: false, expired: false, shouldContinue: true }
-}
-
-/**
- * Mirrors the catch-branch: evaluates the thrown error.  The backend returns
- * HTTP 410 for expired intents, so this is the only path through which
- * `expired` can become true.
- */
-function evaluatePollError(error: unknown): PollResult {
+function evaluatePollError(error: unknown): PollErrorResult {
   if (error instanceof ApiError && error.status === 410) {
-    return { completed: false, overCap: false, expired: true, shouldContinue: false }
+    return { expired: true, shouldContinue: false }
   }
-  return { completed: false, overCap: false, expired: false, shouldContinue: true }
+  return { expired: false, shouldContinue: true }
 }
 
 // ---------------------------------------------------------------------------
-// Tests — successful response branch (try)
+// Tests — successful response branch (try): the real, shared decision function
 // ---------------------------------------------------------------------------
 
 describe('evaluateIntentStatus (try branch)', () => {
   it('marks completed and stops polling for "completed"', () => {
-    const result = evaluateIntentStatus('completed')
-    expect(result.completed).toBe(true)
-    expect(result.overCap).toBe(false)
-    expect(result.expired).toBe(false)
-    expect(result.shouldContinue).toBe(false)
+    expect(evaluateIntentStatus('completed')).toEqual({
+      completed: true,
+      overCap: false,
+      failed: false,
+      shouldContinue: false,
+    })
   })
 
   it('marks overCap and stops polling for "over_cap"', () => {
-    const result = evaluateIntentStatus('over_cap')
-    expect(result.completed).toBe(false)
-    expect(result.overCap).toBe(true)
-    expect(result.expired).toBe(false)
-    expect(result.shouldContinue).toBe(false)
+    expect(evaluateIntentStatus('over_cap')).toEqual({
+      completed: false,
+      overCap: true,
+      failed: false,
+      shouldContinue: false,
+    })
+  })
+
+  it('marks failed and stops polling for "failed"', () => {
+    // Regression guard for #634: the backend marks dust payments FAILED
+    // permanently, so the loop must stop — not poll forever.
+    expect(evaluateIntentStatus('failed')).toEqual({
+      completed: false,
+      overCap: false,
+      failed: true,
+      shouldContinue: false,
+    })
   })
 
   it('continues polling for "pending"', () => {
-    const result = evaluateIntentStatus('pending')
-    expect(result).toEqual({ completed: false, overCap: false, expired: false, shouldContinue: true })
+    expect(evaluateIntentStatus('pending')).toEqual({
+      completed: false,
+      overCap: false,
+      failed: false,
+      shouldContinue: true,
+    })
   })
 
   it('continues polling for "confirmed"', () => {
-    const result = evaluateIntentStatus('confirmed')
-    expect(result).toEqual({ completed: false, overCap: false, expired: false, shouldContinue: true })
+    expect(evaluateIntentStatus('confirmed')).toEqual({
+      completed: false,
+      overCap: false,
+      failed: false,
+      shouldContinue: true,
+    })
   })
 
-  it('continues polling for "failed"', () => {
-    const result = evaluateIntentStatus('failed')
-    expect(result).toEqual({ completed: false, overCap: false, expired: false, shouldContinue: true })
+  it('continues polling for an unknown status', () => {
+    expect(evaluateIntentStatus('something_new').shouldContinue).toBe(true)
   })
 
-  it('over_cap and completed are mutually exclusive', () => {
+  it('terminal statuses are mutually exclusive', () => {
     expect(evaluateIntentStatus('over_cap').completed).toBe(false)
     expect(evaluateIntentStatus('completed').overCap).toBe(false)
+    expect(evaluateIntentStatus('failed').completed).toBe(false)
+    expect(evaluateIntentStatus('failed').overCap).toBe(false)
   })
 })
 
 // ---------------------------------------------------------------------------
-// Tests — error branch (catch)
+// Tests — error branch (catch — expired intent detection)
 // ---------------------------------------------------------------------------
 
 describe('evaluatePollError (catch branch — expired intent detection)', () => {
@@ -114,8 +119,6 @@ describe('evaluatePollError (catch branch — expired intent detection)', () => 
     const error = new ApiError(410, 'Intent has expired')
     const result = evaluatePollError(error)
     expect(result.expired).toBe(true)
-    expect(result.completed).toBe(false)
-    expect(result.overCap).toBe(false)
     expect(result.shouldContinue).toBe(false)
   })
 

--- a/apps/frontend/src/components/views/PurchaseCredits/steps/Step3_TransferTokens.tsx
+++ b/apps/frontend/src/components/views/PurchaseCredits/steps/Step3_TransferTokens.tsx
@@ -42,6 +42,7 @@ export const PurchaseStep3TransferTokens = ({
     isPollingBackend,
     isBackendCompleted,
     isOverCap,
+    isFailed,
     isExpired,
     waitError,
   } = useTransactionConfirmation({
@@ -194,7 +195,7 @@ export const PurchaseStep3TransferTokens = ({
                   </div>
                 </div>
               )}
-              {isFullyConfirmed && !isOverCap && !isExpired && (
+              {isFullyConfirmed && !isOverCap && !isFailed && !isExpired && (
                 <div className='text-xs text-muted-foreground'>
                   {isPollingBackend
                     ? 'Waiting for backend to update credits…'
@@ -216,15 +217,23 @@ export const PurchaseStep3TransferTokens = ({
                   try again or contact support for assistance.
                 </div>
               )}
+              {isFailed && (
+                <div className='rounded-md bg-red-50 p-3 text-sm text-red-700 dark:bg-red-950 dark:text-red-300'>
+                  <strong>Payment failed.</strong> This payment could not be
+                  applied — for example, the amount was too small to credit any
+                  storage. No credits were added. Please try again with a larger
+                  amount or contact support for assistance.
+                </div>
+              )}
               {waitError && (
                 <div className='text-xs text-red-600'>{waitError.message}</div>
               )}
               <div className='flex gap-3'>
                 <Button
                   onClick={() => onNext({ txHash })}
-                  disabled={!isFullyConfirmed || !isBackendCompleted || isOverCap || isExpired}
+                  disabled={!isFullyConfirmed || !isBackendCompleted || isOverCap || isFailed || isExpired}
                 >
-                  {isFullyConfirmed && !isBackendCompleted && !isOverCap && !isExpired
+                  {isFullyConfirmed && !isBackendCompleted && !isOverCap && !isFailed && !isExpired
                     ? 'Finalizing…'
                     : 'Continue'}
                 </Button>

--- a/apps/frontend/src/hooks/intentPolling.ts
+++ b/apps/frontend/src/hooks/intentPolling.ts
@@ -1,0 +1,26 @@
+// Terminal-state decision for the intent-payment polling loop, extracted from
+// useTransactionConfirmation so the hook and its unit tests share one source of
+// truth (no React renderer needed) — that drift is what let `failed` slip through.
+
+export interface IntentStatusDecision {
+  completed: boolean;
+  overCap: boolean;
+  failed: boolean;
+  shouldContinue: boolean;
+}
+
+// `failed` is terminal: the backend marks a payment FAILED permanently (e.g. a
+// dust payment that credits zero bytes), so polling can never change the
+// outcome — stop and surface it, exactly as with over_cap.
+export const evaluateIntentStatus = (status: string): IntentStatusDecision => {
+  if (status === 'completed') {
+    return { completed: true, overCap: false, failed: false, shouldContinue: false };
+  }
+  if (status === 'over_cap') {
+    return { completed: false, overCap: true, failed: false, shouldContinue: false };
+  }
+  if (status === 'failed') {
+    return { completed: false, overCap: false, failed: true, shouldContinue: false };
+  }
+  return { completed: false, overCap: false, failed: false, shouldContinue: true };
+};

--- a/apps/frontend/src/hooks/useTransactionConfirmation.ts
+++ b/apps/frontend/src/hooks/useTransactionConfirmation.ts
@@ -3,6 +3,7 @@ import { usePublicClient, useWaitForTransactionReceipt } from 'wagmi';
 import { type Hash } from 'viem';
 import { useQueryClient } from '@tanstack/react-query';
 import { ApiError } from '../services/api';
+import { evaluateIntentStatus } from './intentPolling';
 
 interface UseTransactionConfirmationProps {
   txHash: Hash | undefined;
@@ -22,6 +23,8 @@ interface UseTransactionConfirmationReturn {
   isBackendCompleted: boolean;
   /** True when the backend put the intent in the over_cap terminal state. */
   isOverCap: boolean;
+  /** True when the backend marked the intent failed — a permanent terminal state. */
+  isFailed: boolean;
   /** True when the intent has expired and credits will never be applied. */
   isExpired: boolean;
   waitError: Error | null;
@@ -51,6 +54,7 @@ export const useTransactionConfirmation = ({
   const [isPollingBackend, setIsPollingBackend] = useState(false);
   const [isBackendCompleted, setIsBackendCompleted] = useState(false);
   const [isOverCap, setIsOverCap] = useState(false);
+  const [isFailed, setIsFailed] = useState(false);
   const [isExpired, setIsExpired] = useState(false);
 
   // Start watching block numbers to compute confirmations once included
@@ -94,7 +98,7 @@ export const useTransactionConfirmation = ({
 
   // After confirmations threshold, poll backend until IntentStatus.COMPLETED
   useEffect(() => {
-    if (!api || !intentId || !isFullyConfirmed || isBackendCompleted || isOverCap || isExpired) return;
+    if (!api || !intentId || !isFullyConfirmed || isBackendCompleted || isOverCap || isFailed || isExpired) return;
     setIsPollingBackend(true);
     let timer: NodeJS.Timeout | undefined;
     let cancelled = false;
@@ -102,7 +106,8 @@ export const useTransactionConfirmation = ({
     const poll = async () => {
       try {
         const intent = await api.getIntent(intentId);
-        if (intent.status === 'completed') {
+        const decision = evaluateIntentStatus(intent.status);
+        if (decision.completed) {
           // Refresh both the legacy account query and the new credit summary
           queryClient.invalidateQueries({ queryKey: ['account'] });
           queryClient.invalidateQueries({ queryKey: ['creditSummary'] });
@@ -110,10 +115,15 @@ export const useTransactionConfirmation = ({
           setIsPollingBackend(false);
           return;
         }
-        // over_cap is a terminal state — credits will NOT be applied without
-        // admin intervention.  Stop polling immediately and surface the error.
-        if (intent.status === 'over_cap') {
+        // over_cap and failed are terminal — credits will NOT be applied
+        // without admin intervention.  Stop polling and surface the error.
+        if (decision.overCap) {
           setIsOverCap(true);
+          setIsPollingBackend(false);
+          return;
+        }
+        if (decision.failed) {
+          setIsFailed(true);
           setIsPollingBackend(false);
           return;
         }
@@ -138,7 +148,7 @@ export const useTransactionConfirmation = ({
       cancelled = true;
       if (timer) clearTimeout(timer);
     };
-  }, [api, intentId, isFullyConfirmed, isBackendCompleted, isOverCap, isExpired, queryClient]);
+  }, [api, intentId, isFullyConfirmed, isBackendCompleted, isOverCap, isFailed, isExpired, queryClient]);
 
   return {
     isWaitingReceipt,
@@ -148,6 +158,7 @@ export const useTransactionConfirmation = ({
     isPollingBackend,
     isBackendCompleted,
     isOverCap,
+    isFailed,
     isExpired,
     waitError,
   };


### PR DESCRIPTION
This PR proposes treating a `failed` payment intent as a terminal state so the credit-purchase flow stops polling and surfaces the failure to the user instead of spinning on the confirmation screen forever. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/266. You can sign in with your GitHub ID to claim ownership of the project.

Fixes #634.

## The defect

At current `main` (`12ab0654`), the backend permanently marks a dust payment `IntentStatus.FAILED` — `apps/backend/src/core/users/intents.ts` sets `status: IntentStatus.FAILED` and then groups it with `COMPLETED`/`OVER_CAP`/`EXPIRED` as "already processed", so it is terminal and will never change. The frontend polling loop in `apps/frontend/src/hooks/useTransactionConfirmation.ts`, however, only treats `completed`, `over_cap`, and the 410-expired error as terminal. A `failed` status matches none of those branches, so it falls through to `timer = setTimeout(poll, 2000)` and the loop retries forever. In `Step3_TransferTokens.tsx` that leaves the user on "Waiting for backend to update credits…" with the Continue button stuck on "Finalizing…" and no way to proceed after a too-small payment — the High-severity symptom described in the issue.

The existing unit test actually encoded this defect: `apps/frontend/__tests__/unit/hooks/useTransactionConfirmation.spec.ts` asserted `failed` → `shouldContinue: true`. It passed only because it tested a copy of the decision logic that mirrored the hook — the drift between that mirror and the real hook is what let the missing terminal case ship unnoticed.

## The change

The try-branch decision is lifted out of the hook into a small, dependency-free module `apps/frontend/src/hooks/intentPolling.ts` (`evaluateIntentStatus`), where `failed` is now a terminal outcome. The hook imports that function, adds an `isFailed` state that stops the loop, and returns it; `Step3_TransferTokens.tsx` surfaces `isFailed` with a "Payment failed" message and disables Continue, exactly as it already does for `over_cap` and `isExpired`. The test now imports the real `evaluateIntentStatus` instead of a mirror, so the hook and its tests share one source of truth and cannot drift apart again. The 410-expired catch-branch is unchanged.

Backward compatibility: the only public change is the additive `isFailed` field on the hook's return; the other consumer (`Step4_Success.tsx`) does not read the terminal flags and is unaffected.

## How I verified it (replayable in a minute)

Reproduction at HEAD and the regression guard both run under `yarn frontend test`:

```
# Revert only the new terminal line in intentPolling.ts (failed -> shouldContinue: true)
# and the regression test goes red, reproducing the poll-forever behaviour:
✕ marks failed and stops polling for "failed"
  - Expected  "shouldContinue": false
  + Received  "shouldContinue": true

# With the fix in place the whole frontend suite is green:
Test Suites: 7 passed, 7 total
Tests:       152 passed, 152 total
```

Baseline before the change had the same suites passing (plus two pre-existing suites that only fail until `@auto-drive/models` is built), so this adds no new failures. `tsc --noEmit` and `next lint` are both clean on the changed files.

## How this work was managed

I imported your repository's issues and pull requests into a live agile board (772 stories, 21 labels) and used it to plan and track this fix. This contribution maps to the imported story for #634:

- Story: https://eastagiletracker.com/projects/266/stories/156126
- Board: https://eastagiletracker.com/projects/266

![board](https://raw.githubusercontent.com/eastagiletracker/auto-drive/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
